### PR TITLE
fpga_plugin: refactor FPGA scans

### DIFF
--- a/cmd/fpga_plugin/devicecache/devicecache.go
+++ b/cmd/fpga_plugin/devicecache/devicecache.go
@@ -1,0 +1,284 @@
+// Copyright 2018 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicecache
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin"
+)
+
+// Device Cache's mode of operation
+const (
+	AfMode     = "af"
+	RegionMode = "region"
+)
+
+const (
+	sysfsDirectory = "/sys/class/fpga"
+	devfsDirectory = "/dev"
+	deviceRE       = `^intel-fpga-dev.[0-9]+$`
+	portRE         = `^intel-fpga-port.[0-9]+$`
+	fmeRE          = `^intel-fpga-fme.[0-9]+$`
+)
+
+// UpdateInfo contains info added, updated and deleted FPGA devices
+type UpdateInfo struct {
+	Added   map[string]map[string]deviceplugin.DeviceInfo
+	Updated map[string]map[string]deviceplugin.DeviceInfo
+	Removed map[string]map[string]deviceplugin.DeviceInfo
+}
+
+type getDevMapFunc func(devices []device) map[string]map[string]deviceplugin.DeviceInfo
+
+func getRegionMap(devices []device) map[string]map[string]deviceplugin.DeviceInfo {
+	regionMap := make(map[string]map[string]deviceplugin.DeviceInfo)
+
+	for _, dev := range devices {
+		for _, region := range dev.regions {
+			if _, present := regionMap[region.interfaceID]; !present {
+				regionMap[region.interfaceID] = make(map[string]deviceplugin.DeviceInfo)
+			}
+			devNodes := make([]string, len(region.afus)+1)
+			for num, afu := range region.afus {
+				devNodes[num] = afu.devNode
+			}
+			devNodes[len(region.afus)] = region.devNode
+			regionMap[region.interfaceID][region.id] = deviceplugin.DeviceInfo{
+				State: pluginapi.Healthy,
+				Nodes: devNodes,
+			}
+		}
+	}
+
+	return regionMap
+}
+
+func getAfuMap(devices []device) map[string]map[string]deviceplugin.DeviceInfo {
+	afuMap := make(map[string]map[string]deviceplugin.DeviceInfo)
+
+	for _, dev := range devices {
+		for _, region := range dev.regions {
+			for _, afu := range region.afus {
+				if _, present := afuMap[afu.afuID]; !present {
+					afuMap[afu.afuID] = make(map[string]deviceplugin.DeviceInfo)
+				}
+				afuMap[afu.afuID][afu.id] = deviceplugin.DeviceInfo{
+					State: pluginapi.Healthy,
+					Nodes: []string{afu.devNode},
+				}
+			}
+		}
+	}
+
+	return afuMap
+}
+
+type afu struct {
+	id      string
+	afuID   string
+	devNode string
+}
+
+type region struct {
+	id          string
+	interfaceID string
+	devNode     string
+	afus        []afu
+}
+
+type device struct {
+	name    string
+	regions []region
+}
+
+// Cache represents FPGA devices found on the host
+type Cache struct {
+	sysfsDir string
+	devfsDir string
+
+	deviceReg *regexp.Regexp
+	portReg   *regexp.Regexp
+	fmeReg    *regexp.Regexp
+
+	devices   []device
+	ch        chan<- UpdateInfo
+	getDevMap getDevMapFunc
+}
+
+// NewCache returns new instance of Cache
+func NewCache(sysfsDir string, devfsDir string, mode string, ch chan<- UpdateInfo) (*Cache, error) {
+	var getDevMap getDevMapFunc
+
+	switch mode {
+	case AfMode:
+		getDevMap = getAfuMap
+	case RegionMode:
+		getDevMap = getRegionMap
+	default:
+		return nil, fmt.Errorf("Wrong mode: '%s'", mode)
+	}
+
+	return &Cache{
+		sysfsDir:  sysfsDir,
+		devfsDir:  devfsDir,
+		deviceReg: regexp.MustCompile(deviceRE),
+		portReg:   regexp.MustCompile(portRE),
+		fmeReg:    regexp.MustCompile(fmeRE),
+		ch:        ch,
+		getDevMap: getDevMap,
+	}, nil
+}
+
+func (c *Cache) getDevNode(devName string) (string, error) {
+	devNode := path.Join(c.devfsDir, devName)
+	if _, err := os.Stat(devNode); err != nil {
+		return "", fmt.Errorf("Device %s doesn't exist: %v", devNode, err)
+	}
+
+	return devNode, nil
+}
+
+func (c *Cache) detectUpdates(devices []device) {
+	added := make(map[string]map[string]deviceplugin.DeviceInfo)
+	updated := make(map[string]map[string]deviceplugin.DeviceInfo)
+
+	oldDevMap := c.getDevMap(c.devices)
+
+	for fpgaID, new := range c.getDevMap(devices) {
+		if old, ok := oldDevMap[fpgaID]; ok {
+			if !reflect.DeepEqual(old, new) {
+				updated[fpgaID] = new
+			}
+			delete(oldDevMap, fpgaID)
+		} else {
+			added[fpgaID] = new
+		}
+	}
+
+	if len(added) > 0 || len(updated) > 0 || len(oldDevMap) > 0 {
+		c.ch <- UpdateInfo{
+			Added:   added,
+			Updated: updated,
+			Removed: oldDevMap,
+		}
+	}
+}
+
+func (c *Cache) scanFPGAs() error {
+	var devices []device
+
+	glog.V(2).Info("Start new FPGA scan")
+
+	fpgaFiles, err := ioutil.ReadDir(c.sysfsDir)
+	if err != nil {
+		return fmt.Errorf("Can't read sysfs folder: %v", err)
+	}
+
+	for _, fpgaFile := range fpgaFiles {
+		fname := fpgaFile.Name()
+
+		if !c.deviceReg.MatchString(fname) {
+			continue
+		}
+
+		deviceFolder := path.Join(c.sysfsDir, fname)
+		deviceFiles, err := ioutil.ReadDir(deviceFolder)
+		if err != nil {
+			return err
+		}
+
+		var regions []region
+		var afus []afu
+		for _, deviceFile := range deviceFiles {
+			name := deviceFile.Name()
+
+			if c.fmeReg.MatchString(name) {
+				if len(regions) > 0 {
+					return fmt.Errorf("Detected more than one FPGA region for device %s. Only one region per FPGA device is supported", fname)
+				}
+				interfaceIDFile := path.Join(deviceFolder, name, "pr", "interface_id")
+				data, err := ioutil.ReadFile(interfaceIDFile)
+				if err != nil {
+					return err
+				}
+				devNode, err := c.getDevNode(name)
+				if err != nil {
+					return err
+				}
+				regions = append(regions, region{
+					id:          name,
+					interfaceID: strings.TrimSpace(string(data)),
+					devNode:     devNode,
+				})
+			} else if c.portReg.MatchString(name) {
+				afuFile := path.Join(deviceFolder, name, "afu_id")
+				data, err := ioutil.ReadFile(afuFile)
+				if err != nil {
+					return err
+				}
+				devNode, err := c.getDevNode(name)
+				if err != nil {
+					return err
+				}
+				afus = append(afus, afu{
+					id:      name,
+					afuID:   strings.TrimSpace(string(data)),
+					devNode: devNode,
+				})
+			}
+		}
+
+		if len(regions) == 0 {
+			return fmt.Errorf("No regions found for device %s", fname)
+		}
+
+		// Currently only one region per device is supported.
+		regions[0].afus = afus
+		devices = append(devices, device{
+			name:    fname,
+			regions: regions,
+		})
+	}
+
+	c.detectUpdates(devices)
+	c.devices = devices
+
+	return nil
+}
+
+// Run starts scanning of FPGA devices on the host
+func (c *Cache) Run() error {
+	for {
+		err := c.scanFPGAs()
+		if err != nil {
+			glog.Error("Device scan failed: ", err)
+			return fmt.Errorf("Device scan failed: %v", err)
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/cmd/fpga_plugin/devicecache/devicecache_test.go
+++ b/cmd/fpga_plugin/devicecache/devicecache_test.go
@@ -1,0 +1,439 @@
+// Copyright 2018 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicecache
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin"
+)
+
+func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFiles map[string][]byte) error {
+	var err error
+
+	for _, devfsdir := range devfsDirs {
+		err = os.MkdirAll(path.Join(devfs, devfsdir), 0755)
+		if err != nil {
+			return fmt.Errorf("Failed to create fake device directory: %v", err)
+		}
+	}
+	for _, sysfsdir := range sysfsDirs {
+		err = os.MkdirAll(path.Join(sysfs, sysfsdir), 0755)
+		if err != nil {
+			return fmt.Errorf("Failed to create fake device directory: %v", err)
+		}
+	}
+	for filename, body := range sysfsFiles {
+		err = ioutil.WriteFile(path.Join(sysfs, filename), body, 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to create fake vendor file: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func TestNewCache(t *testing.T) {
+	tcases := []struct {
+		mode        string
+		expectedErr bool
+	}{
+		{
+			mode: AfMode,
+		},
+		{
+			mode: RegionMode,
+		},
+		{
+			mode:        "unparsable",
+			expectedErr: true,
+		},
+	}
+
+	for _, tcase := range tcases {
+		_, err := NewCache("", "", tcase.mode, nil)
+		if tcase.expectedErr && err == nil {
+			t.Error("No error generated when creating Cache with invalid parameters")
+		}
+	}
+}
+
+// getDevices returns static list of device structs for testing purposes
+func getDevices() []device {
+	return []device{
+		{
+			name: "intel-fpga-dev.0",
+			regions: []region{
+				{
+					id:          "intel-fpga-fme.0",
+					interfaceID: "ce48969398f05f33946d560708be108a",
+					devNode:     "/dev/intel-fpga-fme.0",
+					afus: []afu{
+						{
+							id:      "intel-fpga-port.0",
+							afuID:   "d8424dc4a4a3c413f89e433683f9040b",
+							devNode: "/dev/intel-fpga-port.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "intel-fpga-dev.1",
+			regions: []region{
+				{
+					id:          "intel-fpga-fme.1",
+					interfaceID: "ce48969398f05f33946d560708be108a",
+					devNode:     "/dev/intel-fpga-fme.1",
+					afus: []afu{
+						{
+							id:      "intel-fpga-port.1",
+							afuID:   "d8424dc4a4a3c413f89e433683f9040b",
+							devNode: "/dev/intel-fpga-port.1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetRegionMap(t *testing.T) {
+	expected := map[string]map[string]deviceplugin.DeviceInfo{
+		"ce48969398f05f33946d560708be108a": {
+			"intel-fpga-fme.0": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.0", "/dev/intel-fpga-fme.0"},
+			},
+			"intel-fpga-fme.1": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.1", "/dev/intel-fpga-fme.1"},
+			},
+		},
+	}
+
+	result := getRegionMap(getDevices())
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Got unexpected result: ", result)
+	}
+}
+
+func TestGetAfuMap(t *testing.T) {
+	expected := map[string]map[string]deviceplugin.DeviceInfo{
+		"d8424dc4a4a3c413f89e433683f9040b": {
+			"intel-fpga-port.0": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.0"},
+			},
+			"intel-fpga-port.1": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.1"},
+			},
+		},
+	}
+
+	result := getAfuMap(getDevices())
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Got unexpected result: ", result)
+	}
+}
+
+func getDevMapClosure(oldmap map[string]map[string]deviceplugin.DeviceInfo, newmap map[string]map[string]deviceplugin.DeviceInfo) getDevMapFunc {
+	var callnum int
+
+	if oldmap == nil {
+		oldmap = make(map[string]map[string]deviceplugin.DeviceInfo)
+	}
+	if newmap == nil {
+		newmap = make(map[string]map[string]deviceplugin.DeviceInfo)
+	}
+
+	return func(devices []device) map[string]map[string]deviceplugin.DeviceInfo {
+		defer func() { callnum = callnum + 1 }()
+
+		if callnum%2 == 0 {
+			return oldmap
+
+		}
+		return newmap
+	}
+}
+
+func TestDetectUpdates(t *testing.T) {
+	tcases := []struct {
+		name            string
+		expectedAdded   int
+		expectedUpdated int
+		expectedRemoved int
+		oldmap          map[string]map[string]deviceplugin.DeviceInfo
+		newmap          map[string]map[string]deviceplugin.DeviceInfo
+	}{
+		{
+			name: "No devices found",
+		},
+		{
+			name: "Added 1 new device type",
+			newmap: map[string]map[string]deviceplugin.DeviceInfo{
+				"fpgaID": {
+					"intel-fpga-port.0": {
+						State: pluginapi.Healthy,
+						Nodes: []string{"/dev/intel-fpga-port.0"},
+					},
+				},
+			},
+			expectedAdded: 1,
+		},
+		{
+			name: "Updated 1 new device type",
+			oldmap: map[string]map[string]deviceplugin.DeviceInfo{
+				"fpgaID": {
+					"intel-fpga-port.0": {
+						State: pluginapi.Healthy,
+						Nodes: []string{"/dev/intel-fpga-port.0"},
+					},
+				},
+			},
+			newmap: map[string]map[string]deviceplugin.DeviceInfo{
+				"fpgaID": {
+					"intel-fpga-port.1": {
+						State: pluginapi.Healthy,
+						Nodes: []string{"/dev/intel-fpga-port.1"},
+					},
+				},
+			},
+			expectedUpdated: 1,
+		},
+		{
+			name: "Removed 1 new device type",
+			oldmap: map[string]map[string]deviceplugin.DeviceInfo{
+				"fpgaID": {
+					"intel-fpga-port.0": {
+						State: pluginapi.Healthy,
+						Nodes: []string{"/dev/intel-fpga-port.0"},
+					},
+				},
+			},
+			expectedRemoved: 1,
+		},
+	}
+
+	for _, tcase := range tcases {
+		ch := make(chan UpdateInfo, 1)
+		cache, err := NewCache("", "", AfMode, ch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cache.getDevMap = getDevMapClosure(tcase.oldmap, tcase.newmap)
+
+		cache.detectUpdates([]device{})
+
+		var update UpdateInfo
+		select {
+		case update = <-ch:
+		default:
+		}
+
+		if tcase.expectedAdded != len(update.Added) {
+			t.Errorf("Test case '%s': expected %d added device types, but got %d", tcase.name, tcase.expectedAdded, len(update.Added))
+		}
+		if tcase.expectedUpdated != len(update.Updated) {
+			t.Errorf("Test case '%s': expected %d updated device types, but got %d", tcase.name, tcase.expectedUpdated, len(update.Updated))
+		}
+		if tcase.expectedRemoved != len(update.Removed) {
+			t.Errorf("Test case '%s': expected %d removed device types, but got %d", tcase.name, tcase.expectedUpdated, len(update.Updated))
+		}
+	}
+}
+
+func TestScanFPGAs(t *testing.T) {
+	tmpdir := fmt.Sprintf("/tmp/fpgaplugin-TestDiscoverFPGAs-%d", time.Now().Unix())
+	sysfs := path.Join(tmpdir, "sys", "class", "fpga")
+	devfs := path.Join(tmpdir, "dev")
+	tcases := []struct {
+		name            string
+		devfsdirs       []string
+		sysfsdirs       []string
+		sysfsfiles      map[string][]byte
+		errorContains   string
+		expectedDevices []device
+	}{
+		{
+			name:          "No sysfs folder given",
+			errorContains: "Can't read sysfs folder",
+		},
+		{
+			name:          "FPGA device without FME and ports",
+			sysfsdirs:     []string{"intel-fpga-dev.0", "incorrect-file-name"},
+			errorContains: "No regions found",
+		},
+		{
+			name:          "AFU without ID",
+			sysfsdirs:     []string{"intel-fpga-dev.0/intel-fpga-port.0"},
+			errorContains: "afu_id: no such file or directory",
+		},
+		{
+			name:      "No device node for detected AFU",
+			sysfsdirs: []string{"intel-fpga-dev.0/intel-fpga-port.0"},
+			sysfsfiles: map[string][]byte{
+				"intel-fpga-dev.0/intel-fpga-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+			},
+			errorContains: "/dev/intel-fpga-port.0: no such file or directory",
+		},
+		{
+			name:      "AFU without corresponding FME",
+			sysfsdirs: []string{"intel-fpga-dev.0/intel-fpga-port.0"},
+			devfsdirs: []string{"intel-fpga-port.0"},
+			sysfsfiles: map[string][]byte{
+				"intel-fpga-dev.0/intel-fpga-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+			},
+			errorContains: "No regions found",
+		},
+		{
+			name: "More than one FME per FPGA device",
+			sysfsdirs: []string{
+				"intel-fpga-dev.0/intel-fpga-fme.0/pr",
+				"intel-fpga-dev.0/intel-fpga-fme.1/pr",
+			},
+			sysfsfiles: map[string][]byte{
+				"intel-fpga-dev.0/intel-fpga-fme.0/pr/interface_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"intel-fpga-dev.0/intel-fpga-fme.1/pr/interface_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+			},
+			devfsdirs: []string{
+				"intel-fpga-fme.0",
+				"intel-fpga-fme.1",
+			},
+			errorContains: "Detected more than one FPGA region",
+		},
+		{
+			name:          "FME without interface ID",
+			sysfsdirs:     []string{"intel-fpga-dev.0/intel-fpga-fme.0"},
+			errorContains: "interface_id: no such file or directory",
+		},
+		{
+			name:      "No device node for detected region",
+			sysfsdirs: []string{"intel-fpga-dev.0/intel-fpga-fme.0/pr"},
+			sysfsfiles: map[string][]byte{
+				"intel-fpga-dev.0/intel-fpga-fme.0/pr/interface_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+			},
+			errorContains: "/dev/intel-fpga-fme.0: no such file or directory",
+		},
+		{
+			name: "No errors expected",
+			sysfsdirs: []string{
+				"intel-fpga-dev.0/intel-fpga-port.0",
+				"intel-fpga-dev.0/intel-fpga-fme.0/pr",
+				"intel-fpga-dev.1/intel-fpga-port.1",
+				"intel-fpga-dev.1/intel-fpga-fme.1/pr",
+			},
+			sysfsfiles: map[string][]byte{
+				"intel-fpga-dev.0/intel-fpga-port.0/afu_id":         []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"intel-fpga-dev.1/intel-fpga-port.1/afu_id":         []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"intel-fpga-dev.0/intel-fpga-fme.0/pr/interface_id": []byte("ce48969398f05f33946d560708be108a\n"),
+				"intel-fpga-dev.1/intel-fpga-fme.1/pr/interface_id": []byte("ce48969398f05f33946d560708be108a\n"),
+			},
+			devfsdirs: []string{
+				"intel-fpga-port.0", "intel-fpga-fme.0",
+				"intel-fpga-port.1", "intel-fpga-fme.1",
+			},
+			expectedDevices: []device{
+				{
+					name: "intel-fpga-dev.0",
+					regions: []region{
+						{
+							id:          "intel-fpga-fme.0",
+							interfaceID: "ce48969398f05f33946d560708be108a",
+							devNode:     path.Join(devfs, "intel-fpga-fme.0"),
+							afus: []afu{
+								{
+									id:      "intel-fpga-port.0",
+									afuID:   "d8424dc4a4a3c413f89e433683f9040b",
+									devNode: path.Join(devfs, "intel-fpga-port.0"),
+								},
+							},
+						},
+					},
+				},
+				{
+					name: "intel-fpga-dev.1",
+					regions: []region{
+						{
+							id:          "intel-fpga-fme.1",
+							interfaceID: "ce48969398f05f33946d560708be108a",
+							devNode:     path.Join(devfs, "intel-fpga-fme.1"),
+							afus: []afu{
+								{
+									id:      "intel-fpga-port.1",
+									afuID:   "d8424dc4a4a3c413f89e433683f9040b",
+									devNode: path.Join(devfs, "intel-fpga-port.1"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range tcases {
+		err := createTestDirs(devfs, sysfs, tcase.devfsdirs, tcase.sysfsdirs, tcase.sysfsfiles)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cache, err := NewCache(sysfs, devfs, AfMode, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cache.getDevMap = func(devices []device) map[string]map[string]deviceplugin.DeviceInfo {
+			return make(map[string]map[string]deviceplugin.DeviceInfo)
+		}
+
+		err = cache.scanFPGAs()
+		if tcase.errorContains != "" {
+			if err == nil || !strings.Contains(err.Error(), tcase.errorContains) {
+				t.Errorf("Test case '%s': expected error '%s', but got '%v'", tcase.name, tcase.errorContains, err)
+			}
+		} else if err != nil {
+			t.Errorf("Test case '%s': expected no error, but got '%v'", tcase.name, err)
+		}
+		if tcase.expectedDevices != nil && !reflect.DeepEqual(tcase.expectedDevices, cache.devices) {
+			t.Errorf("Test case '%s': expected devices '%v', but got '%v'", tcase.name, tcase.expectedDevices, cache.devices)
+		}
+
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRun(t *testing.T) {
+	cache := Cache{
+		sysfsDir: "/dev/null",
+	}
+	err := cache.Run()
+	if err == nil {
+		t.Error("Expected error, but got nil")
+	}
+}


### PR DESCRIPTION
This refactoring brings in device Cache running in its own
thread and scanning FPGA devices once every 5 secs. Then no timers
are used inside ListAndWatch() method of device managers and
no need to run scanning periodically in every device manager's
thread.

Cache generates update events and the plugin creates, updates or
deletes device managers on the fly upon receiving the events.

Introducing new modes of operations is a matter of adding a single
function converting and filtering the content of Cache.