### PR TITLE
Makefile: fail test target correctly upon errors in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,12 @@ test:
 ifndef WHAT
 	@$(GO) test -race -coverprofile=coverage.txt -covermode=atomic $(pkgs)
 else
-	@cd $(WHAT) && $(GO) test -v -cover -coverprofile cover.out
-	@cd $(WHAT) && $(GO) tool cover -html=cover.out -o coverage.html
-	@cd $(WHAT) && rm cover.out
+	@cd $(WHAT) && \
+            $(GO) test -v -cover -coverprofile cover.out -args -logtostderr -v 2 || rc=1; \
+            $(GO) tool cover -html=cover.out -o coverage.html; \
+            rm cover.out; \
+            echo "Coverage report: file://$$(realpath coverage.html)"; \
+            exit $$rc
 endif
 
 lint:


### PR DESCRIPTION
When refactoring FPGA discovery I realized that upon test failures the coverage report isn't re-generated and the `test` target doesn't actually fail. Thus this correction.