### PR TITLE
fix make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO := go
+GOFMT := gofmt
 GOCYCLO := gocyclo
 
 pkgs  = $(shell $(GO) list ./... | grep -v vendor)
@@ -7,7 +8,7 @@ cmds = $(shell ls cmd)
 all: build
 
 format:
-	@$(GO) fmt $(pkgs)
+	@report=`$(GOFMT) -s -d -w $$(find cmd internal -name \*.go)` ; if [ -n "$$report" ]; then echo "$$report"; exit 1; fi
 
 vet:
 	@$(GO) vet -v -shadow $(pkgs)

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"path"
 	"time"
 
 	"github.com/golang/glog"
@@ -153,7 +153,7 @@ func getDeviceID(pciAddr string) (string, error) {
 // bindDevice the device where id is the pci address to the specified device driver
 func bindDevice(dpdkDriver string, id string) error {
 
-	devicePCIAddr := "0000:"+id
+	devicePCIAddr := "0000:" + id
 	unbindKernelDevicePath := path.Join(pciDeviceDir, devicePCIAddr, driverUnbindSuffix)
 	bindDevicePath := path.Join(pciDriverDir, dpdkDriver, newIDSuffix)
 	devicePCIAddrBytes := []byte(devicePCIAddr)
@@ -330,7 +330,7 @@ func (dm *deviceManager) PreStartContainer(ctx context.Context, rqt *pluginapi.P
 func main() {
 	flag.Parse()
 	fmt.Println("QAT device plugin started")
-	
+
 	err := isValidDpdkDeviceDriver(*dpdkDriver)
 	if err != nil {
 		glog.Fatalf("Error in user input for DPDK Device Driver: %v", err)


### PR DESCRIPTION
Makefile: fix format target
- Used gofmt instead of go fmt to show the changes and simplify the code
- Made 'make format' to exit with error when formatting is not correct

Fixed formatting errors in QAT plugin code to make Travis CI happy

Fixes: #57