### PR TITLE
use glog.Error when mode is incorrect

### DIFF
--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -234,7 +234,8 @@ func main() {
 
 	mode := parseMode(modeStr)
 	if mode == wrongMode {
-		glog.Fatal("Wrong mode: ", modeStr)
+		glog.Error("Wrong mode: ", modeStr)
+		os.Exit(1)
 	}
 
 	fmt.Println("FPGA device plugin started in", modeStr, "mode")


### PR DESCRIPTION
Using glog.Fatal produces stacktrace, which looks quite scary
for this simple case:
$ ./fpga_plugin -mode bla
F0523 15:17:57.997937   11555 fpga_plugin.go:237] Wrong mode: bla
goroutine 1 [running]:
github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog.stacks(0xc420214000, 0xc42018e000, 0x42, 0x8f)
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog/glog.go:769 +0xcf
github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog.(*loggingT).output(0xbf72c0, 0xc400000003, 0xc4200bea50, 0xba3309, 0xe, 0xed, 0x0)
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog/glog.go:720 +0x32d
github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog.(*loggingT).printDepth(0xbf72c0, 0x7f4500000003, 0x1, 0xc420079ec8, 0x2, 0x2)
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog/glog.go:646 +0x129
github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog.(*loggingT).print(0xbf72c0, 0x3, 0xc420079ec8, 0x2, 0x2)
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog/glog.go:637 +0x5a
github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog.Fatal(0xc420079ec8, 0x2, 0x2)
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/vendor/github.com/golang/glog/glog.go:1128 +0x53
main.main()
	/home/ed/go/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin.go:237 +0x5fb