### PR TITLE
fpga_crihook: use -s fpgaconf option

### DIFF
--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -119,7 +119,7 @@ func (bitStream *opaeBitStream) validate() error {
 }
 
 func (bitStream *opaeBitStream) program() error {
-	output, err := bitStream.execer.Command(fpgaconf, "-S", bitStream.params.devNum, bitStream.path).CombinedOutput()
+	output, err := bitStream.execer.Command(fpgaconf, "-s", bitStream.params.devNum, bitStream.path).CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "failed to program AFU %s to socket %s, region %s: output: %s", bitStream.params.afu, bitStream.params.devNum, bitStream.params.region, string(output))
 	}


### PR DESCRIPTION
Different versions of OPAE tool fpgaconf use different command line
options to specify socket number. Latest version uses -S, which CRI-O
hook used so far.

However, fpgaconf in initcontainer comes from older OPAE version, which
uses -s option for the same purpose. This caused fpgaconf and CRI-O hook
to fail with "Invalid cmdline options".

Used 'fpgaconf-wrapper -s' in the CRI-O hook to fix this.

Signed-off-by: Ed Bartosh <eduard.bartosh@intel.com>