### PR TITLE
fpga_crihook: specify socket number when programming device

### DIFF
--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -185,9 +185,9 @@ func (he *hookEnv) validateBitStream(params *fpgaParams, fpgaBitStreamPath strin
 }
 
 func (he *hookEnv) programBitStream(params *fpgaParams, fpgaBitStreamPath string) error {
-	output, err := he.execer.Command("fpgaconf", fpgaBitStreamPath).CombinedOutput()
+	output, err := he.execer.Command("fpgaconf", "-S", params.devNum, fpgaBitStreamPath).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to program AFU %s to region %s: error: %v, output: %s", params.afu, params.region, err, string(output))
+		return fmt.Errorf("failed to program AFU %s to socket %s, region %s: error: %v, output: %s", params.afu, params.devNum, params.region, err, string(output))
 	}
 
 	programmedAfu, err := he.getProgrammedAfu(params.devNum)


### PR DESCRIPTION
Added -S <device number> parameter to fpgaconf command line to
ensure usage of allocated device.