### PR TITLE
Fixing minor bugs with QAT plugin

### DIFF
--- a/demo/crypto-perf-dpdk-pod-requesting-qat.yaml
+++ b/demo/crypto-perf-dpdk-pod-requesting-qat.yaml
@@ -16,12 +16,12 @@ spec:
       requests:
         cpu: "3"
         memory: "128Mi"
-        intel.com/qat: '4'
+        qat.intel.com/generic: '4'
         hugepages-2Mi: "1Gi"
       limits:
         cpu: "3"
         memory: "128Mi"
-        intel.com/qat: '4'
+        qat.intel.com/generic: '4'
         hugepages-2Mi: "1Gi"
     securityContext:
       capabilities:


### PR DESCRIPTION
- To ensure that the device plugin continues to run in case a certain QAT device
family is not detected on the node
- Updated the extended resource name to qat/generic in demo/crypto-perf-dpdk-pod-requesting-qat.yaml file