### PR TITLE
fpga: add support for Arria10 DCP 1.0

### DIFF
--- a/deployments/fpga_admissionwebhook/mappings-collection.yaml
+++ b/deployments/fpga_admissionwebhook/mappings-collection.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: fpga.intel.com/v1
 kind: AcceleratorFunction
 metadata:
-  name: arria10-compress
+  name: arria10_dcp1.0-compress
 spec:
   afuId: 18b79ffa2ee54aa096ef4230dafacb5f
 ---
@@ -25,3 +25,10 @@ metadata:
   name: arria10
 spec:
   interfaceId: 9926ab6d6c925a68aabca7d84c545738
+---
+apiVersion: fpga.intel.com/v1
+kind: FpgaRegion
+metadata:
+  name: arria10_dcp1.0
+spec:
+  interfaceId: ce48969398f05f33946d560708be108a


### PR DESCRIPTION
Added DCP 1.0 Arria10 region and compress AFU ids
to the mapping collection to be able to work with
DCP 1.0 bitstreams.

This is also an enabler for FPGA demo that uses compress.aocx,
which is not compilable by aoc compiler from DCP 1.1