### PR TITLE
fix make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 	@$(GO) test -cover $(pkgs)
 
 lint:
-	@for f in $$(find ./cmd ./internal -name \*.go) ; do golint $$f ;done
+	@rc=0 ; for f in $$(find -name \*.go | grep -v \.\/vendor) ; do golint -set_exit_status $$f || rc=1 ; done ; exit $$rc
 
 TAG?=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
make lint always returs 0 even if there were errors found by golint
Fixed it by using golint command line option -set_exit_status and
checking golint return code