### PR TITLE
qat: deployment: set parameters via ConfigMap

### DIFF
--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -68,6 +68,7 @@ $ make  intel-qat-plugin
 ### Deploy QAT device plugin as a DaemonSet:
 ```
 $ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+kubectl create -f deployments/qat_plugin/qat_plugin_default_configmap.yaml
 kubectl create -f deployments/qat_plugin/qat_plugin.yaml
 ```
 

--- a/deployments/qat_plugin/qat_plugin.yaml
+++ b/deployments/qat_plugin/qat_plugin.yaml
@@ -16,7 +16,29 @@ spec:
       containers:
       - name: intel-qat-plugin
         image: intel-qat-plugin:devel
+        env:
+        - name: DPDK_DRIVER
+          valueFrom:
+            configMapKeyRef:
+              name: intel-qat-plugin-config
+              key: DPDK_DRIVER
+        - name: KERNEL_VF_DRIVERS
+          valueFrom:
+            configMapKeyRef:
+              name: intel-qat-plugin-config
+              key: KERNEL_VF_DRIVERS
+        - name: MAX_NUM_DEVICES
+          valueFrom:
+            configMapKeyRef:
+              name: intel-qat-plugin-config
+              key: MAX_NUM_DEVICES
+        - name: DEBUG
+          valueFrom:
+            configMapKeyRef:
+              name: intel-qat-plugin-config
+              key: DEBUG
         imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/intel_qat_device_plugin", "-dpdk-driver", "$(DPDK_DRIVER)", "-kernel-vf-drivers", "$(KERNEL_VF_DRIVERS)", "-max-num-devices", "$(MAX_NUM_DEVICES)", "-debug", "$(DEBUG)"]
         volumeMounts:
         - name: pcidir
           mountPath: /sys/bus/pci

--- a/deployments/qat_plugin/qat_plugin_default_configmap.yaml
+++ b/deployments/qat_plugin/qat_plugin_default_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: intel-qat-plugin-config
+data:
+  DPDK_DRIVER: "igb_uio"
+  KERNEL_VF_DRIVERS: "dh895xccvf,c6xxvf,c3xxxvf,d15xxvf"
+  MAX_NUM_DEVICES: "32"
+  DEBUG: "false"


### PR DESCRIPTION
For easier deployments, fetch plugin command line arguments from ConfigMap.
When using ConfigMaps, qat_plugin.yaml needs no changes and can always
be used as is.

qat_plugin_default_configmap.yaml uses built-in defaults.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>