### PR TITLE
reformatted *.go with gofmt -s -w

### DIFF
--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -116,22 +116,22 @@ func TestDiscoverFPGAs(t *testing.T) {
 				"intel-fpga-port.2", "intel-fpga-fme.2",
 			},
 			expectedResult: map[string]map[string]deviceplugin.DeviceInfo{
-				fmt.Sprintf("%s-d8424dc4a4a3c413f89e433683f9040b", afMode): map[string]deviceplugin.DeviceInfo{
-					"intel-fpga-dev.0": deviceplugin.DeviceInfo{
+				fmt.Sprintf("%s-d8424dc4a4a3c413f89e433683f9040b", afMode): {
+					"intel-fpga-dev.0": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-port.0"),
 						},
 					},
-					"intel-fpga-dev.1": deviceplugin.DeviceInfo{
+					"intel-fpga-dev.1": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-port.1"),
 						},
 					},
 				},
-				fmt.Sprintf("%s-47595d0fae972fbed0c51b4a41c7a349", afMode): map[string]deviceplugin.DeviceInfo{
-					"intel-fpga-dev.2": deviceplugin.DeviceInfo{
+				fmt.Sprintf("%s-47595d0fae972fbed0c51b4a41c7a349", afMode): {
+					"intel-fpga-dev.2": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-port.2"),
@@ -187,15 +187,15 @@ func TestDiscoverFPGAs(t *testing.T) {
 				"intel-fpga-port.2", "intel-fpga-fme.2",
 			},
 			expectedResult: map[string]map[string]deviceplugin.DeviceInfo{
-				fmt.Sprintf("%s-ce48969398f05f33946d560708be108a", regionMode): map[string]deviceplugin.DeviceInfo{
-					"intel-fpga-dev.0": deviceplugin.DeviceInfo{
+				fmt.Sprintf("%s-ce48969398f05f33946d560708be108a", regionMode): {
+					"intel-fpga-dev.0": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-fme.0"),
 							path.Join(tmpdir, "/dev/intel-fpga-port.0"),
 						},
 					},
-					"intel-fpga-dev.1": deviceplugin.DeviceInfo{
+					"intel-fpga-dev.1": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-fme.1"),
@@ -203,8 +203,8 @@ func TestDiscoverFPGAs(t *testing.T) {
 						},
 					},
 				},
-				fmt.Sprintf("%s-fd967345645f05f338462a0748be0091", regionMode): map[string]deviceplugin.DeviceInfo{
-					"intel-fpga-dev.2": deviceplugin.DeviceInfo{
+				fmt.Sprintf("%s-fd967345645f05f338462a0748be0091", regionMode): {
+					"intel-fpga-dev.2": {
 						State: "Healthy",
 						Nodes: []string{
 							path.Join(tmpdir, "/dev/intel-fpga-fme.2"),
@@ -329,8 +329,8 @@ func TestListAndWatch(t *testing.T) {
 				"intel-fpga-port.2", "intel-fpga-fme.2",
 			},
 			expectedResult: []*pluginapi.Device{
-				&pluginapi.Device{"intel-fpga-dev.0", "Healthy"},
-				&pluginapi.Device{"intel-fpga-dev.1", "Healthy"},
+				{"intel-fpga-dev.0", "Healthy"},
+				{"intel-fpga-dev.1", "Healthy"},
 			},
 			expectedErr: false,
 		},
@@ -393,7 +393,7 @@ func TestAllocate(t *testing.T) {
 
 	rqt := &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
-			&pluginapi.ContainerAllocateRequest{
+			{
 				DevicesIDs: []string{"dev1"},
 			},
 		},

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -101,7 +101,7 @@ func TestAllocate(t *testing.T) {
 
 	rqt := &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
-			&pluginapi.ContainerAllocateRequest{
+			{
 				DevicesIDs: []string{"dev1"},
 			},
 		},

--- a/internal/deviceplugin/deviceplugin_test.go
+++ b/internal/deviceplugin/deviceplugin_test.go
@@ -163,7 +163,7 @@ func TestSetupAndServe(t *testing.T) {
 	client := pluginapi.NewDevicePluginClient(conn)
 	_, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
-			&pluginapi.ContainerAllocateRequest{
+			{
 				DevicesIDs: []string{"dev1", "dev2"},
 			},
 		},
@@ -205,7 +205,7 @@ func TestSetupAndServe(t *testing.T) {
 	client = pluginapi.NewDevicePluginClient(conn)
 	_, err = client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
-			&pluginapi.ContainerAllocateRequest{
+			{
 				DevicesIDs: []string{"dev1", "dev2"},
 			},
 		},
@@ -226,7 +226,7 @@ func TestStop(t *testing.T) {
 func TestMakeAllocateResponse(t *testing.T) {
 	rqt := &pluginapi.AllocateRequest{
 		ContainerRequests: []*pluginapi.ContainerAllocateRequest{
-			&pluginapi.ContainerAllocateRequest{
+			{
 				DevicesIDs: []string{"dev1"},
 			},
 		},
@@ -238,7 +238,7 @@ func TestMakeAllocateResponse(t *testing.T) {
 	}
 
 	devices := map[string]DeviceInfo{
-		"dev1": DeviceInfo{pluginapi.Unhealthy, []string{"/dev/dev1"}},
+		"dev1": {pluginapi.Unhealthy, []string{"/dev/dev1"}},
 	}
 
 	_, err = MakeAllocateResponse(rqt, devices)


### PR DESCRIPTION
This is done to fix https://goreportcard.com warnnigs:

gofmt 33%
Gofmt formats Go programs. We run gofmt -s on your code, where -s is for the "simplify" command

intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin_test.go
Line 1: warning: file is not gofmted with -s (gofmt)

intel-device-plugins-for-kubernetes/internal/deviceplugin/deviceplugin_test.go
Line 1: warning: file is not gofmted with -s (gofmt)

intel-device-plugins-for-kubernetes/cmd/gpu_plugin/gpu_plugin_test.go
Line 1: warning: file is not gofmted with -s (gofmt)

intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin.go
Line 1: warning: file is not gofmted with -s (gofmt)