### PR TITLE
Makefile: get rid of using --build-arg to pass proxy to the Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,12 @@ build: $(cmds)
 clean:
 	@for cmd in $(cmds) ; do pwd=$(shell pwd) ; cd cmd/$$cmd ; go clean ; cd $$pwd ; done
 
-DOCKER_ARGS?=--build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --pull
 TAG?=$(shell git rev-parse HEAD)
 
 images = $(shell ls build/docker/*.Dockerfile | sed 's/.*\/\(.\+\)\.Dockerfile/\1/')
 
 $(images):
-	docker build -f build/docker/$@.Dockerfile $(DOCKER_ARGS) -t $@:$(TAG) .
+	docker build -f build/docker/$@.Dockerfile --pull -t $@:$(TAG) .
 	docker tag $@:$(TAG) $@:devel
 
 images: $(images)


### PR DESCRIPTION
Docker documentation recommends configuring proxy in
a Docker client configuration file ~/.docker/config.json for Docker
version >= 17.07: https://docs.docker.com/network/proxy/

Using --build-arg for this purpose is not recommended, hence
removing.