### PR TITLE
fix script name in fpga job spec

### DIFF
--- a/demo/intelfpga-job.yaml
+++ b/demo/intelfpga-job.yaml
@@ -15,7 +15,7 @@ spec:
         - name: intelfpga-demo-job-1
           image: ubuntu-demo-opae:latest
           imagePullPolicy: IfNotPresent
-          command: ["/usr/bin/run_hello_fpga.sh"]
+          command: ["/usr/bin/test_fpga.sh"]
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
Name of the test script has been changed recently, but job
spec hasn't been updated.