### PR TITLE
demo: update OpenSSL QAT engine version in containers

### DIFF
--- a/demo/openssl-qat-engine/Dockerfile
+++ b/demo/openssl-qat-engine/Dockerfile
@@ -1,13 +1,11 @@
 FROM debian:sid as builder
 
 ENV QAT_DRIVER_RELEASE="qat1.7.l.4.3.0-00033"
-ENV QAT_ENGINE_VERSION="v0.5.39"
-ENV PERL5LIB="/openssl"
+ENV QAT_ENGINE_VERSION="v0.5.41"
 
 RUN apt-get update && \
-    apt-get install -y git build-essential wget libssl-dev openssl libudev-dev pkg-config autoconf autogen libtool && \
+    apt-get install -y git build-essential wget libssl-dev openssl libudev-dev pkg-config autoconf autogen libtool gawk && \
     git clone https://github.com/intel/QAT_Engine && \
-    git clone -b OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git && \
     wget https://01.org/sites/default/files/downloads/intelr-quickassist-technology/$QAT_DRIVER_RELEASE.tar.gz && \
     tar zxf $QAT_DRIVER_RELEASE.tar.gz
 
@@ -18,16 +16,16 @@ RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
     install -m 755 build/libqat_s.so /usr/lib/ && \
     install -m 755 build/libusdm_drv_s.so /usr/lib/ && \
     install -m 755 build/adf_ctl /usr/bin/ && \
-    cd openssl && ./config && cd - && \
     cd QAT_Engine && git checkout $QAT_ENGINE_VERSION && \
     ./autogen.sh && \
     ./configure \
     --with-qat_dir=/ \
-    --with-openssl_dir=/openssl \
+    --with-openssl_dir=/usr \
     --with-openssl_install_dir=/usr/lib/x86_64-linux-gnu \
     --enable-upstream_driver \
     --enable-usdm \
     --with-qat_install_dir=/usr/lib \
+    --enable-qat_skip_err_files_build \
     --enable-openssl_install_build_arch_path && \
     make && make install
 

--- a/demo/openssl-qat-engine/Dockerfile.clear
+++ b/demo/openssl-qat-engine/Dockerfile.clear
@@ -1,15 +1,13 @@
 FROM clearlinux:base as builder
 
 ENV QAT_DRIVER_RELEASE="qat1.7.l.4.3.0-00033"
-ENV QAT_ENGINE_VERSION="v0.5.40"
-ENV PERL5LIB="/openssl"
+ENV QAT_ENGINE_VERSION="v0.5.41"
 
 # add trusted CAs
 RUN rm -rf /run/lock/clrtrust.lock && \
     clrtrust generate && \
     swupd bundle-add --skip-diskspace-check devpkg-systemd devpkg-openssl c-basic wget git && \
     git clone https://github.com/intel/QAT_Engine && \
-    git clone -b OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git && \
     wget https://01.org/sites/default/files/downloads/intelr-quickassist-technology/$QAT_DRIVER_RELEASE.tar.gz && \
     tar zxf $QAT_DRIVER_RELEASE.tar.gz
 
@@ -19,16 +17,16 @@ RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
     install -m 755 build/libqat_s.so /usr/lib/ && \
     install -m 755 build/libusdm_drv_s.so /usr/lib/ && \
     install -m 755 build/adf_ctl /usr/bin/ && \
-    cd openssl && ./config && cd - && \
     cd QAT_Engine && git checkout $QAT_ENGINE_VERSION && \
     ./autogen.sh && \
     ./configure \
     --with-qat_dir=/ \
-    --with-openssl_dir=/openssl \
+    --with-openssl_dir=/usr \
     --with-openssl_install_dir=/usr/lib64 \
     --enable-upstream_driver \
     --enable-usdm \
     --with-qat_install_dir=/usr/lib \
+    --enable-qat_skip_err_files_build \
     --enable-openssl_install_build_arch_path && \
     make && make install
 


### PR DESCRIPTION
v0.5.41 QAT_Engine allows us to drop pulling external openssl
git repository.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>