### PR TITLE
demos: get rid of using --build-arg to pass proxy to the Docker

### DIFF
--- a/demo/build-image.sh
+++ b/demo/build-image.sh
@@ -13,16 +13,4 @@ if [ ! -d "$IMG" ]; then
     exit 1
 fi
 
-PROXY_VARS="http_proxy https_proxy"
-
-BUILD_ARGS=""
-
-for proxy in $PROXY_VARS; do
-    if [ -v $proxy ]; then
-        val=`echo ${!proxy} | tr -d ' '`
-        BUILD_ARGS="${BUILD_ARGS} --build-arg $proxy=${val}"
-        RUN_ARGS="$RUN_ARGS -e $proxy=${!proxy}"
-    fi
-done
-
-docker build -t ${IMG} $BUILD_ARGS "$CWD/$IMG/"
+docker build -t ${IMG} "$CWD/$IMG/"


### PR DESCRIPTION
Docker documentation recommends configuring proxy in
a Docker client configuration file ~/.docker/config.json for Docker
version >= 17.07: https://docs.docker.com/network/proxy/

Using --build-arg for this purpose is not recommended, hence
removing.