### PR TITLE
Tag latest image build as 'latest'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ build: $(cmds)
 
 $(images):
 	docker build -f build/docker/$@.Dockerfile $(DOCKER_ARGS) -t $@:$(TAG) .
+	docker tag $@:$(TAG) $@:devel
 
 images: $(images)
 


### PR DESCRIPTION
It's easier to refer <image-name>:latest tags in demo YAML files than to update all of them to use the latest hashes of the images.