### PR TITLE
demo: use ubuntu-demo-opae:devel in FPGA pods

### DIFF
--- a/demo/intelfpga-job.yaml
+++ b/demo/intelfpga-job.yaml
@@ -13,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: intelfpga-demo-job-1
-          image: ubuntu-demo-opae:latest
+          image: ubuntu-demo-opae:devel
           imagePullPolicy: IfNotPresent
           command: ["/usr/bin/test_fpga.sh"]
           securityContext:

--- a/demo/test-fpga-region.yml
+++ b/demo/test-fpga-region.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: ubuntu-demo-opae
+    image: ubuntu-demo-opae:devel
     imagePullPolicy: IfNotPresent
     command: ["sh", "/usr/bin/test_fpga.sh"]
     securityContext:


### PR DESCRIPTION
Updated FPGA pods that use ubuntu-demo-opae image to
use 'devel' tag.