### PR TITLE
Move FPGA plugin to Distroless and Clearlinux

### DIFF
--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.11 as builder
 ARG DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .
 RUN cd cmd/fpga_admissionwebhook; go install
 RUN chmod a+x /go/bin/fpga_admissionwebhook
 
-FROM alpine
+FROM gcr.io/distroless/base
 COPY --from=builder /go/bin/fpga_admissionwebhook /usr/bin/intel_fpga_admissionwebhook
 CMD ["/usr/bin/intel_fpga_admissionwebhook"]

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.11 as builder
 ARG DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .
 RUN cd cmd/fpga_plugin; go install
 RUN chmod a+x /go/bin/fpga_plugin
 
-FROM alpine
+FROM gcr.io/distroless/base
 COPY --from=builder /go/bin/fpga_plugin /usr/bin/intel_fpga_device_plugin
 CMD ["/usr/bin/intel_fpga_device_plugin"]

--- a/deployments/fpga_plugin/intel-fpga-initcontainer.Dockerfile
+++ b/deployments/fpga_plugin/intel-fpga-initcontainer.Dockerfile
@@ -19,7 +19,7 @@ RUN tar -zxf a10_gx_pac_ias_1_1_pv_rte_installer/components/a10_gx_pac_ias_1_1_p
 RUN tar -zxf opencl/opencl_bsp.tar.gz && rm -rf opencl_bsp/hardware
 
 ### 2. Final initcontainer image
-FROM alpine as final
+FROM clearlinux:base as final
 
 ARG SRC_DIR=/opt/intel/fpga-sw.src
 ARG DST_DIR=/opt/intel/fpga-sw
@@ -68,8 +68,7 @@ RUN echo -e "{\n\
 
 # Setup
 
-RUN apk update
-RUN apk add rsync
+RUN swupd bundle-add network-basic
 
 RUN echo -e "#!/bin/sh\n\
 rsync -a --delete $SRC_DIR/ $DST_DIR\n\


### PR DESCRIPTION
1) fpga-admissionwebhook and fpga-plugin moved to Distroless
2) fpga-initcontainer moved to Clearlinux 

Signed-off-by: Hector Augusto Garcia Baleon <hector.augusto.garcia.baleon@intel.com>