### PR TITLE
demo: add OpenSSL QAT Engine demo files

### DIFF
--- a/demo/openssl-qat-engine-pod.yaml
+++ b/demo/openssl-qat-engine-pod.yaml
@@ -1,0 +1,32 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: openssl-qat-engine
+  annotations:
+      io.kubernetes.docker.TrustedSandbox: "false"
+      io.kubernetes.cri-o.TrustedSandbox: "false"
+      io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+  - name: openssl-qat-engine
+    image: docker.io/library/openssl-qat-engine:devel
+    imagePullPolicy: Never
+    volumeMounts:
+            - mountPath: /dev
+              name: dev-mount
+            - mountPath: /etc/c6xxvf_dev0.conf
+              name: dev0
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        qat.intel.com/generic: '1'
+      limits:
+        qat.intel.com/generic: '1'
+  volumes:
+  - name: dev-mount
+    hostPath:
+        path: /dev
+  - name: dev0
+    hostPath:
+        path: /etc/c6xxvf_dev0.conf

--- a/demo/openssl-qat-engine/Dockerfile
+++ b/demo/openssl-qat-engine/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:sid as builder
+
+ENV QAT_DRIVER_RELEASE="qat1.7.l.4.3.0-00033"
+ENV QAT_ENGINE_VERSION="v0.5.39"
+ENV PERL5LIB="/openssl"
+
+RUN apt-get update && \
+    apt-get install -y git build-essential wget libssl-dev openssl libudev-dev pkg-config autoconf autogen libtool && \
+    git clone https://github.com/intel/QAT_Engine && \
+    git clone -b OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git && \
+    wget https://01.org/sites/default/files/downloads/intelr-quickassist-technology/$QAT_DRIVER_RELEASE.tar.gz && \
+    tar zxf $QAT_DRIVER_RELEASE.tar.gz
+
+
+RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
+    KERNEL_SOURCE_ROOT=/tmp ./configure && \
+    make quickassist-all adf-ctl-all && \
+    install -m 755 build/libqat_s.so /usr/lib/ && \
+    install -m 755 build/libusdm_drv_s.so /usr/lib/ && \
+    install -m 755 build/adf_ctl /usr/bin/ && \
+    cd openssl && ./config && cd - && \
+    cd QAT_Engine && git checkout $QAT_ENGINE_VERSION && \
+    ./autogen.sh && \
+    ./configure \
+    --with-qat_dir=/ \
+    --with-openssl_dir=/openssl \
+    --with-openssl_install_dir=/usr/lib/x86_64-linux-gnu \
+    --enable-upstream_driver \
+    --enable-usdm \
+    --with-qat_install_dir=/usr/lib \
+    --enable-openssl_install_build_arch_path && \
+    make && make install
+
+FROM debian:sid-slim
+
+RUN apt-get update && apt-get install -y openssl
+
+COPY --from=builder /usr/lib/libqat_s.so /usr/lib/
+COPY --from=builder /usr/lib/libusdm_drv_s.so /usr/lib/
+COPY --from=builder /usr/bin/adf_ctl /usr/bin
+COPY --from=builder /usr/lib/x86_64-linux-gnu/engines-1.1/qat.so /usr/lib/x86_64-linux-gnu/engines-1.1/qat.so

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -54,3 +54,11 @@ with the [Go runtime](https://golang.org/doc/install).
 Intel® FPGA Device Plugin deployment
 
 [![Intel® FPGA Device Plugin deployment](https://asciinema.org/a/mRn15bkRRUzTG4kp2UeHQX6gk.png)](https://asciinema.org/a/mRn15bkRRUzTG4kp2UeHQX6gk)
+
+## Intel® QuickAssist Technology Device Plugin OpenSSL demo video
+
+TBD
+
+### Demo platform configuration
+### Demo steps
+### Screencast


### PR DESCRIPTION
I'm submitting this PR for early review. TODOs to be completed before merging.

Add:
* Dockerfile that builds a container with OpenSSL 1.1.1 + QAT Engine
* Sample openssl-qat-engine-pod deployment yaml

The demo deployment yaml has the following dependencies:

* kata-runtime is installed and registered as the untrusted workload
handler
* QAT virtual function device configuration(s) (from QAT_Engine repo) are
available  in /etc for the target hardware.

TODOs:
* readme.md
* move to RuntimeClass

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>