### PR TITLE
fpga: mutate pods with CRDs from its corresponding namespace

### DIFF
--- a/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
+++ b/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
@@ -123,6 +123,9 @@ func TestServe(t *testing.T) {
 
 func TestMutatePods(t *testing.T) {
 	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -237,7 +240,13 @@ func TestMutatePods(t *testing.T) {
 				"fpga.intel.com/arria10": "ce48969398f05f33946d560708be108a",
 			},
 		}
-		resp := mutatePods(tcase.ar, p)
+		pm := &patcherManager{
+			defaultMode: tcase.mode,
+			patchers: map[string]*patcher{
+				"default": p,
+			},
+		}
+		resp := mutatePods(tcase.ar, pm)
 
 		if !tcase.expectedResponse && resp != nil {
 			t.Errorf("Test case '%s': got unexpected response", tcase.name)
@@ -272,6 +281,6 @@ func (*fakeResponseWriter) WriteHeader(int) {
 }
 
 func TestMakePodsHandler(t *testing.T) {
-	serveFunc := makePodsHandler(&patcher{})
+	serveFunc := makePodsHandler(&patcherManager{})
 	serveFunc(&fakeResponseWriter{}, &http.Request{})
 }

--- a/cmd/fpga_admissionwebhook/patcher_test.go
+++ b/cmd/fpga_admissionwebhook/patcher_test.go
@@ -389,3 +389,32 @@ func TestGetPatchOpsOrchestrated(t *testing.T) {
 		}
 	}
 }
+
+func TestNewPatcherManager(t *testing.T) {
+	tcases := []struct {
+		name        string
+		defaultMode string
+		expectedErr bool
+	}{
+		{
+			name:        "Everything is OK",
+			defaultMode: preprogrammed,
+		},
+		{
+			name:        "Unknown default mode",
+			defaultMode: "unknownMode",
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tcases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newPatcherManager(tt.defaultMode)
+			if tt.expectedErr && err == nil {
+				t.Errorf("Test case '%s': no error returned", tt.name)
+			}
+			if !tt.expectedErr && err != nil {
+				t.Errorf("Test case '%s': unexpected error %+v", tt.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
CRDs for AF or Region mappings are scoped to namespaces. So an
admitted pod has to be mutated with CRDs existing in the same
namespace as the pod's.

Closes #167