### PR TITLE
demo: update OpenSSL QAT engine and QAT HAL versions in containers

### DIFF
--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -1,9 +1,11 @@
 FROM clearlinux:base as builder
 
+ARG QAT_DRIVER_RELEASE="qat1.7.l.4.6.0-00025"
+
 RUN swupd bundle-add wget c-basic go-basic && \
     mkdir -p /usr/src/qat && \
     cd /usr/src/qat && \
-    wget https://01.org/sites/default/files/downloads/qat1.7.l.4.5.0-00034.tar.gz && \
+    wget https://01.org/sites/default/files/downloads/$QAT_DRIVER_RELEASE.tar.gz && \
     tar xf *.tar.gz
 RUN cd /usr/src/qat/quickassist/utilities/adf_ctl && \
     make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat && \

--- a/demo/openssl-qat-engine/Dockerfile
+++ b/demo/openssl-qat-engine/Dockerfile
@@ -1,13 +1,13 @@
 FROM debian:sid as builder
 
-ENV QAT_DRIVER_RELEASE="qat1.7.l.4.3.0-00033"
-ENV QAT_ENGINE_VERSION="v0.5.41"
+ARG QAT_DRIVER_RELEASE="qat1.7.l.4.6.0-00025"
+ARG QAT_ENGINE_VERSION="v0.5.42"
 
 RUN apt-get update && \
     apt-get install -y git build-essential wget libssl-dev openssl libudev-dev pkg-config autoconf autogen libtool gawk && \
     git clone https://github.com/intel/QAT_Engine && \
-    wget https://01.org/sites/default/files/downloads/intelr-quickassist-technology/$QAT_DRIVER_RELEASE.tar.gz && \
-    tar zxf $QAT_DRIVER_RELEASE.tar.gz
+    wget https://01.org/sites/default/files/downloads/$QAT_DRIVER_RELEASE.tar.gz && \
+    tar xf *.tar.gz
 
 
 RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \

--- a/demo/openssl-qat-engine/Dockerfile.clear
+++ b/demo/openssl-qat-engine/Dockerfile.clear
@@ -1,15 +1,15 @@
 FROM clearlinux:base as builder
 
-ENV QAT_DRIVER_RELEASE="qat1.7.l.4.3.0-00033"
-ENV QAT_ENGINE_VERSION="v0.5.41"
+ARG QAT_DRIVER_RELEASE="qat1.7.l.4.6.0-00025"
+ARG QAT_ENGINE_VERSION="v0.5.42"
 
 # add trusted CAs
 RUN rm -rf /run/lock/clrtrust.lock && \
     clrtrust generate && \
     swupd bundle-add --skip-diskspace-check devpkg-systemd devpkg-openssl c-basic wget git && \
     git clone https://github.com/intel/QAT_Engine && \
-    wget https://01.org/sites/default/files/downloads/intelr-quickassist-technology/$QAT_DRIVER_RELEASE.tar.gz && \
-    tar zxf $QAT_DRIVER_RELEASE.tar.gz
+    wget https://01.org/sites/default/files/downloads/$QAT_DRIVER_RELEASE.tar.gz && \
+    tar xf *.tar.gz
 
 RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
     KERNEL_SOURCE_ROOT=/tmp ./configure && \


### PR DESCRIPTION
Also, move from ENV to ARG to be able to override the versions
using --build-arg option.

Note: releases qat1.7.l.4.3.0-00033 and older do not have consistent
download URLs so wget'ing those will fail from this commit onwards.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>