### PR TITLE
fix fpga-region pod definition

### DIFF
--- a/demo/test-fpga-region.yml
+++ b/demo/test-fpga-region.yml
@@ -8,6 +8,10 @@ spec:
     image: ubuntu-demo-opae
     imagePullPolicy: IfNotPresent
     command: ["sh", "/usr/bin/test_fpga.sh"]
+    securityContext:
+      capabilities:
+        add:
+          [IPC_LOCK]
     resources:
       limits:
         fpga.intel.com/arria10-nlb3: 1


### PR DESCRIPTION
Added IPC_LOC capability to NLB3 workload failure:
[8][ERROR][accelerator::allocate_buffer] Could not allocate buffer
[8][ERROR][nlb3] failed to allocate DSM workspace.
Error: configuration failed.