### PR TITLE
fix golint warnings

### DIFF
--- a/internal/deviceplugin/deviceplugin.go
+++ b/internal/deviceplugin/deviceplugin.go
@@ -27,19 +27,23 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 )
 
+// DeviceInfo contains information about device maintained by Device Plugin
 type DeviceInfo struct {
 	State string
 	Nodes []string
 }
 
+// Server structure to keep server parameters
 type Server struct {
 	grpcServer *grpc.Server
 }
 
+// Serve serves starts gRPC server to serve Device Plugin functionality
 func (srv *Server) Serve(dm pluginapi.DevicePluginServer, resourceName string, pluginPrefix string) error {
 	return srv.setupAndServe(dm, resourceName, pluginPrefix, pluginapi.DevicePluginPath, pluginapi.KubeletSocket)
 }
 
+// Stop stops serving Device Plugin
 func (srv *Server) Stop() error {
 	if srv.grpcServer == nil {
 		return fmt.Errorf("Can't stop non-existing gRPC server. Calling Stop() before Serve()?")


### PR DESCRIPTION
Fixed the following golint warnings:
```
    ./cmd/fpga_plugin/fpga_plugin.go:71:2: struct field fpgaId should be fpgaID
    ./cmd/fpga_plugin/fpga_plugin.go:78:44: func parameter fpgaId should be fpgaID
    ./cmd/fpga_plugin/fpga_plugin.go:104:8: var interfaceId should be interfaceID
    ./cmd/fpga_plugin/fpga_plugin.go:120:7: var interfaceIdFile should be interfaceIDFile
    ./cmd/fpga_plugin/fpga_plugin.go:156:8: range var fpgaId should be fpgaID
    ./cmd/fpga_plugin/fpga_plugin.go:254:6: range var fpgaId should be fpgaID
    ./cmd/fpga_plugin/fpga_plugin.go:254:14: should omit 2nd value from range; this loop is equivalent to `for fpgaId := range ...`
    ./internal/deviceplugin/deviceplugin.go:30:6: exported type DeviceInfo should have comment or be unexported
    ./internal/deviceplugin/deviceplugin.go:35:6: exported type Server should have comment or be unexported
    ./internal/deviceplugin/deviceplugin.go:39:1: exported method Server.Serve should have comment or be unexported
    ./internal/deviceplugin/deviceplugin.go:43:1: exported method Server.Stop should have comment or be unexported
```