### PR TITLE
demo: update crypto-perf Dockerfile

### DIFF
--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -1,8 +1,36 @@
 FROM centos:7
+
 ENV SHELL=/bin/bash
-COPY ./resolv.conf /etc/resolv.conf
-RUN rpm --rebuilddb; yum -y clean all; yum -y update; RUN yum -y install epel-release  httpd httpd-tools curl traceroute tcpdump bind-utils nc net-tools nmap screen htop cairo-devel hwloc-libs hwloc-gui pciutils
-RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
+
+ENV RTE_TARGET=x86_64-native-linuxapp-gcc
+
+# verified git commit hash
+ENV DPDK_VERSION=3d2e044
+
+# install dependencies and some handy tools
+RUN rpm --rebuilddb; yum -y clean all; yum -y update;
+RUN yum -y install curl pciutils git numactl-devel make gcc openssl-devel
+
+# clone DPDK and checkout desired version
+WORKDIR /usr/src
+RUN git clone http://dpdk.org/git/dpdk
 WORKDIR /usr/src/dpdk
-COPY . /usr/src/dpdk
+RUN git checkout $DPDK_VERSION
+
+# explicitly enable QAT in the config
+RUN sed s#CONFIG_RTE_LIBRTE_PMD_QAT=n#CONFIG_RTE_LIBRTE_PMD_QAT=y# \
+        -i config/common_base
+
+# don't build kernel modules as they depend on the host kernel version
+RUN sed s#CONFIG_RTE_EAL_IGB_UIO=y#CONFIG_RTE_EAL_IGB_UIO=n# \
+        -i config/common_linuxapp
+RUN sed s#CONFIG_RTE_KNI_KMOD=y#CONFIG_RTE_KNI_KMOD=n# \
+        -i config/common_linuxapp
+
+# build DPDK
+RUN make T=$RTE_TARGET config && \
+    make T=$RTE_TARGET && \
+    make T=$RTE_TARGET DESTDIR=install install
+
+# go to the location of dpdk-test-crypto-perf app by default
 WORKDIR /usr/src/dpdk/build/app


### PR DESCRIPTION
This change:
* adds cloning and building of QAT-enabled DPDK to the Dockerfile
* disables unnecessary compilation of DPDK kernel modules which depend on the host kernel version
* fixes issue with missing ./resolv.conf file and dpdk directory