### PR TITLE
fix go_vet error reported by goreportcard.com

### DIFF
--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -410,7 +410,7 @@ func TestAllocate(t *testing.T) {
 	}
 }
 
-func TestisValidPluginMode(t *testing.T) {
+func TestIsValidPluginMode(t *testing.T) {
 	tcases := []struct {
 		input  pluginMode
 		output bool


### PR DESCRIPTION
Fixed go_vet error:
 Line 413: error: TestisValidPluginMode has malformed name: first letter after 'Test' must not be lowercase (vet)