### PR TITLE
crypto-perf: add IPC_LOCK to ensure mmap() works

### DIFF
--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -109,6 +109,9 @@ $ kubectl describe node <node name> | grep qat.intel.com/generic
 
      ```
 
+    **Note**: If the `igb_uio` VF driver is used with the QAT device plugin,
+    the workload be deployed with `SYS_ADMIN` capabilities added.
+
 3. Manually execute the `dpdk-test-crypto-perf` application to review the logs:
    ```
    $ kubectl exec -it dpdkqatuio bash

--- a/demo/crypto-perf-dpdk-pod-requesting-qat.yaml
+++ b/demo/crypto-perf-dpdk-pod-requesting-qat.yaml
@@ -26,7 +26,7 @@ spec:
     securityContext:
       capabilities:
         add:
-          [SYS_ADMIN]
+          ["IPC_LOCK"]
   volumes:
   - name: hugepage
     emptyDir:


### PR DESCRIPTION
Make sure IPC_LOCK capability is set to get DPDK to mmap() hugepages.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>