### PR TITLE
fpga_admissionwebhook: add orchestrated mode

### DIFF
--- a/cmd/fpga_admissionwebhook/README.md
+++ b/cmd/fpga_admissionwebhook/README.md
@@ -39,6 +39,14 @@ Then run the script `scripts/webhook-deploy.sh`.
     Register webhook
     mutatingwebhookconfiguration "fpga-mutator-webhook-cfg" created
 
+By default the script deploys the webhook in the preprogrammed mode (when
+requested FPGA resources get translated to AF resources, e.g.
+"intel.com/fpga-arria10-nlb0" -> "intel.com/fpga-af-d8424dc4a4a3c413f89e433683f9040b").
+You can command the script to deploy the webhook in the orchestrated mode with
+the option `--mode`.
+
+    $ ./scripts/webhook-deploy.sh --mode orchestrated
+
 Please note that the script needs the CA bundle used for signing cerificate
 requests in your cluster. By default it fetches the bundle stored
 in the configmap `extension-apiserver-authentication`. But it may differ from

--- a/deployments/fpga_admissionwebhook/deployment-tpl.yaml
+++ b/deployments/fpga_admissionwebhook/deployment-tpl.yaml
@@ -20,6 +20,7 @@ spec:
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-private-key-file=/etc/webhook/certs/key.pem
+            - -mode={MODE}
             - -alsologtostderr
             - -v=2
             - 2>&1

--- a/scripts/webhook-deploy.sh
+++ b/scripts/webhook-deploy.sh
@@ -1,10 +1,21 @@
 #!/bin/bash -e
 
-# Check we've got all dependencies installed
-which cfssl > /dev/null
-which jq > /dev/null
-
 srcroot="$(realpath $(dirname $0)/..)"
+service="intel-fpga-webhook-svc"
+secret="intel-fpga-webhook-certs"
+
+function help {
+    echo "Usage: $1 <options> [help|cleanup]"
+    echo '    Command "help" prints this message'
+    echo '    Command "cleanup" removes admission webhook deployment'
+    echo ''
+    echo '    If no command is given the script will deploy the webhook'
+    echo ''
+    echo '    Options:'
+    echo '      --kubectl <kubectl> - path to the kubectl utility'
+    echo '      --mode <mode> - "preprogrammed" (default) or "orchestrated" mode of operation'
+    echo '      --ca-bundle-path <path> - path to CA bundle used for signing cerificates in the cluster'
+}
 
 while [[ $# -gt 0 ]]; do
     case ${1} in
@@ -20,12 +31,31 @@ while [[ $# -gt 0 ]]; do
 	    mode="$2"
             shift
             ;;
+	help)
+	    help $(basename $0)
+	    exit 0
+	    ;;
+	cleanup)
+	    command="cleanup"
+	    ;;
     esac
     shift
 done
 
 [ -z ${kubectl} ] && kubectl="kubectl"
 [ -z ${mode} ] && mode="preprogrammed"
+
+# clean up any previously created deployment
+${kubectl} delete MutatingWebhookConfiguration "fpga-mutator-webhook-cfg" 2>/dev/null || true
+${kubectl} delete service ${service} 2>/dev/null || true
+${kubectl} delete deployment "intel-fpga-webhook-deployment" 2>/dev/null || true
+${kubectl} delete secret ${secret} 2>/dev/null || true
+${kubectl} delete csr "${service}.default" 2>/dev/null || true
+
+if [ "x${command}" = "xcleanup" ]; then
+    echo "Cleanup done. Exiting..."
+    exit 0
+fi
 
 if [ "x${mode}" != "xpreprogrammed" -a "x${mode}" != "xorchestrated" ]; then
     echo "ERROR: supported modes are 'preprogrammed' and 'orchestrated'"
@@ -39,7 +69,7 @@ else
 fi
 
 echo "Create secret including signed key/cert pair for the webhook"
-${srcroot}/scripts/webhook-create-signed-cert.sh --kubectl ${kubectl}
+${srcroot}/scripts/webhook-create-signed-cert.sh --kubectl ${kubectl} --service ${service} --secret ${secret} --namespace "default"
 
 echo "Create webhook deployment"
 cat ${srcroot}/deployments/fpga_admissionwebhook/deployment-tpl.yaml | sed -e "s/{MODE}/${mode}/g" | ${kubectl} create -f -


### PR DESCRIPTION
In `orchestrated` mode the webhook parses requested resources and to translates
them to a container's ENV variables to let CRI hooks to program the FPGA with
requested bitstreams before starting the container.