### PR TITLE
CI: check if demos can be built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - make cyclomatic-check
   - make test
   - make images
+  - make demos
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,11 @@ $(images):
 
 images: $(images)
 
+demos = $(shell cd demo/ && ls -d */ | sed 's/\(.\+\)\//\1/g' | grep -v crypto-perf)
+
+$(demos):
+	@cd demo/ && ./build-image.sh $@
+
+demos: $(demos)
+
 .PHONY: all format vet cyclomatic-check test lint build images $(cmds) $(images)


### PR DESCRIPTION
Added 'demos' and <demo image name> targets to the Makefile
Added 'make demos' to the TravisCI configuration file

@swatisehgal I excluded crypto-perf from the build due to the issue #81. Please, include it back after fixing the issue. Thanks.