### PR TITLE
fix CRI hook configuration in initcontainer

### DIFF
--- a/deployments/fpga_plugin/intel-fpga-initcontainer.Dockerfile
+++ b/deployments/fpga_plugin/intel-fpga-initcontainer.Dockerfile
@@ -62,8 +62,8 @@ COPY ./$CRI_HOOK $CRI_HOOK_SRC
 
 RUN echo -e "{\n\
     \"hook\" : \"$CRI_HOOK_DST\",\n\
-    \"stages\" : [ \"prestart\" ],\n\
-    \"annotations\": [ \"fpga.intel.com/region\" ]\n\
+    \"stage\" : [ \"prestart\" ],\n\
+    \"annotation\": [ \"fpga.intel.com/region\" ]\n\
 }\n">>$HOOK_CONF_SRC
 
 # Setup


### PR DESCRIPTION
Current configuration has incorrect keywords that caused
CRI not to call prestart hook.