### PR TITLE
admissionwebhook: fix region regexp

### DIFF
--- a/cmd/fpga_admissionwebhook/patcher.go
+++ b/cmd/fpga_admissionwebhook/patcher.go
@@ -67,7 +67,7 @@ const (
 
 var (
 	rfc6901Escaper = strings.NewReplacer("~", "~0", "/", "~1")
-	resourceRe     = regexp.MustCompile(namespace + `/(?P<Region>[[:alnum:]]+)(-(?P<Af>[[:alnum:]]+))?`)
+	resourceRe     = regexp.MustCompile(namespace + `/(?P<Region>[[:alnum:].]+)(-(?P<Af>[[:alnum:]]+))?`)
 )
 
 type patcher struct {


### PR DESCRIPTION
Region regexp doesn't allow to have dots, which
results in incorrect matching of arria10.dcp1.0 region.