### PR TITLE
Add MDEV plugin (for extend GVT-g VGPU support)

### DIFF
--- a/cmd/mdev_plugin/mdev_plugin.go
+++ b/cmd/mdev_plugin/mdev_plugin.go
@@ -1,0 +1,130 @@
+// Copyright 2017 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
+)
+
+const (
+	iommuGroupDirectory = "/sys/kernel/iommu_groups"
+	vfioDevicePath      = "/dev/vfio"
+	iommuGroupDevices   = "devices"
+	uuidPattern         = "[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
+
+	// Device plugin settings.
+	namespace  = "mdev.intel.com"
+	deviceType = "mdev"
+)
+
+type devicePlugin struct {
+	iommuGroupDir string
+	vfioDevPath   string
+}
+
+func newDevicePlugin(iommuGroupDir string, vfioDevPath string) *devicePlugin {
+	return &devicePlugin{
+		iommuGroupDir: iommuGroupDir,
+		vfioDevPath:   vfioDevPath,
+	}
+}
+
+func (dp *devicePlugin) Scan(notifier deviceplugin.Notifier) error {
+	for {
+		devTree, err := dp.scan()
+		if err != nil {
+			return err
+		}
+
+		notifier.Notify(devTree)
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (dp *devicePlugin) scan() (deviceplugin.DeviceTree, error) {
+	vfioNodes, err := ioutil.ReadDir(dp.vfioDevPath)
+
+	if err != nil {
+		fmt.Println("Can't read vfio Device Path: ", dp.vfioDevPath)
+	}
+	devTree := deviceplugin.NewDeviceTree()
+	for _, node := range vfioNodes {
+		if strings.HasSuffix(node.Name(), "vfio") {
+			continue
+		}
+		iommuGroupNode := path.Join(dp.iommuGroupDir, node.Name())
+
+		vfioDevices, err := ioutil.ReadDir(path.Join(iommuGroupNode, iommuGroupDevices))
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "Can't read %s vfio device", vfioDevices)
+		}
+		for _, device := range vfioDevices {
+
+			match, _ := regexp.MatchString(uuidPattern, device.Name()) // Judge whether it is MDEV decice
+
+			if match {
+				var nodes []pluginapi.DeviceSpec
+
+				devDir := path.Join(iommuGroupNode, device.Name())
+
+				mdevNode := path.Join(dp.vfioDevPath, node.Name())
+
+				fmt.Printf("The %s device detected, the corresponding MDEV device detected is %s\n", devDir, mdevNode)
+
+				nodes = append(nodes, pluginapi.DeviceSpec{
+					HostPath:      mdevNode,
+					ContainerPath: mdevNode,
+					Permissions:   "rw",
+				})
+
+				devInfo := deviceplugin.DeviceInfo{
+					State: pluginapi.Healthy,
+					Nodes: nodes,
+				}
+				devTree.AddDevice("mdev", devDir, devInfo)
+			}
+		}
+	}
+
+	return devTree, nil
+}
+
+func main() {
+	debugEnabled := flag.Bool("debug", false, "enable debug output")
+	flag.Parse()
+	fmt.Println("MDEV device plugin started")
+
+	if *debugEnabled {
+		debug.Activate()
+	}
+
+	plugin := newDevicePlugin(iommuGroupDirectory, vfioDevicePath)
+	manager := deviceplugin.NewManager(namespace, plugin)
+	manager.Run()
+}

--- a/cmd/mdev_plugin/mdev_plugin_test.go
+++ b/cmd/mdev_plugin/mdev_plugin_test.go
@@ -1,0 +1,134 @@
+// Copyright 2017 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
+)
+
+func init() {
+	debug.Activate()
+}
+
+func TestScan(t *testing.T) {
+	tmpdir := fmt.Sprintf("/tmp/mdevplugin-test-%d", time.Now().Unix())
+	iommuGroupDirectory := path.Join(tmpdir, "sys/kernel/iommu_groups")
+	vfioDevicePath := path.Join(tmpdir, "dev/vfio")
+
+	tcases := []struct {
+		iommuGroupDirectorydirs []string
+		mdevDevicefiles         map[string][]byte
+		vfioDevicedirs          []string
+		expectedDevs            int
+		expectedErr             bool
+	}{
+		{
+			expectedErr:  false,
+			expectedDevs: 0,
+		},
+		{
+			vfioDevicedirs: []string{"0"},
+			expectedErr:    true,
+			expectedDevs:   0,
+		},
+		{
+			iommuGroupDirectorydirs: []string{"0", "0/devices"},
+			expectedErr:             false,
+			expectedDevs:            0,
+		},
+
+		{
+			iommuGroupDirectorydirs: []string{"0", "0/devices"},
+			mdevDevicefiles: map[string][]byte{
+				"0/devices/a297de6a-f4c2-11e6-90f7-cb6a86ce449f": []byte("test uuid"),
+			},
+			vfioDevicedirs: []string{"0"},
+			expectedErr:    false,
+			expectedDevs:   1,
+		},
+		{
+			iommuGroupDirectorydirs: []string{"0", "0/devices", "1", "1/devices"},
+			mdevDevicefiles: map[string][]byte{
+				"0/devices/a297de6a-f4c2-11e6-90f7-cb6a86ce449f": []byte("test uuid"),
+				"1/devices/a297db4a-f4c2-11e6-90f6-d3b88d6c9525": []byte("test uuid"),
+			},
+			vfioDevicedirs: []string{"0", "1"},
+			expectedErr:    false,
+			expectedDevs:   2,
+		},
+		{
+			iommuGroupDirectorydirs: []string{"0", "0/devices", "2", "2/devices"},
+			mdevDevicefiles: map[string][]byte{
+				"0/devices/a297de6a-f4c2-11e6-90f7-cb6a86ce449f": []byte("test uuid"),
+				"2/devices/a297db4a-f4c2-11e6-90f6-d3b88d6c952":  []byte("test fake uuid"),
+			},
+			vfioDevicedirs: []string{"0", "2"},
+			expectedErr:    false,
+			expectedDevs:   1,
+		},
+	}
+
+	testPlugin := newDevicePlugin(iommuGroupDirectory, vfioDevicePath)
+
+	if testPlugin == nil {
+		t.Fatal("Failed to create a deviceManager")
+	}
+
+	for _, tcase := range tcases {
+		for _, iommuGroupDirectorydir := range tcase.iommuGroupDirectorydirs {
+			err := os.MkdirAll(path.Join(iommuGroupDirectory, iommuGroupDirectorydir), 0755)
+			if err != nil {
+				t.Fatalf("Failed to create iommu group directory: %+v", err)
+			}
+		}
+		for filename, body := range tcase.mdevDevicefiles {
+			err := ioutil.WriteFile(path.Join(iommuGroupDirectory, filename), body, 0644)
+			if err != nil {
+				t.Fatalf("Failed to create mdev device file: %+v", err)
+			}
+		}
+
+		for _, vfioDevicedir := range tcase.vfioDevicedirs {
+			err := os.MkdirAll(path.Join(vfioDevicePath, vfioDevicedir), 0755)
+			if err != nil {
+				t.Fatalf("Failed to create vfio device directory: %+v", err)
+			}
+		}
+
+		tree, err := testPlugin.scan()
+
+		if tcase.expectedErr && err == nil {
+			t.Error("Expected error hasn't been triggered")
+		}
+		if !tcase.expectedErr && err != nil {
+			t.Errorf("Unexpcted error: %+v", err)
+		}
+		if tcase.expectedDevs != len(tree[deviceType]) {
+			t.Errorf("Wrong number of discovered devices")
+		}
+
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatalf("Failed to remove fake device directory: %+v", err)
+		}
+	}
+}


### PR DESCRIPTION
This is an Intel device plugin for MDEV. Especially on VM-based 
container side, this fills the last piece of Kata mediated pass through
solution support for orchestration.

It adds Kata VFIO/MDEV assignment capability for Kubernetes which
is supported from Kata 1.3 e.g vGPU device for Intel GVT-g.

It identify MDEV device created by UUID e.g
"a297db4a-f4c2-11e6-90f6-d3b88d6c9525" for each VFIO device. Then
expose VFIO/mdev device path through device plugin.

Signed-off-by: Terrence Xu <terrence.xu@intel.com>

@rojkov @mythi  The old PR (https://github.com/intel/intel-device-plugins-for-kubernetes/pull/175) has been deleted automatically since I renamed my branch from "terrence/kata" to "terrence/mdev"