### PR TITLE
bump up Go version for Docker builds

### DIFF
--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.10-alpine as builder
 ARG DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.10-alpine as builder
 ARG DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.10-alpine as builder
 ARG DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .


### PR DESCRIPTION
This fixes build error:
```
github.com/intel/intel-device-plugins-for-kubernetes/internal/deviceplugin
../../internal/deviceplugin/server.go:186: cannot use srv (type *server) as type v1beta1.DevicePluginServer in argument to v1beta1.RegisterDevicePluginServer:
	*server does not implement v1beta1.DevicePluginServer (wrong type for Allocate method)
		have Allocate("context".Context, *v1beta1.AllocateRequest) (*v1beta1.AllocateResponse, error)
		want Allocate("github.com/intel/intel-device-plugins-for-kubernetes/vendor/golang.org/x/net/context".Context, *v1beta1.AllocateRequest) (*v1beta1.AllocateResponse, error)
```