### PR TITLE
fpga: restore mode names in resource prefixes

### DIFF
--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -25,7 +25,7 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 $ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode af
 FPGA device plugin started in af mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/intel-fpga-f7df405cbd7acf7222f144b0b93acd18.sock
+device-plugin start server at: /var/lib/kubelet/device-plugins/intel-fpga-af-f7df405cbd7acf7222f144b0b93acd18.sock
 device-plugin registered
 ```
 
@@ -42,7 +42,7 @@ $ kubectl describe node <node name> | grep intel.com/fpga
 ```
 $ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode region
 FPGA device plugin started in region mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/intel-fpga-ce48969398f05f33946d560708be108a.sock
+device-plugin start server at: /var/lib/kubelet/device-plugins/intel-fpga-region-ce48969398f05f33946d560708be108a.sock
 device-plugin registered
 ```
 

--- a/cmd/fpga_plugin/devicecache/devicecache.go
+++ b/cmd/fpga_plugin/devicecache/devicecache.go
@@ -61,15 +61,16 @@ func getRegionDevelMap(devices []device) map[string]map[string]deviceplugin.Devi
 
 	for _, dev := range devices {
 		for _, region := range dev.regions {
-			if _, present := regionMap[region.interfaceID]; !present {
-				regionMap[region.interfaceID] = make(map[string]deviceplugin.DeviceInfo)
+			fpgaID := fmt.Sprintf("%s-%s", RegionMode, region.interfaceID)
+			if _, present := regionMap[fpgaID]; !present {
+				regionMap[fpgaID] = make(map[string]deviceplugin.DeviceInfo)
 			}
 			devNodes := make([]string, len(region.afus)+1)
 			for num, afu := range region.afus {
 				devNodes[num] = afu.devNode
 			}
 			devNodes[len(region.afus)] = region.devNode
-			regionMap[region.interfaceID][region.id] = deviceplugin.DeviceInfo{
+			regionMap[fpgaID][region.id] = deviceplugin.DeviceInfo{
 				State: pluginapi.Healthy,
 				Nodes: devNodes,
 			}
@@ -85,14 +86,15 @@ func getRegionMap(devices []device) map[string]map[string]deviceplugin.DeviceInf
 
 	for _, dev := range devices {
 		for _, region := range dev.regions {
-			if _, present := regionMap[region.interfaceID]; !present {
-				regionMap[region.interfaceID] = make(map[string]deviceplugin.DeviceInfo)
+			fpgaID := fmt.Sprintf("%s-%s", RegionMode, region.interfaceID)
+			if _, present := regionMap[fpgaID]; !present {
+				regionMap[fpgaID] = make(map[string]deviceplugin.DeviceInfo)
 			}
 			devNodes := make([]string, len(region.afus))
 			for num, afu := range region.afus {
 				devNodes[num] = afu.devNode
 			}
-			regionMap[region.interfaceID][region.id] = deviceplugin.DeviceInfo{
+			regionMap[fpgaID][region.id] = deviceplugin.DeviceInfo{
 				State: pluginapi.Healthy,
 				Nodes: devNodes,
 			}
@@ -109,10 +111,11 @@ func getAfuMap(devices []device) map[string]map[string]deviceplugin.DeviceInfo {
 	for _, dev := range devices {
 		for _, region := range dev.regions {
 			for _, afu := range region.afus {
-				if _, present := afuMap[afu.afuID]; !present {
-					afuMap[afu.afuID] = make(map[string]deviceplugin.DeviceInfo)
+				fpgaID := fmt.Sprintf("%s-%s", AfMode, afu.afuID)
+				if _, present := afuMap[fpgaID]; !present {
+					afuMap[fpgaID] = make(map[string]deviceplugin.DeviceInfo)
 				}
-				afuMap[afu.afuID][afu.id] = deviceplugin.DeviceInfo{
+				afuMap[fpgaID][afu.id] = deviceplugin.DeviceInfo{
 					State: pluginapi.Healthy,
 					Nodes: []string{afu.devNode},
 				}

--- a/cmd/fpga_plugin/devicecache/devicecache_test.go
+++ b/cmd/fpga_plugin/devicecache/devicecache_test.go
@@ -124,7 +124,7 @@ func getDevices() []device {
 
 func TestGetRegionDevelMap(t *testing.T) {
 	expected := map[string]map[string]deviceplugin.DeviceInfo{
-		"ce48969398f05f33946d560708be108a": {
+		RegionMode + "-ce48969398f05f33946d560708be108a": {
 			"intel-fpga-fme.0": {
 				State: pluginapi.Healthy,
 				Nodes: []string{"/dev/intel-fpga-port.0", "/dev/intel-fpga-fme.0"},
@@ -144,7 +144,7 @@ func TestGetRegionDevelMap(t *testing.T) {
 
 func TestGetRegionMap(t *testing.T) {
 	expected := map[string]map[string]deviceplugin.DeviceInfo{
-		"ce48969398f05f33946d560708be108a": {
+		RegionMode + "-ce48969398f05f33946d560708be108a": {
 			"intel-fpga-fme.0": {
 				State: pluginapi.Healthy,
 				Nodes: []string{"/dev/intel-fpga-port.0"},
@@ -164,7 +164,7 @@ func TestGetRegionMap(t *testing.T) {
 
 func TestGetAfuMap(t *testing.T) {
 	expected := map[string]map[string]deviceplugin.DeviceInfo{
-		"d8424dc4a4a3c413f89e433683f9040b": {
+		AfMode + "-d8424dc4a4a3c413f89e433683f9040b": {
 			"intel-fpga-port.0": {
 				State: pluginapi.Healthy,
 				Nodes: []string{"/dev/intel-fpga-port.0"},


### PR DESCRIPTION
The latest refactoring of FPGA scanning accidentally removed
mode names from resource name prefixes.

Restore them back.