### PR TITLE
fpga remove endless serving loop

### DIFF
--- a/cmd/fpga_plugin/devicecache/devicecache.go
+++ b/cmd/fpga_plugin/devicecache/devicecache.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/golang/glog"
@@ -269,6 +270,12 @@ func (c *Cache) scanFPGAs() error {
 				afuFile := path.Join(deviceFolder, name, "afu_id")
 				data, err := ioutil.ReadFile(afuFile)
 				if err != nil {
+					if perr, ok := err.(*os.PathError); ok {
+						if perr.Err.(syscall.Errno) == syscall.EBUSY {
+							glog.Warningf("afu_id is busy, skipping: %+v", err)
+							continue
+						}
+					}
 					return err
 				}
 				devNode, err := c.getDevNode(name)


### PR DESCRIPTION
This loop is not needed as device manager object is created
by devicecach on demand. Having it running is waste of resources.
    
It also doesn't allow setupAndServe function to exit, which creates race
condition on the plugin socket:
F0702 17:38:21.776794   49939 fpga_plugin.go:112] Socket
    /var/lib/kubelet/device-plugins/intel-fpga-af-d8424dc4a4a3c413f89e433683f9040b.sock
    is already in use
