### PR TITLE
QAT: fixed spelling

### DIFF
--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -150,7 +150,7 @@ func (dp *devicePlugin) getDpdkMountPaths(id string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	return nil, fmt.Errorf("Unknwon DPDK driver")
+	return nil, fmt.Errorf("Unknown DPDK driver")
 }
 
 func (dp *devicePlugin) getDeviceID(pciAddr string) (string, error) {


### PR DESCRIPTION
Fixed misspell warning in QAT plugin code:
   Line 153: warning: "Unknwon" is a misspelling of "Unknown" (misspell)