### PR TITLE
fpga_plugin: don't exit if OPAE driver is not loaded

### DIFF
--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -241,7 +241,8 @@ func (dp *devicePlugin) scanFPGAs() (dpapi.DeviceTree, error) {
 
 	fpgaFiles, err := ioutil.ReadDir(dp.sysfsDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "Can't read sysfs folder")
+		fmt.Printf("WARNING: Can't read folder %s. Kernel driver not loaded?\n", dp.sysfsDir)
+		return dp.getDevTree([]device{}), nil
 	}
 
 	for _, fpgaFile := range fpgaFiles {

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -223,9 +223,8 @@ func TestScanFPGAs(t *testing.T) {
 		mode            string
 	}{
 		{
-			name:          "No sysfs folder given",
-			mode:          afMode,
-			errorContains: "Can't read sysfs folder",
+			name: "No sysfs folder exists",
+			mode: afMode,
 		},
 		{
 			name:          "FPGA device without FME and ports",


### PR DESCRIPTION
This helps to avoid restarting pods with fpga_plugin by DaemonSet if the node doesn't have the OPAE driver loaded.