### PR TITLE
 webhook-deploy.sh: error upon unknown option 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 \#*#
 
 coverage.html
+coverage.txt
 
 cmd/fpga_admissionwebhook/fpga_admissionwebhook
 cmd/fpga_crihook/fpga_crihook

--- a/scripts/webhook-deploy.sh
+++ b/scripts/webhook-deploy.sh
@@ -38,6 +38,10 @@ while [[ $# -gt 0 ]]; do
 	cleanup)
 	    command="cleanup"
 	    ;;
+	*)
+	    echo "Unknown option: ${1}"
+	    exit 1
+	    ;;
     esac
     shift
 done


### PR DESCRIPTION
It's too easy to miss double dash in the `--mode orchestration` option leading to wrong mode of the webhook.

Exit on error in case a user types in something line `-mode orchestration`.