### PR TITLE
gpu: add log messages for not found cards

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -79,6 +79,20 @@ func TestScan(t *testing.T) {
 			expectedDevs: 1,
 			expectedErr:  false,
 		},
+		{
+			sysfsdirs: []string{"card0/device/drm/card0"},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor": []byte("0xbeef"),
+			},
+			devfsdirs:    []string{"card0"},
+			expectedDevs: 0,
+			expectedErr:  false,
+		},
+		{
+			sysfsdirs:    []string{"non_gpu_card"},
+			expectedDevs: 0,
+			expectedErr:  false,
+		},
 	}
 
 	testPlugin := newDevicePlugin(sysfs, devfs, 1)


### PR DESCRIPTION
Let a user know the plugin can't find any Intel GPU if that's the case. It might be cumbersome to realize that the plugin runs on a host which doesn't have any Intel GPUs.

Also make the code less nested for better readability.