### PR TITLE
deviceplugin: fix duplicate device nodes in ContainerResponse

### DIFF
--- a/pkg/deviceplugin/server.go
+++ b/pkg/deviceplugin/server.go
@@ -110,11 +110,11 @@ func (srv *server) Allocate(ctx context.Context, rqt *pluginapi.AllocateRequest)
 			if dev.State != pluginapi.Healthy {
 				return nil, errors.Errorf("Invalid allocation request with unhealthy device %s", id)
 			}
-			for _, devnode := range dev.Nodes {
-				cresp.Devices = append(cresp.Devices, &devnode)
+			for i := range dev.Nodes {
+				cresp.Devices = append(cresp.Devices, &dev.Nodes[i])
 			}
-			for _, devmount := range dev.Mounts {
-				cresp.Mounts = append(cresp.Mounts, &devmount)
+			for i := range dev.Mounts {
+				cresp.Mounts = append(cresp.Mounts, &dev.Mounts[i])
 			}
 			for key, value := range dev.Envs {
 				if cresp.Envs == nil {

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -285,11 +286,20 @@ func TestAllocate(t *testing.T) {
 							ContainerPath: "/dev/dev1",
 							Permissions:   "rw",
 						},
+						{
+							HostPath:      "/dev/dev2",
+							ContainerPath: "/dev/dev2",
+							Permissions:   "rw",
+						},
 					},
 					Mounts: []pluginapi.Mount{
 						{
 							HostPath:      "/dev",
 							ContainerPath: "/dev",
+						},
+						{
+							HostPath:      "/mnt",
+							ContainerPath: "/mnt",
 						},
 					},
 					Envs: map[string]string{
@@ -300,7 +310,7 @@ func TestAllocate(t *testing.T) {
 			postAllocate: func(resp *pluginapi.AllocateResponse) error {
 				return nil
 			},
-			expectedAllocated: 1,
+			expectedAllocated: 2,
 		},
 		{
 			name: "Allocate healthy device with failing postAllocate hook",
@@ -338,6 +348,11 @@ func TestAllocate(t *testing.T) {
 		}
 		if tt.expectedAllocated > 0 && len(resp.ContainerResponses[0].Devices) != tt.expectedAllocated {
 			t.Errorf("Test case '%s': allocated wrong number of devices", tt.name)
+		}
+		if tt.expectedAllocated > 1 {
+			if reflect.DeepEqual(resp.ContainerResponses[0].Devices[0], resp.ContainerResponses[0].Devices[1]) {
+				t.Errorf("Test case '%s': got equal dev nodes in the same response", tt.name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The variable which gets assigned a value from a list element on every
loop iteration is always the same. Getting a pointer to this variable
results in the same pointer on every iteration.

Rather get a pointer to the actual element of the list.