### PR TITLE
fix make vet

### DIFF
--- a/internal/deviceplugin/deviceplugin_test.go
+++ b/internal/deviceplugin/deviceplugin_test.go
@@ -187,7 +187,7 @@ func TestSetupAndServe(t *testing.T) {
 		kubelet.Unlock()
 		pluginSocket = path.Join(devicePluginPath, pEndpoint)
 		if pEndpoint != "" {
-			if _, err := os.Stat(pluginSocket); err == nil {
+			if _, err = os.Stat(pluginSocket); err == nil {
 				break
 			}
 		}


### PR DESCRIPTION
Fixed make vet failure:

internal/deviceplugin/deviceplugin_test.go:190: declaration of "err"
shadows declaration at internal/deviceplugin/deviceplugin_test.go:150
Makefile:14: recipe for target 'vet' failed
make: *** [vet] Error 2