### PR TITLE
Revert "fpga: add support for Arria10 DCP 1.0"

### DIFF
--- a/deployments/fpga_admissionwebhook/mappings-collection.yaml
+++ b/deployments/fpga_admissionwebhook/mappings-collection.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: fpga.intel.com/v1
 kind: AcceleratorFunction
 metadata:
-  name: arria10_dcp1.0-compress
+  name: arria10-compress
 spec:
   afuId: 18b79ffa2ee54aa096ef4230dafacb5f
 ---
@@ -25,10 +25,3 @@ metadata:
   name: arria10
 spec:
   interfaceId: 9926ab6d6c925a68aabca7d84c545738
----
-apiVersion: fpga.intel.com/v1
-kind: FpgaRegion
-metadata:
-  name: arria10_dcp1.0
-spec:
-  interfaceId: ce48969398f05f33946d560708be108a


### PR DESCRIPTION
Reverting as this was not a good idea for two reasons:
- Supporting old DCP version is additional mainentance effort
- it breaks webhook deployment with this kind of errors:
Invalid value: "arria10_dcp1.0": a DNS-1123 subdomain must consist of
lower case alphanumeric characters, '-' or '.', and must start and end
with an alphanumeric character (e.g. 'example.com', regex used for
validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'