### PR TITLE
Proposal for logging and error tracing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,142 +2,189 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:cd4f86461732066e277335465962660cbf02999e18d5bbb5e9285eac4608b970"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
     "protoc-gen-gogo/descriptor",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "NUT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:03e14cff610a8a58b774e36bd337fa979482be86aab01be81fb8bbd6d0f07fc8"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:06a7dadb7b760767341ffb6c8d377238d68a1226f2b21b5d497d2e3f6ecf6b4e"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "NUT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
+  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  digest = "1:9a52adf44086cead3b384e5d0dbf7a1c1cce65e67552ee3383a8561c42a18cd3"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
   version = "v0.3.6"
 
 [[projects]]
+  digest = "1:8e36686e8b139f8fe240c1d5cf3a145bc675c22ff8e707857cdd3ae17b00d728"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "1.1.5"
 
 [[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:e3707aeaccd2adc89eba6c062fec72116fe1fc1ba71097da85b4d8ae1668a675"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "NUT"
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
+  digest = "1:98f099782e33665fa7aa22c534581cd4a18f9a06b9af22cf57721019511d74b4"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -146,20 +193,24 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "f9ce57c11b242f0f1599cf25c89d8cb02c45295a"
 
 [[projects]]
   branch = "master"
+  digest = "1:87aef4c266c820591e859450c3ee5ab98f9b8755d7cfd9e4db606959eb5b483d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "904bdc257025c7b3f43c19360ad3ab85783fad78"
 
 [[projects]]
+  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -175,34 +226,42 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
+  digest = "1:e1c96c8c8ce0af57da9dccb008e540b3d13b55ea04b530fb4fceb81706082bdd"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
   ]
+  pruneopts = "NUT"
   revision = "2fad9c56520a6ca94c6960472b921c21a8fa9343"
 
 [[projects]]
   branch = "master"
+  digest = "1:077c1c599507b3b3e9156d17d36e1e61928ee9b53a5b420f10f28ebd4a0b275c"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "NUT"
   revision = "383e8b2c3b9e36c4076b235b32537292176bae20"
 
 [[projects]]
+  digest = "1:c2d756dba3cf0bc2d50ff9b3e4b80cd327436cf678386a51c8417d084625a51d"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -230,25 +289,31 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = "NUT"
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:f2d1cf20d271df921c28e96d0d8af3ac43211a891f2bf97cfacefabea8affa70"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -280,17 +345,21 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NUT"
   revision = "70491ec73e10be2989242c913738f049a37e72c7"
 
 [[projects]]
   branch = "master"
+  digest = "1:aff2ac035da399e2ccd6d58a0c484f87a52c82868b652397727c2ce1a3aba7f0"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
+  pruneopts = "NUT"
   revision = "4d05e43ad98c1edcf2f52291685bd9bbc12fd2cd"
 
 [[projects]]
+  digest = "1:1863cb213bf50c1505c7ef97e78ce4e641e4fda9b4e7dc666ad57b094fdaffe8"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -333,21 +402,25 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NUT"
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
   version = "kubernetes-1.11.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:532581eda44a6fdb169ab6d654c90e7246c49ff0692c551fabcd3e03b9bfa93e"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/features",
-    "pkg/util/feature"
+    "pkg/util/feature",
   ]
+  pruneopts = "NUT"
   revision = "f26e5b1f0e9c0ddd9bbff06bf6facf000baffe8f"
 
 [[projects]]
+  digest = "1:408600b610dfa70d4582595301b58ce28122ed441658e8e655a17a18c9a6c3aa"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -408,12 +481,14 @@
     "util/homedir",
     "util/integer",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NUT"
   revision = "7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65"
   version = "v8.0.0"
 
 [[projects]]
+  digest = "1:8ab487a323486c8bbbaa3b689850487fdccc6cbea8690620e083b2d230a4447e"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -434,13 +509,15 @@
     "cmd/lister-gen",
     "cmd/lister-gen/args",
     "cmd/lister-gen/generators",
-    "pkg/util"
+    "pkg/util",
   ]
+  pruneopts = "T"
   revision = "6702109cc68eb6fe6350b83e14407c8d7309fd1a"
   version = "kubernetes-1.11.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5249c83f0fb9e277b2d28c19eca814feac7ef05dc762e4deaf0a2e4b1a7c5df3"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -450,40 +527,85 @@
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "c42f3cdacc394f43077ff17e327d1b351c0304e4"
 
 [[projects]]
   branch = "master"
+  digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
+  pruneopts = "NUT"
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
+  digest = "1:e357138048f5ba471a540b3451a8820e7e76595fcb49632480bcbf2e4aab62ac"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/apis/core",
     "pkg/features",
     "pkg/kubelet/apis",
     "pkg/kubelet/apis/deviceplugin/v1beta1",
-    "pkg/util/node"
+    "pkg/util/node",
   ]
+  pruneopts = "NUT"
   revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
   version = "v1.11.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ff016649ea9f95bbc11850683ed8a9b1788c2a2a8b1b811793344f730628a9f"
   name = "k8s.io/utils"
   packages = [
     "exec",
-    "exec/testing"
+    "exec/testing",
   ]
+  pruneopts = "NUT"
   revision = "045dc31ee5c40e8240241ce28dc24d7b56130373"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e631bc45585e5188f4ad4251919a7d8b6223142c229aad5a806a1162a83e3aa4"
+  input-imports = [
+    "github.com/fsnotify/fsnotify",
+    "github.com/golang/glog",
+    "github.com/pkg/errors",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/metadata",
+    "k8s.io/api/admission/v1beta1",
+    "k8s.io/api/admissionregistration/v1beta1",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/code-generator/cmd/defaulter-gen",
+    "k8s.io/code-generator/cmd/informer-gen",
+    "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1",
+    "k8s.io/kubernetes/pkg/util/node",
+    "k8s.io/utils/exec",
+    "k8s.io/utils/exec/testing",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,10 +34,6 @@ ignored = ["k8s.io/code-generator"]
   unused-packages = false
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/golang/glog"
-
-[[constraint]]
   name = "google.golang.org/grpc"
   version = "1.11.0"
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifndef WHAT
 	@$(GO) test -race -coverprofile=coverage.txt -covermode=atomic $(pkgs)
 else
 	@cd $(WHAT) && \
-            $(GO) test -v -cover -coverprofile cover.out -args -logtostderr -v 2 || rc=1; \
+            $(GO) test -v -cover -coverprofile cover.out || rc=1; \
             $(GO) tool cover -html=cover.out -o coverage.html; \
             rm cover.out; \
             echo "Coverage report: file://$$(realpath coverage.html)"; \

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -7,4 +7,4 @@ RUN chmod a+x /go/bin/fpga_plugin
 
 FROM alpine
 COPY --from=builder /go/bin/fpga_plugin /usr/bin/intel_fpga_device_plugin
-CMD ["/usr/bin/intel_fpga_device_plugin", "-logtostderr"]
+CMD ["/usr/bin/intel_fpga_device_plugin"]

--- a/cmd/fpga_admissionwebhook/controller.go
+++ b/cmd/fpga_admissionwebhook/controller.go
@@ -19,8 +19,9 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -55,8 +56,7 @@ type controller struct {
 func newController(patcher *patcher, config *rest.Config) (*controller, error) {
 	clientset, err := clientset.NewForConfig(config)
 	if err != nil {
-		glog.Error("Failed to create REST clientset ", err)
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to create REST clientset")
 	}
 
 	informerFactory := informers.NewSharedInformerFactory(clientset, resyncPeriod)
@@ -94,11 +94,11 @@ func (c *controller) run(threadiness int) error {
 	go c.informerFactory.Start(c.stopCh)
 
 	if ok := cache.WaitForCacheSync(c.stopCh, c.afsSynced); !ok {
-		return fmt.Errorf("failed to wait for AF caches to sync")
+		return errors.New("failed to wait for AF caches to sync")
 	}
 
 	if ok := cache.WaitForCacheSync(c.stopCh, c.regionsSynced); !ok {
-		return fmt.Errorf("failed to wait for Region caches to sync")
+		return errors.New("failed to wait for Region caches to sync")
 	}
 
 	for i := 0; i < threadiness; i++ {
@@ -107,7 +107,7 @@ func (c *controller) run(threadiness int) error {
 			}
 		}, time.Second, c.stopCh)
 	}
-	glog.Info("Started controller workers")
+	fmt.Println("Started controller workers")
 	<-c.stopCh
 
 	return nil
@@ -133,21 +133,21 @@ func (c *controller) processNextWorkItem() bool {
 
 		if key, ok = obj.(fpgaObjectKey); !ok {
 			c.queue.Forget(obj)
-			return fmt.Errorf("expected fpgaObjectKey in workqueue but got %#v", obj)
+			return errors.Errorf("expected fpgaObjectKey in workqueue but got %#v", obj)
 		}
 
 		switch key.kind {
 		case "af":
 			if err := c.syncAfHandler(key.name); err != nil {
-				return fmt.Errorf("error syncing '%s': %v", key.name, err)
+				return errors.Wrapf(err, "error syncing '%s'", key.name)
 			}
 		case "region":
 			if err := c.syncRegionHandler(key.name); err != nil {
-				return fmt.Errorf("error syncing '%s': %v", key.name, err)
+				return errors.Wrapf(err, "error syncing '%s'", key.name)
 			}
 		default:
 			c.queue.Forget(obj)
-			return fmt.Errorf("Unknown kind of object key: %s", key.kind)
+			return errors.Errorf("Unknown kind of object key: %s", key.kind)
 		}
 
 		// Finally, if no error occurs we Forget this item so it does not
@@ -169,7 +169,7 @@ func (c *controller) syncAfHandler(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		runtime.HandleError(errors.Errorf("invalid resource key: %s", key))
 		return nil
 	}
 
@@ -178,8 +178,8 @@ func (c *controller) syncAfHandler(key string) error {
 	if err != nil {
 		// The AcceleratorFunction resource may no longer exist, in which case we stop
 		// processing.
-		if errors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("accelerated function '%s' in work queue no longer exists", key))
+		if k8serrors.IsNotFound(err) {
+			runtime.HandleError(errors.Errorf("accelerated function '%s' in work queue no longer exists", key))
 			glog.V(2).Infof("AF '%s' no longer exists", key)
 			c.patcher.removeAf(name)
 			return nil
@@ -197,7 +197,7 @@ func (c *controller) syncRegionHandler(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		runtime.HandleError(errors.Errorf("invalid resource key: %s", key))
 		return nil
 	}
 
@@ -206,8 +206,8 @@ func (c *controller) syncRegionHandler(key string) error {
 	if err != nil {
 		// The FpgaRegion resource may no longer exist, in which case we stop
 		// processing.
-		if errors.IsNotFound(err) {
-			runtime.HandleError(fmt.Errorf("FPGA region '%s' in work queue no longer exists", key))
+		if k8serrors.IsNotFound(err) {
+			runtime.HandleError(errors.Errorf("FPGA region '%s' in work queue no longer exists", key))
 			glog.V(2).Infof("Region '%s' no longer exists", key)
 			c.patcher.removeRegion(name)
 			return nil

--- a/cmd/fpga_admissionwebhook/controller.go
+++ b/cmd/fpga_admissionwebhook/controller.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +30,7 @@ import (
 	clientset "github.com/intel/intel-device-plugins-for-kubernetes/pkg/client/clientset/versioned"
 	informers "github.com/intel/intel-device-plugins-for-kubernetes/pkg/client/informers/externalversions"
 	listers "github.com/intel/intel-device-plugins-for-kubernetes/pkg/client/listers/fpga.intel.com/v1"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 const (
@@ -89,7 +89,7 @@ func (c *controller) run(threadiness int) error {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	glog.Info("Starting controller")
+	fmt.Println("Starting controller")
 
 	go c.informerFactory.Start(c.stopCh)
 
@@ -153,7 +153,7 @@ func (c *controller) processNextWorkItem() bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.queue.Forget(obj)
-		glog.V(2).Infof("Successfully synced '%s'", key)
+		debug.Printf("Successfully synced '%s'", key)
 		return nil
 	}(obj)
 
@@ -180,7 +180,7 @@ func (c *controller) syncAfHandler(key string) error {
 		// processing.
 		if k8serrors.IsNotFound(err) {
 			runtime.HandleError(errors.Errorf("accelerated function '%s' in work queue no longer exists", key))
-			glog.V(2).Infof("AF '%s' no longer exists", key)
+			debug.Printf("AF '%s' no longer exists", key)
 			c.patcher.removeAf(name)
 			return nil
 		}
@@ -188,7 +188,7 @@ func (c *controller) syncAfHandler(key string) error {
 		return err
 	}
 
-	glog.V(2).Info("Received ", af)
+	debug.Print("Received", af)
 	c.patcher.addAf(af)
 	return nil
 }
@@ -208,7 +208,7 @@ func (c *controller) syncRegionHandler(key string) error {
 		// processing.
 		if k8serrors.IsNotFound(err) {
 			runtime.HandleError(errors.Errorf("FPGA region '%s' in work queue no longer exists", key))
-			glog.V(2).Infof("Region '%s' no longer exists", key)
+			debug.Printf("Region '%s' no longer exists", key)
 			c.patcher.removeRegion(name)
 			return nil
 		}
@@ -216,7 +216,7 @@ func (c *controller) syncRegionHandler(key string) error {
 		return err
 	}
 
-	glog.V(2).Info("Received ", region)
+	debug.Print("Received", region)
 	c.patcher.addRegion(region)
 	return nil
 }

--- a/cmd/fpga_admissionwebhook/controller_test.go
+++ b/cmd/fpga_admissionwebhook/controller_test.go
@@ -25,11 +25,16 @@ import (
 
 	v1 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga.intel.com/v1"
 	listers "github.com/intel/intel-device-plugins-for-kubernetes/pkg/client/listers/fpga.intel.com/v1"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 type fakeAfNamespaceLister struct {
 	af  *v1.AcceleratorFunction
 	err error
+}
+
+func init() {
+	debug.Activate()
 }
 
 func (nl *fakeAfNamespaceLister) Get(name string) (*v1.AcceleratorFunction, error) {

--- a/cmd/fpga_admissionwebhook/controller_test.go
+++ b/cmd/fpga_admissionwebhook/controller_test.go
@@ -98,18 +98,18 @@ func TestSyncAfHandler(t *testing.T) {
 	for _, tt := range tcases {
 		p, err := newPatcher(preprogrammed)
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		c, err := newController(p, &rest.Config{})
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		if tt.afLister != nil {
 			c.afLister = tt.afLister
 		}
 		err = c.syncAfHandler(tt.key)
 		if err != nil && !tt.expectedErr {
-			t.Errorf("Test case '%s': unexpected error: %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error: %+v", tt.name, err)
 		}
 		if err == nil && tt.expectedErr {
 			t.Errorf("Test case '%s': expected error, but got success", tt.name)
@@ -188,18 +188,18 @@ func TestSyncRegionHandler(t *testing.T) {
 	for _, tt := range tcases {
 		p, err := newPatcher(preprogrammed)
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		c, err := newController(p, &rest.Config{})
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		if tt.regionLister != nil {
 			c.regionLister = tt.regionLister
 		}
 		err = c.syncRegionHandler(tt.key)
 		if err != nil && !tt.expectedErr {
-			t.Errorf("Test case '%s': unexpected error: %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error: %+v", tt.name, err)
 		}
 		if err == nil && tt.expectedErr {
 			t.Errorf("Test case '%s': expected error, but got success", tt.name)
@@ -308,7 +308,7 @@ func TestProcessNextWorkItem(t *testing.T) {
 		p := &patcher{}
 		c, err := newController(p, &rest.Config{})
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		c.queue = &fakeQueue{
 			shutdown: tt.shutdown,
@@ -349,12 +349,12 @@ func TestRun(t *testing.T) {
 		p := &patcher{}
 		c, err := newController(p, &rest.Config{})
 		if err != nil {
-			t.Fatalf("Test case '%s': %v", tt.name, err)
+			t.Fatalf("Test case '%s': %+v", tt.name, err)
 		}
 		close(c.stopCh)
 		err = c.run(0)
 		if err != nil && !tt.expectedErr {
-			t.Errorf("Test case '%s': unexpected error: %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error: %+v", tt.name, err)
 		}
 		if err == nil && tt.expectedErr {
 			t.Errorf("Test case '%s': expected error, but got success", tt.name)
@@ -384,7 +384,7 @@ func TestNewController(t *testing.T) {
 		p := &patcher{}
 		c, err := newController(p, config)
 		if err != nil && !tt.expectedErr {
-			t.Errorf("Test case '%s': unexpected error: %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error: %+v", tt.name, err)
 		}
 		if err == nil && tt.expectedErr {
 			t.Errorf("Test case '%s': expected error, but got success", tt.name)

--- a/cmd/fpga_admissionwebhook/fpga_admissionwebhook.go
+++ b/cmd/fpga_admissionwebhook/fpga_admissionwebhook.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	"k8s.io/api/admission/v1beta1"
@@ -36,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 const (
@@ -71,11 +72,11 @@ func getTLSConfig(certFile string, keyFile string) *tls.Config {
 func mutatePods(ar v1beta1.AdmissionReview, p *patcher) *v1beta1.AdmissionResponse {
 	var ops []string
 
-	glog.V(2).Info("mutating pods")
+	debug.Print("mutating pods")
 
 	podResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	if ar.Request.Resource != podResource {
-		glog.Errorf("expect resource to be %s", podResource)
+		fmt.Printf("WARNING: Unexpected resource type %s\n", ar.Request.Resource)
 		return nil
 	}
 
@@ -128,7 +129,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 	}
 
 	if len(body) == 0 {
-		glog.Error("No body in request")
+		debug.Print("No body in request")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -136,16 +137,16 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		glog.Errorf("contentType=%s, expect application/json", contentType)
+		debug.Printf("contentType=%s, expect application/json", contentType)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	glog.V(2).Info(fmt.Sprintf("handling request: %s", string(body)))
+	debug.Printf("handling request: %s", string(body))
 	ar := v1beta1.AdmissionReview{}
 	deserializer := codecs.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
-		glog.Error(err)
+		fmt.Printf("ERROR: %+v\n", err)
 		reviewResponse = toAdmissionResponse(err)
 	} else {
 		if ar.Request == nil {
@@ -156,7 +157,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 			reviewResponse = admit(ar)
 		}
 	}
-	glog.V(2).Info(fmt.Sprintf("sending response: %v", reviewResponse))
+	debug.Print("sending response", reviewResponse)
 
 	response := v1beta1.AdmissionReview{}
 	if reviewResponse != nil {
@@ -172,11 +173,11 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 
 	resp, err := json.Marshal(response)
 	if err != nil {
-		glog.Error(err)
+		fmt.Println("ERROR:", err)
 		return
 	}
 	if _, err := w.Write(resp); err != nil {
-		glog.Error(err)
+		fmt.Println("ERROR:", err)
 	}
 }
 
@@ -201,6 +202,7 @@ func main() {
 	var mode string
 	var config *rest.Config
 	var err error
+	var debugEnabled bool
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&master, "master", "", "master url")
@@ -208,25 +210,30 @@ func main() {
 		"File containing the x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).")
 	flag.StringVar(&keyFile, "tls-private-key-file", keyFile, "File containing the x509 private key matching --tls-cert-file.")
 	flag.StringVar(&mode, "mode", preprogrammed, fmt.Sprintf("webhook mode: '%s' (default) or '%s'", preprogrammed, orchestrated))
+	flag.BoolVar(&debugEnabled, "debug", false, "enable debug output")
 	flag.Parse()
 
+	if debugEnabled {
+		debug.Activate()
+	}
+
 	if certFile == "" {
-		glog.Error("TLS certificate file is not set")
+		fmt.Println("TLS certificate file is not set")
 		os.Exit(1)
 	}
 
 	if keyFile == "" {
-		glog.Error("TLS private key is not set")
+		fmt.Println("TLS private key is not set")
 		os.Exit(1)
 	}
 
 	if _, err = os.Stat(certFile); err != nil {
-		glog.Error("TLS certificate not found")
+		fmt.Println("TLS certificate not found")
 		os.Exit(1)
 	}
 
 	if _, err = os.Stat(keyFile); err != nil {
-		glog.Error("TLS private key not found")
+		fmt.Println("TLS private key not found")
 		os.Exit(1)
 	}
 
@@ -236,7 +243,7 @@ func main() {
 		config, err = clientcmd.BuildConfigFromFlags(master, kubeconfig)
 	}
 	if err != nil {
-		glog.Error("Failed to get cluster config ", err)
+		fmt.Println("Failed to get cluster config ", err)
 		os.Exit(1)
 	}
 
@@ -253,7 +260,7 @@ func main() {
 
 	http.HandleFunc("/pods", makePodsHandler(patcher))
 
-	glog.V(2).Info("Webhook started")
+	debug.Print("Webhook started")
 
 	server := &http.Server{
 		Addr:      ":443",

--- a/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
+++ b/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
@@ -28,7 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func fakeMutatePods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	reviewResponse := v1beta1.AdmissionResponse{}

--- a/cmd/fpga_admissionwebhook/patcher_test.go
+++ b/cmd/fpga_admissionwebhook/patcher_test.go
@@ -278,7 +278,7 @@ func TestGetPatchOpsOrchestrated(t *testing.T) {
 			t.Errorf("Test case '%s': no error returned", tt.name)
 		}
 		if !tt.expectedErr && err != nil {
-			t.Errorf("Test case '%s': unexpected error %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error %+v", tt.name, err)
 		}
 		if len(ops) != tt.expectedOps {
 			t.Errorf("test case '%s': expected %d ops, but got %d\n%v", tt.name, tt.expectedOps, len(ops), ops)
@@ -366,7 +366,7 @@ func TestGetEnvVars(t *testing.T) {
 			t.Errorf("Test case '%s': no error returned", tt.name)
 		}
 		if !tt.expectedErr && err != nil {
-			t.Errorf("Test case '%s': unexpected error %v", tt.name, err)
+			t.Errorf("Test case '%s': unexpected error %+v", tt.name, err)
 		}
 	}
 }

--- a/cmd/fpga_admissionwebhook/patcher_test.go
+++ b/cmd/fpga_admissionwebhook/patcher_test.go
@@ -22,7 +22,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fpgav1 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga.intel.com/v1"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func TestPatcherStorageFunctions(t *testing.T) {
 	af := &fpgav1.AcceleratorFunction{

--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -108,7 +108,7 @@ func TestGetFPGAParams(t *testing.T) {
 
 		content, err := decodeJSONStream(stdin)
 		if err != nil {
-			t.Fatalf("can't decode json file %s: %v", tc.stdinJSON, err)
+			t.Fatalf("can't decode json file %s: %+v", tc.stdinJSON, err)
 		}
 
 		he := newHookEnv("", tc.configJSON, nil, "")
@@ -117,7 +117,7 @@ func TestGetFPGAParams(t *testing.T) {
 
 		if err != nil {
 			if !tc.expectedErr {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error: %+v", err)
 			}
 		} else {
 			if params.region != tc.expectedRegion {
@@ -238,7 +238,7 @@ func TestValidateBitstream(t *testing.T) {
 		he := newHookEnv("", "", &execer, "")
 		err := he.validateBitStream(tc.params, "")
 		if err != nil && !tc.expectedErr {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %+v", err)
 		}
 	}
 }
@@ -300,7 +300,7 @@ func TestProgramBitStream(t *testing.T) {
 		he.execer = &fakeexec.FakeExec{CommandScript: genFakeActions(&fcmd, len(fcmd.CombinedOutputScript))}
 		err := he.programBitStream(tc.params, "")
 		if err != nil && !tc.expectedErr {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %+v", err)
 		}
 	}
 }
@@ -416,7 +416,7 @@ func TestProcess(t *testing.T) {
 		err = he.process(stdin)
 
 		if err != nil && !tc.expectedErr {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %+v", err)
 		}
 	}
 }

--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -22,7 +22,13 @@ import (
 
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func TestGetFPGAParams(t *testing.T) {
 	tcases := []struct {

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin"
@@ -35,19 +37,19 @@ func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFil
 	for _, devfsdir := range devfsDirs {
 		err = os.MkdirAll(path.Join(devfs, devfsdir), 0755)
 		if err != nil {
-			return fmt.Errorf("Failed to create fake device directory: %v", err)
+			return errors.Wrap(err, "Failed to create fake device directory")
 		}
 	}
 	for _, sysfsdir := range sysfsDirs {
 		err = os.MkdirAll(path.Join(sysfs, sysfsdir), 0755)
 		if err != nil {
-			return fmt.Errorf("Failed to create fake device directory: %v", err)
+			return errors.Wrap(err, "Failed to create fake device directory")
 		}
 	}
 	for filename, body := range sysfsFiles {
 		err = ioutil.WriteFile(path.Join(sysfs, filename), body, 0644)
 		if err != nil {
-			return fmt.Errorf("Failed to create fake vendor file: %v", err)
+			return errors.Wrap(err, "Failed to create fake vendor file")
 		}
 	}
 
@@ -326,12 +328,12 @@ func TestScanFPGAs(t *testing.T) {
 	for _, tcase := range tcases {
 		err := createTestDirs(devfs, sysfs, tcase.devfsdirs, tcase.sysfsdirs, tcase.sysfsfiles)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%+v", err)
 		}
 
 		plugin, err := newDevicePlugin(sysfs, devfs, tcase.mode)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%+v", err)
 		}
 		plugin.getDevTree = func(devices []device) dpapi.DeviceTree {
 			return dpapi.NewDeviceTree()
@@ -343,7 +345,7 @@ func TestScanFPGAs(t *testing.T) {
 				t.Errorf("Test case '%s': expected error '%s', but got '%v'", tcase.name, tcase.errorContains, err)
 			}
 		} else if err != nil {
-			t.Errorf("Test case '%s': expected no error, but got '%v'", tcase.name, err)
+			t.Errorf("Test case '%s': expected no error, but got '%+v'", tcase.name, err)
 		}
 
 		err = os.RemoveAll(tmpdir)

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -29,7 +29,12 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFiles map[string][]byte) error {
 	var err error

--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 
@@ -67,8 +68,7 @@ func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
 	for {
 		devTree, err := dp.scan()
 		if err != nil {
-			glog.Error("Device scan failed: ", err)
-			return fmt.Errorf("Device scan failed: %v", err)
+			return err
 		}
 
 		notifier.Notify(devTree)
@@ -80,7 +80,7 @@ func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
 func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 	files, err := ioutil.ReadDir(dp.sysfsDir)
 	if err != nil {
-		return nil, fmt.Errorf("Can't read sysfs folder: %v", err)
+		return nil, errors.Wrap(err, "Can't read sysfs folder")
 	}
 
 	devTree := dpapi.NewDeviceTree()
@@ -97,7 +97,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 
 				drmFiles, err := ioutil.ReadDir(path.Join(dp.sysfsDir, f.Name(), "device/drm"))
 				if err != nil {
-					return nil, fmt.Errorf("Can't read device folder: %v", err)
+					return nil, errors.Wrap(err, "Can't read device folder")
 				}
 
 				for _, drmFile := range drmFiles {

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -21,7 +21,13 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func TestScan(t *testing.T) {
 	tmpdir := fmt.Sprintf("/tmp/gpuplugin-test-%d", time.Now().Unix())

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -105,6 +105,9 @@ func TestScan(t *testing.T) {
 		if tcase.expectedErr && err == nil {
 			t.Error("Expected error hasn't been triggered")
 		}
+		if !tcase.expectedErr && err != nil {
+			t.Errorf("Unexpcted error: %+v", err)
+		}
 		if tcase.expectedDevs != len(tree[deviceType]) {
 			t.Errorf("Wrong number of discovered devices")
 		}

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -35,7 +35,7 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 ### Deploy QAT device plugin directly on the host:
 ```
 $ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/qat_plugin/qat_plugin \
--dpdk-driver igb_uio -kernel-vf-drivers dh895xccvf -max-num-devices 10 -v 10 logtostderr
+-dpdk-driver igb_uio -kernel-vf-drivers dh895xccvf -max-num-devices 10 -debug
 QAT device plugin started
 Discovered Devices below:
 03:01.0 device: corresponding DPDK device detected is uio0

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -25,12 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 
 	"github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 const (
@@ -263,8 +263,13 @@ func main() {
 	dpdkDriver := flag.String("dpdk-driver", "igb_uio", "DPDK Device driver for configuring the QAT device")
 	kernelVfDrivers := flag.String("kernel-vf-drivers", "dh895xccvf,c6xxvf,c3xxxvf,d15xxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC,C62x,C3xxx and D15xx")
 	maxNumDevices := flag.Int("max-num-devices", 32, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
+	debugEnabled := flag.Bool("debug", false, "enable debug output")
 	flag.Parse()
 	fmt.Println("QAT device plugin started")
+
+	if *debugEnabled {
+		debug.Activate()
+	}
 
 	if !isValidDpdkDeviceDriver(*dpdkDriver) {
 		fmt.Println("Wrong DPDK device driver:", *dpdkDriver)

--- a/cmd/qat_plugin/qat_plugin_test.go
+++ b/cmd/qat_plugin/qat_plugin_test.go
@@ -23,7 +23,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func createTestFiles(prefix string, dirs []string, files map[string][]byte) error {
 	for _, dir := range dirs {

--- a/cmd/qat_plugin/qat_plugin_test.go
+++ b/cmd/qat_plugin/qat_plugin_test.go
@@ -21,19 +21,21 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func createTestFiles(prefix string, dirs []string, files map[string][]byte) error {
 	for _, dir := range dirs {
 		err := os.MkdirAll(path.Join(prefix, dir), 0755)
 		if err != nil {
-			return fmt.Errorf("Failed to create fake device directory: %v", err)
+			return errors.Wrap(err, "Failed to create fake device directory")
 		}
 	}
 	for filename, body := range files {
 		err := ioutil.WriteFile(path.Join(prefix, filename), body, 0644)
 		if err != nil {
-			return fmt.Errorf("Failed to create fake vendor file: %v", err)
+			return errors.Wrap(err, "Failed to create fake vendor file")
 		}
 	}
 
@@ -163,7 +165,7 @@ func TestScanPrivate(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := createTestFiles(tmpdir, tt.dirs, tt.files); err != nil {
-			t.Fatal(err)
+			t.Fatalf("%+v", err)
 		}
 
 		dp := &devicePlugin{

--- a/deployments/fpga_admissionwebhook/deployment-tpl.yaml
+++ b/deployments/fpga_admissionwebhook/deployment-tpl.yaml
@@ -21,9 +21,7 @@ spec:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-private-key-file=/etc/webhook/certs/key.pem
             - -mode={MODE}
-            - -alsologtostderr
-            - -v=2
-            - 2>&1
+            - -debug
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/internal/deviceplugin/manager.go
+++ b/internal/deviceplugin/manager.go
@@ -119,7 +119,8 @@ func (m *Manager) handleUpdate(update updateInfo) {
 		go func() {
 			err := m.servers[devType].Serve(m.namespace)
 			if err != nil {
-				glog.Fatal(err)
+				fmt.Printf("Failed to serve %s/%s: %+v\n", m.namespace, devType, err)
+				os.Exit(1)
 			}
 		}()
 		m.servers[devType].Update(devices)

--- a/internal/deviceplugin/manager.go
+++ b/internal/deviceplugin/manager.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/golang/glog"
-
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 // updateInfo contains info for added, updated and deleted devices.
@@ -107,7 +107,7 @@ func (m *Manager) Run() {
 }
 
 func (m *Manager) handleUpdate(update updateInfo) {
-	glog.V(2).Info("Received dev updates: ", update)
+	debug.Print("Received dev updates:", update)
 	for devType, devices := range update.Added {
 		var postAllocate func(*pluginapi.AllocateResponse) error
 

--- a/internal/deviceplugin/manager_test.go
+++ b/internal/deviceplugin/manager_test.go
@@ -18,7 +18,13 @@ import (
 	"testing"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
+
+func init() {
+	debug.Activate()
+}
 
 func TestNotify(t *testing.T) {
 	tcases := []struct {

--- a/internal/deviceplugin/server_test.go
+++ b/internal/deviceplugin/server_test.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -65,8 +67,7 @@ func (k *kubeletStub) start() error {
 	os.Remove(k.socket)
 	s, err := net.Listen("unix", k.socket)
 	if err != nil {
-		fmt.Printf("Can't listen at the socket: %+v", err)
-		return err
+		return errors.Wrap(err, "Can't listen at the socket")
 	}
 
 	k.server = grpc.NewServer()
@@ -89,7 +90,10 @@ func TestRegisterWithKublet(t *testing.T) {
 	}
 
 	kubelet := newKubeletStub(kubeletSocket)
-	kubelet.start()
+	err = kubelet.start()
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
 	defer kubelet.server.Stop()
 
 	err = registerWithKubelet(kubeletSocket, pluginSocket, resourceName)
@@ -405,7 +409,7 @@ func TestListAndWatch(t *testing.T) {
 
 		err := testServer.ListAndWatch(&pluginapi.Empty{}, server)
 		if err != nil && tt.errorOnCall == 0 {
-			t.Errorf("Test case '%s': got unexpected error %v", tt.name, err)
+			t.Errorf("Test case '%s': got unexpected error %+v", tt.name, err)
 		}
 		if err == nil && tt.errorOnCall != 0 {
 			t.Errorf("Test case '%s': expected an error, but got nothing", tt.name)

--- a/internal/deviceplugin/server_test.go
+++ b/internal/deviceplugin/server_test.go
@@ -29,6 +29,7 @@ import (
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	"github.com/pkg/errors"
 )
 
@@ -45,6 +46,10 @@ type kubeletStub struct {
 	socket         string
 	pluginEndpoint string
 	server         *grpc.Server
+}
+
+func init() {
+	debug.Activate()
 }
 
 // newKubeletStub returns an initialized kubeletStub for testing purpose.

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+const (
+	prefix = "DEBUG"
+)
+
+var (
+	isEnabled bool
+)
+
+func getFileAndLine() string {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "???:0"
+	}
+	parts := strings.Split(file, "/")
+	return fmt.Sprintf("%s:%d", parts[len(parts)-1], line)
+}
+
+// Activate activates debugging output
+func Activate() {
+	isEnabled = true
+}
+
+// Print prints its arguments with fmt.Println() if debug output is activated
+func Print(obj ...interface{}) {
+	if isEnabled {
+		fmt.Println(append([]interface{}{prefix, getFileAndLine()}, obj...)...)
+	}
+}
+
+// Printf prints its arguments with fmt.Printf() if debug output is activated
+func Printf(pattern string, obj ...interface{}) {
+	if isEnabled {
+		fmt.Printf(strings.Join([]string{prefix, getFileAndLine(), pattern + "\n"}, " "), obj...)
+	}
+}

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
@pohly has discovered recently that the command `make test WHAT=internal/deviceplugin` fails because it runs `go test -args -logtostderr` even though the package under test doesn't use glog:
```
$ make WHAT=internal/deviceplugin test
flag provided but not defined: -logtostderr
```
glog is inconvenient since it redirects output from file to stderr only through setting its command line flags. And this doesn't fit nicely with one of the 12 cloud app factors (https://12factor.net/logs).

I think that for error tracing it's better to use annotated errors (annotated with a stack trace). See this blog post https://dave.cheney.net/tag/error-handling

For optional debugging output it should be enough to use a very small home-grown `debug` package.

For user visible output the `fmt`'s capabilities are enough as well. I expect that the cloud logging tools will prefix the output with what ever a user wants.