### PR TITLE
Makefile: enable crypto-perf build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(images):
 
 images: $(images)
 
-demos = $(shell cd demo/ && ls -d */ | sed 's/\(.\+\)\//\1/g' | grep -v crypto-perf)
+demos = $(shell cd demo/ && ls -d */ | sed 's/\(.\+\)\//\1/g')
 
 $(demos):
 	@cd demo/ && ./build-image.sh $@ $(BUILDER)


### PR DESCRIPTION
This build was excluded from the 'make demos' targets as
it was failing. Now the build is fixed, adding the build back.