### PR TITLE
Announce region IDs instead of AFUs

### DIFF
--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -112,7 +112,10 @@ func discoverFPGAs(sysfsDir string, devfsDir string) (map[string]map[string]devi
 				if _, ok := result[afuID]; !ok {
 					result[afuID] = make(map[string]deviceplugin.DeviceInfo)
 				}
-				result[afuID][fname] = deviceplugin.DeviceInfo{pluginapi.Healthy, devNodes}
+				result[afuID][fname] = deviceplugin.DeviceInfo{
+					State: pluginapi.Healthy,
+					Nodes: devNodes,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Also add `-mode` switch making the FPGA plugin announce AFU IDs instead if regions' interface IDs.