### PR TITLE
add regiondevel mode to fpga_plugin

### DIFF
--- a/cmd/fpga_plugin/devicecache/devicecache_test.go
+++ b/cmd/fpga_plugin/devicecache/devicecache_test.go
@@ -66,6 +66,9 @@ func TestNewCache(t *testing.T) {
 			mode: RegionMode,
 		},
 		{
+			mode: RegionDevelMode,
+		},
+		{
 			mode:        "unparsable",
 			expectedErr: true,
 		},
@@ -119,7 +122,7 @@ func getDevices() []device {
 	}
 }
 
-func TestGetRegionMap(t *testing.T) {
+func TestGetRegionDevelMap(t *testing.T) {
 	expected := map[string]map[string]deviceplugin.DeviceInfo{
 		"ce48969398f05f33946d560708be108a": {
 			"intel-fpga-fme.0": {
@@ -129,6 +132,26 @@ func TestGetRegionMap(t *testing.T) {
 			"intel-fpga-fme.1": {
 				State: pluginapi.Healthy,
 				Nodes: []string{"/dev/intel-fpga-port.1", "/dev/intel-fpga-fme.1"},
+			},
+		},
+	}
+
+	result := getRegionDevelMap(getDevices())
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Got unexpected result: ", result)
+	}
+}
+
+func TestGetRegionMap(t *testing.T) {
+	expected := map[string]map[string]deviceplugin.DeviceInfo{
+		"ce48969398f05f33946d560708be108a": {
+			"intel-fpga-fme.0": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.0"},
+			},
+			"intel-fpga-fme.1": {
+				State: pluginapi.Healthy,
+				Nodes: []string{"/dev/intel-fpga-port.1"},
 			},
 		},
 	}

--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -119,7 +119,8 @@ func handleUpdate(dms map[string]*deviceManager, updateInfo devicecache.UpdateIn
 func main() {
 	var mode string
 
-	flag.StringVar(&mode, "mode", string(devicecache.AfMode), fmt.Sprintf("device plugin mode: '%s' (default) or '%s'", devicecache.AfMode, devicecache.RegionMode))
+	flag.StringVar(&mode, "mode", string(devicecache.AfMode),
+		fmt.Sprintf("device plugin mode: '%s' (default), '%s' or '%s'", devicecache.AfMode, devicecache.RegionMode, devicecache.RegionDevelMode))
 	flag.Parse()
 
 	updatesCh := make(chan devicecache.UpdateInfo)


### PR DESCRIPTION
In the `af` mode the plugin announces AFUs and tells kubelet
to pass only AFU ports to containers.

In the `region` mode the plugin announces region interfaces and tells
kubelet to pass only AFU ports to containers.

In the `regiondevel` mode the plugin announces region interfaces and
tells kubelet to pass AFU ports and FME devices to containers, so the
conteainers have full access to the regions.