### PR TITLE
gpu_plugin: add -shared-dev-num option

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -75,7 +75,7 @@ func TestScan(t *testing.T) {
 		},
 	}
 
-	testPlugin := newDevicePlugin(sysfs, devfs)
+	testPlugin := newDevicePlugin(sysfs, devfs, 1)
 
 	if testPlugin == nil {
 		t.Fatal("Failed to create a deviceManager")


### PR DESCRIPTION
The DRM driver of Intel i915 GPUs allows sharing one device between many containers.

Make it possible to use the same device from different containers. The exact number of containers sharing the same device can be limited with the new option `-shared-dev-num` set to 1 by default.

closes #53