### PR TITLE
qat: per driver load balancer

### DIFF
--- a/cmd/qat_plugin/qat_plugin_test.go
+++ b/cmd/qat_plugin/qat_plugin_test.go
@@ -341,6 +341,7 @@ func TestScanPrivate(t *testing.T) {
 
 		dp := &devicePlugin{
 			maxDevices:      tt.maxDevNum,
+			balanceDevices:  false,
 			pciDriverDir:    pciDrvDir,
 			pciDeviceDir:    pciDevDir,
 			dpdkDriver:      tt.dpdkDriver,
@@ -413,6 +414,43 @@ func TestPostAllocate(t *testing.T) {
 			} else {
 				t.Errorf("Unexpected value %s", value)
 			}
+		}
+	}
+}
+
+func TestSortByFunction(t *testing.T) {
+	testArray := []string{
+		"0000:03:01.0",
+		"0000:03:01.1",
+		"0000:03:01.2",
+		"0000:04:01.0",
+		"0000:04:01.1",
+		"0000:04:01.2",
+		"0000:05:01.0",
+		"0000:05:01.1",
+		"0000:05:01.2",
+	}
+	expectedValues := []string{
+		"0000:03:01.0",
+		"0000:04:01.0",
+		"0000:05:01.0",
+		"0000:03:01.1",
+		"0000:04:01.1",
+		"0000:05:01.1",
+		"0000:03:01.2",
+		"0000:04:01.2",
+		"0000:05:01.2",
+	}
+
+	results := sortByFunction(testArray)
+
+	if len(results) != len(expectedValues) {
+		t.Fatalf("sortByFunction returned an array of wrong size %v (expected %v)", len(results), len(expectedValues))
+	}
+
+	for idx, val := range expectedValues {
+		if results[idx] != val {
+			t.Errorf("Unexpected value %s in sorted array (expected %s).", results[idx], val)
 		}
 	}
 }


### PR DESCRIPTION
By default, the QAT device plugin binds devices to VF driver using
the device order ioutil.ReadDir() returns. It may look like this:

0000:84:01.0
0000:84:01.1
0000:84:01.2
...
0000:85:01.0
0000:85:01.1
0000:85:01.2
...
0000:86:01.0
0000:86:01.1
0000:86:01.2
...

on a QAT card providing three physical devices.

This results in a setup where containers first get to use 000:84:xx.x
pool and leaving other physical devices idle.

For better load balancing, this commit implements a simple shuffler
that makes scan() to register devices from a balanced pool:

0000:84:01.0
0000:85:01.0
0000:86:01.0
...
0000:84:01.1
0000:85:01.1
0000:86:01.1
...
0000:84:01.2
0000:85:01.2
0000:86:01.2
...

note: kubelet does not see the same order because of the way Go
organizes DeviceTree map entries.

Additionally, fix maxDevices resource counting. The variable n is
in driver scope but that should count total amount of allocated
devices.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>