### PR TITLE
fpga_crihook: check if intel annotation is set

### DIFF
--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -43,11 +43,6 @@ func TestGetFPGAParams(t *testing.T) {
 			expectedDeviceNum: "0",
 		},
 		{
-			stdinJSON:   "stdin-broken-json.json",
-			configJSON:  "config-correct.json",
-			expectedErr: true,
-		},
-		{
 			stdinJSON:   "stdin-no-bundle.json",
 			configJSON:  "config-correct.json",
 			expectedErr: true,
@@ -111,9 +106,14 @@ func TestGetFPGAParams(t *testing.T) {
 			t.Fatalf("can't open file %s: %v", tc.stdinJSON, err)
 		}
 
+		content, err := decodeJSONStream(stdin)
+		if err != nil {
+			t.Fatalf("can't decode json file %s: %v", tc.stdinJSON, err)
+		}
+
 		he := newHookEnv("", tc.configJSON, nil, "")
 
-		params, err := he.getFPGAParams(stdin)
+		params, err := he.getFPGAParams(content)
 
 		if err != nil {
 			if !tc.expectedErr {
@@ -311,6 +311,22 @@ func TestProcess(t *testing.T) {
 				},
 				func() ([]byte, error) { return []byte(""), nil },
 			},
+		},
+		{
+			stdinJSON:   "stdin-broken-json.json",
+			expectedErr: true,
+		},
+		{
+			stdinJSON:   "stdin-no-annotations.json",
+			expectedErr: true,
+		},
+		{
+			stdinJSON:   "stdin-no-intel-annotation.json",
+			expectedErr: true,
+		},
+		{
+			stdinJSON:   "stdin-incorrect-intel-annotation.json",
+			expectedErr: true,
 		},
 		{
 			stdinJSON:     "stdin-correct.json",

--- a/cmd/fpga_crihook/testdata/stdin-incorrect-intel-annotation.json
+++ b/cmd/fpga_crihook/testdata/stdin-incorrect-intel-annotation.json
@@ -7,7 +7,7 @@
         "io.kubernetes.pod.namespace": "default",
         "io.kubernetes.pod.terminationGracePeriod": "30",
         "io.kubernetes.pod.uid": "942e94c1-72d3-11e8-b221-c81f66f62fcc",
-        "com.intel.fpga.mode": "intel.com/fpga-region"
+        "com.intel.fpga.mode": "incorrect value"
     },
     "bundle": "testdata",
     "id": "1c40dd8efd268a47d7fb9f75d00f50c20af49d07d8d3c5fb948e68abb6d5ecf9",

--- a/cmd/fpga_crihook/testdata/stdin-no-annotations.json
+++ b/cmd/fpga_crihook/testdata/stdin-no-annotations.json
@@ -1,0 +1,7 @@
+{
+    "bundle": "testdata",
+    "id": "1c40dd8efd268a47d7fb9f75d00f50c20af49d07d8d3c5fb948e68abb6d5ecf9",
+    "ociVersion": "1.0.0",
+    "pid": 39638,
+    "status": ""
+}

--- a/cmd/fpga_crihook/testdata/stdin-no-intel-annotation.json
+++ b/cmd/fpga_crihook/testdata/stdin-no-intel-annotation.json
@@ -6,8 +6,7 @@
         "io.kubernetes.pod.name": "test-fpga-region",
         "io.kubernetes.pod.namespace": "default",
         "io.kubernetes.pod.terminationGracePeriod": "30",
-        "io.kubernetes.pod.uid": "942e94c1-72d3-11e8-b221-c81f66f62fcc",
-        "com.intel.fpga.mode": "intel.com/fpga-region"
+        "io.kubernetes.pod.uid": "942e94c1-72d3-11e8-b221-c81f66f62fcc"
     },
     "bundle": "testdata",
     "id": "1c40dd8efd268a47d7fb9f75d00f50c20af49d07d8d3c5fb948e68abb6d5ecf9",


### PR DESCRIPTION
Check if container annotation com.intel.fpga.mode is set to
"intel.com/fpga-region". This annotation is set by device plugin.
So, the check should help to filter out unwanted workflow that
device plugin is not aware of.