### PR TITLE
Fix golint failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ sudo: required
 
 before_install:
   ## checkers
-  - go get -v github.com/golang/lint/golint
+  - go get -v golang.org/x/lint/golint
   - go get -v github.com/fzipp/gocyclo
   ## hack for building on forks
   - repo=`basename $PWD`; src=`dirname $PWD`; dest="`dirname $src`/intel"


### PR DESCRIPTION
`github.com/golang/lint/golint` doesn't exist and I proposed the change off the `golint` documentation.