### PR TITLE
jenkins: Add initial jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,135 @@
+pipeline {
+  agent {
+    label "xenial-intel-device-plugins"
+  }
+  options {
+    timeout(time: 2, unit: "HOURS")
+  }
+  environment {
+    RUNC_VERSION="v1.0.0-rc6"
+    CRIO_VERSION="v1.11.5"
+    OSTREE_VERSION="v2018.8"
+    BUILDAH_VERSION="v1.4"
+    GO_VERSION="1.11.11"
+    GO_TAR="go${GO_VERSION}.linux-amd64.tar.gz"
+    GOROOT="/usr/local/go"
+    GOPATH="/tmp/go"
+    PATH="${env.PATH}:/usr/local/go/bin:${GOPATH}/bin"
+    REPO_NAME="intel-device-plugins-for-kubernetes"
+    REPO_DIR="$GOPATH/src/github.com/intel/${REPO_NAME}"
+  }
+  stages {
+    stage("Get requirements") {
+      parallel {
+        stage("go") {
+          steps {
+            sh "curl -O https://dl.google.com/go/${GO_TAR}"
+            sh "tar -xvf $GO_TAR"
+            sh "sudo mv go $GOROOT"
+            sh "mkdir -p $GOPATH/src/github.com/intel"
+            sh "cp -rf ${env.WORKSPACE} $REPO_DIR"
+            dir(path: "$REPO_DIR") {
+              sh "go get -v golang.org/x/lint/golint"
+              sh "go get -v github.com/fzipp/gocyclo"
+            }
+          }
+        }
+        stage("buildah") {
+          steps {
+            sh "sudo apt-get -y install e2fslibs-dev libfuse-dev libgpgme11-dev libdevmapper-dev libglib2.0-dev libprotobuf-dev"
+            sh "mkdir -p ${GOPATH}/src/github.com/containers"
+            dir(path: "${GOPATH}/src/github.com/containers") {
+              sh "git clone --single-branch --depth 1 -b $BUILDAH_VERSION https://github.com/containers/buildah"
+            }
+            dir(path: "${GOPATH}/src/github.com/containers/buildah") {
+              sh 'make buildah TAGS=""'
+              sh "sudo cp buildah /usr/local/bin"
+              sh "sudo mkdir -p /etc/containers"
+              sh '''echo '[registries.search]' > registries.conf'''
+              sh '''echo 'registries = ["docker.io"]' >> registries.conf'''
+              sh "sudo mv registries.conf /etc/containers/registries.conf"
+              sh "sudo curl https://raw.githubusercontent.com/kubernetes-sigs/cri-o/$CRIO_VERSION/test/policy.json -o /etc/containers/policy.json"
+              sh "sudo curl -L https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 -o /usr/bin/runc"
+              sh "sudo chmod +x /usr/bin/runc"
+            }
+          }
+        }
+      }
+    }
+    stage("make vet, lint, cyclomatic"){
+      parallel {
+        stage("make lint") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make lint"
+            }
+          }
+        }
+        stage("make format") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make format"
+            }
+          }
+        }
+        stage("make vet") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make vet"
+            }
+          }
+        }
+        stage("make cyclomatic-check") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make cyclomatic-check"
+            }
+          }
+        }
+        stage("make test") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make test"
+            }
+          }
+        }
+      }
+    }
+    stage('make images') {
+      parallel {
+        stage("make images with docker") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make images"
+            }
+          }
+        }
+        stage("make images with buildah") {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make images BUILDER=buildah"
+            }
+          }
+        }
+      }
+    }
+    stage('make demos') {
+      parallel {
+        stage('make demos with docker') {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make demos"
+            }
+          }
+        }
+        stage('make demos with buildah') {
+          steps {
+            dir(path: "$REPO_DIR") {
+              sh "make demos BUILDER=buildah"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This Jenkinsfile provides basic CI based on the .travis.yml
which ports the travis behaviour to Jenkins by checking the
following make targets:

  - make format
  - make lint
  - make
  - make vet
  - make cyclomatic-check
  - make test
  - make images
  - make images BUILDER=buildah
  - make demos
  - make demos BUILDER=buildah

The main intention of this commit is to provide an starting point
where anybody can improve the coverage at anytime and get PR cheks
on Jenkins.