### PR TITLE
travis: use buildah v1.4 for image builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - RUNC_VERSION=v1.0.0-rc5
     - CRIO_VERSION=v1.11.5
     - OSTREE_VERSION=v2018.8
+    - BUILDAH_VERSION=v1.4
 
 sudo: required
 
@@ -38,6 +39,7 @@ before_install:
   - cd $GOPATH/src/github.com/containers
   - git clone https://github.com/containers/buildah
   - cd buildah
+  - git reset --hard $BUILDAH_VERSION
   - make buildah TAGS=""
   - sudo cp buildah /usr/local/bin
   # configure buildah


### PR DESCRIPTION
Buildah from its master branch causes Travis CI to break
with this error:

$ sudo make demos BUILDER=buildah
./build-image.sh: 23: ./build-image.sh: buildah: Permission denied
Makefile:54: recipe for target 'ubuntu-demo-opae' failed
make: *** [ubuntu-demo-opae] Error 126
The command "sudo make demos BUILDER=buildah" exited with 2.

It makes sense to use particular release as we do for other
tools.