### PR TITLE
gpu_plugin: skip drm control node

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -35,7 +35,7 @@ import (
 const (
 	sysfsDrmDirectory = "/sys/class/drm"
 	devfsDriDirectory = "/dev/dri"
-	gpuDeviceRE       = `^card[0-9]*$`
+	gpuDeviceRE       = `^card[0-9]+$`
 	vendorString      = "0x8086"
 
 	// Device plugin settings.


### PR DESCRIPTION
DRM control node is deprecated and removed by latest kernel.
This will skip possible drm control node found on host.

Signed-off-by: Zhenyu Wang <zhenyuw@linux.intel.com>