### PR TITLE
fix spelling mistake

### DIFF
--- a/internal/deviceplugin/deviceplugin_test.go
+++ b/internal/deviceplugin/deviceplugin_test.go
@@ -87,7 +87,7 @@ func (ps *pluginStub) GetDevicePluginOptions(ctx context.Context, empty *plugina
 	return new(pluginapi.DevicePluginOptions), nil
 }
 
-func (ps *pluginStub) ListAndWatch(emtpy *pluginapi.Empty, stream pluginapi.DevicePlugin_ListAndWatchServer) error {
+func (ps *pluginStub) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.DevicePlugin_ListAndWatchServer) error {
 	return nil
 }
 


### PR DESCRIPTION
Fixed misspell warning pointed out by goreportcard.com:
```
misspell 83%
Misspell Finds commonly misspelled English words
intel-device-plugins-for-kubernetes/internal/deviceplugin/deviceplugin_test.go
Line 90: warning: "emtpy" is a misspelling of "empty" (misspell)
```