### PR TITLE
Build images with buildah

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,54 @@
 language: go
 
+dist: xenial
+
 go:
   - 1.10.x
+
+env:
+  global:
+    - RUNC_VERSION=v1.0.0-rc5
+    - CRIO_VERSION=v1.11.5
+    - OSTREE_VERSION=v2018.8
 
 sudo: required
 
 before_install:
+  ## checkers
   - go get -v github.com/golang/lint/golint
   - go get -v github.com/fzipp/gocyclo
-  # hack for building on forks
+  ## hack for building on forks
   - repo=`basename $PWD`; src=`dirname $PWD`; dest="`dirname $src`/intel"
   - if [[ "$src" != "$dest" ]]; then mv "$src" "$dest"; cd ../../intel/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi
+  ## install buildah build deps
+  - cdir=$(pwd)
+  - sudo apt-get -y install e2fslibs-dev libfuse-dev libgpgme11-dev
+  # build and install ostree
+  - git clone https://github.com/ostreedev/ostree
+  - cd ostree
+  - git reset --hard $OSTREE_VERSION
+  - git submodule update --init
+  - env NOCONFIGURE=1 ./autogen.sh
+  - ./configure
+  - make
+  - sudo make install
+  - sudo apt-get -y install libdevmapper-dev libglib2.0-dev libprotobuf-dev
+  # build buildah
+  - mkdir -p $GOPATH/src/github.com/containers
+  - cd $GOPATH/src/github.com/containers
+  - git clone https://github.com/containers/buildah
+  - cd buildah
+  - make buildah TAGS=""
+  - sudo cp buildah /usr/local/bin
+  # configure buildah
+  - sudo mkdir -p /etc/containers
+  - echo -e '[registries.search]\nregistries = ["docker.io"]\n\n' | sudo tee /etc/containers/registries.conf
+  - sudo curl https://raw.githubusercontent.com/kubernetes-sigs/cri-o/$CRIO_VERSION/test/policy.json -o /etc/containers/policy.json
+  # install runc
+  - sudo curl -L https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 -o /usr/bin/runc
+  - sudo chmod +x /usr/bin/runc
+  - cd $cdir
+
 script:
   - make format
   - make lint
@@ -19,7 +57,9 @@ script:
   - make cyclomatic-check
   - make test
   - make images
+  - sudo make images BUILDER=buildah
   - make demos
+  - sudo make demos BUILDER=buildah
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,16 @@ TAG?=$(shell git rev-parse HEAD)
 images = $(shell ls build/docker/*.Dockerfile | sed 's/.*\/\(.\+\)\.Dockerfile/\1/')
 
 $(images):
-	docker build -f build/docker/$@.Dockerfile --pull -t $@:$(TAG) .
-	docker tag $@:$(TAG) $@:devel
+	@build/docker/build-image.sh $@ $(BUILDER)
 
 images: $(images)
 
 demos = $(shell cd demo/ && ls -d */ | sed 's/\(.\+\)\//\1/g' | grep -v crypto-perf)
 
 $(demos):
-	@cd demo/ && ./build-image.sh $@
+	@cd demo/ && ./build-image.sh $@ $(BUILDER)
 
 demos: $(demos)
+
 
 .PHONY: all format vet cyclomatic-check test lint build images $(cmds) $(images)

--- a/build/docker/build-image.sh
+++ b/build/docker/build-image.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+
+IMG=$1
+BUILDER=$2
+
+DOCKERFILE="$(dirname $0)/${IMG}.Dockerfile"
+
+if [ -z "$IMG" ]; then
+    (>&2 echo "Usage: $0 <Dockerfile>")
+    exit 1
+fi
+
+if [ ! -e "${DOCKERFILE}" ]; then
+    (>&2 echo "File ${DOCKERFILE} doesn't exist")
+    exit 1
+fi
+
+TAG=$(git rev-parse HEAD)
+
+if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then
+    docker build -t ${IMG}:${TAG} -f ${DOCKERFILE} .
+    docker tag ${IMG}:${TAG} ${IMG}:devel
+elif [ "${BUILDER}" = 'buildah' ] ; then
+    buildah bud -t ${IMG}:${TAG} -f ${DOCKERFILE} .
+    buildah tag ${IMG}:${TAG} ${IMG}:devel
+else
+    (>&2 echo "Unknown builder ${BUILDER}")
+    exit 1
+fi

--- a/demo/build-image.sh
+++ b/demo/build-image.sh
@@ -1,6 +1,7 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 IMG=$1
+BUILDER=$2
 
 if [ -z "$IMG" ]; then
     (>&2 echo "Usage: $0 <image directory>")
@@ -15,5 +16,13 @@ fi
 CWD=`dirname $0`
 TAG=`git rev-parse HEAD`
 
-docker build --rm -t ${IMG}:${TAG} "$CWD/$IMG/"
-docker tag ${IMG}:${TAG} ${IMG}:devel
+if [ -z "$BUILDER" -o "$BUILDER" = 'docker' ] ; then
+    docker build --rm -t ${IMG}:${TAG} "$CWD/$IMG/"
+    docker tag ${IMG}:${TAG} ${IMG}:devel
+elif [ "$BUILDER" = 'buildah' ] ; then
+    buildah bud -t ${IMG}:${TAG} "$CWD/$IMG/"
+    buildah tag ${IMG}:${TAG} ${IMG}:devel
+else
+    (>&2 echo "Unknown builder $BUILDER")
+    exit 1
+fi

--- a/deployments/fpga_plugin/build-initcontainer-image.sh
+++ b/deployments/fpga_plugin/build-initcontainer-image.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+BUILDER=$1
+
 # check if DCP tarball is present
 DCP_TARBALL=a10_gx_pac_ias_1_1_pv_rte_installer.tar.gz
 if [ ! -f ${DCP_TARBALL} ] ; then
@@ -18,5 +20,13 @@ WORKSPACE=`realpath .`
 IMG="intel-fpga-initcontainer"
 TAG=$(git rev-parse HEAD)
 
-docker build --rm -t $IMG:devel -f $WORKSPACE/$IMG.Dockerfile $WORKSPACE
-docker tag $IMG:devel $IMG:$TAG
+if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then
+    docker build --rm -t $IMG:devel -f $WORKSPACE/$IMG.Dockerfile $WORKSPACE
+    docker tag $IMG:devel $IMG:$TAG
+elif [ "${BUILDER}" = 'buildah' ] ; then
+    buildah bud -t $IMG:devel -f $WORKSPACE/$IMG.Dockerfile --layers $WORKSPACE
+    buildah tag $IMG:devel $IMG:$TAG
+else
+    (>&2 echo "Unknown builder ${BUILDER}")
+    exit 1
+fi


### PR DESCRIPTION
Added alternative builder for project images: [buildah](https://github.com/containers/buildah)
    
Considering that some of our plugins use CRI-O runtime it could be
a good idea to get rid of docker as a builder. It should allow us
not to run docker daemon at all, even for build purposes.
    
Kubernetes also goes this way encouraging users to switch to CRI
runtimes (CRI-O and containerd), so having non-docker builds supported
looks good from this perspective too.
