### PR TITLE
qat_plugin: kerneldrv: get device.id from inst_id

### DIFF
--- a/cmd/qat_plugin/kerneldrv/kerneldrv.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	adfCtlRegex = regexp.MustCompile(`qat_(?P<devid>[[:alnum:]]+) - type: (?P<devtype>[[:alnum:]]+), .* bsf: ([0-9a-f]{4}:)?(?P<bsf>[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]), .* state: (?P<state>[[:alpha:]]+)$`)
+	adfCtlRegex = regexp.MustCompile(`type: (?P<devtype>[[:alnum:]]+), .* inst_id: (?P<instid>[0-9]+), .* bsf: ([0-9a-f]{4}:)?(?P<bsf>[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]), .* state: (?P<state>[[:alpha:]]+)$`)
 )
 
 type endpoint struct {
@@ -153,10 +153,11 @@ func (dp *DevicePlugin) getOnlineDevices() ([]device, error) {
 		}
 
 		devices = append(devices, device{
-			id:      matches[1],
-			devtype: matches[2],
+			id:      fmt.Sprintf("dev%s", matches[2]),
+			devtype: matches[1],
 			bsf:     matches[4],
 		})
+		debug.Print("New online device", devices[len(devices)-1])
 	}
 
 	return devices, nil


### PR DESCRIPTION
In adf_ctl output, qat_devX is a sequence number that includes both
PF and VF devices:

qat_dev0 - type: c6xx,  inst_id: 0,  node_id: 1,  bsf: 84:00.0, #accel: 5 #engines: 10 state: up
qat_dev1 - type: c6xx,  inst_id: 1,  node_id: 1,  bsf: 85:00.0, #accel: 5 #engines: 10 state: up
qat_dev2 - type: c6xx,  inst_id: 2,  node_id: 1,  bsf: 86:00.0, #accel: 5 #engines: 10 state: up
qat_dev3 - type: c6xxvf,  inst_id: 0,  node_id: 1,  bsf: 84:01.0, #accel: 1 #engines: 1 state: up
qat_dev4 - type: c6xxvf,  inst_id: 1,  node_id: 1,  bsf: 84:01.1, #accel: 1 #engines: 1 state: up
...

X cannot be used as the config file identified because it does not match
the real id of the device. inst_id gives this so move to use that to find
the right config file.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>