### PR TITLE
internal: isolate goroutine from its outter scope

### DIFF
--- a/internal/deviceplugin/manager.go
+++ b/internal/deviceplugin/manager.go
@@ -116,13 +116,13 @@ func (m *Manager) handleUpdate(update updateInfo) {
 		}
 
 		m.servers[devType] = m.createServer(devType, postAllocate)
-		go func() {
-			err := m.servers[devType].Serve(m.namespace)
+		go func(dt string) {
+			err := m.servers[dt].Serve(m.namespace)
 			if err != nil {
-				fmt.Printf("Failed to serve %s/%s: %+v\n", m.namespace, devType, err)
+				fmt.Printf("Failed to serve %s/%s: %+v\n", m.namespace, dt, err)
 				os.Exit(1)
 			}
-		}()
+		}(devType)
 		m.servers[devType].Update(devices)
 	}
 	for devType, devices := range update.Updated {


### PR DESCRIPTION
Goroutines don't capture the values of the variables they reference from their
outter scope. As result the last value of `devType` is used at the moment
the goroutine runs.

Pass the correct value of `devType` to the goroutine call.

closes #113