### PR TITLE
Fix a couple of typos in the GPU documentation

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -60,7 +60,7 @@ $ kubectl describe node <node name> | grep gpu.intel.com
 
 2. Create a pod running unit tests off the local Docker image:
    ```
-   $ kubectl apply -f demo/intelgpu_job.yaml
+   $ kubectl apply -f demo/intelgpu-job.yaml
    ```
 
 3. Review the pod's logs:

--- a/demo/intelgpu-job.yaml
+++ b/demo/intelgpu-job.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
         -
           name: intelgpu-demo-job-1
-          image: ubuntu-demo-opencl:latest
+          image: ubuntu-demo-opencl:devel
           imagePullPolicy: IfNotPresent
           command: [ "/run-opencl-example.sh", "/root/6-1/fft" ]
           resources:


### PR DESCRIPTION
There are a two typos in the GPU documentation which I discovered when running the demo in the README file:
- The demo file is called `intelgpu-job.yaml` instead of `intelgpu_job.yaml`
- The container which is created is tagged `ubuntu-demo-opencl:devel` instead of `ubuntu-demo-opencl:latest`