### PR TITLE
fpga: fix deployment setup

### DIFF
--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -32,4 +32,4 @@ RUN chmod a+x /go/bin/fpga_admissionwebhook \
 
 FROM scratch as final
 COPY --from=builder /install_root /
-CMD ["/usr/local/bin/intel_fpga_admissionwebhook"]
+ENTRYPOINT ["/usr/local/bin/intel_fpga_admissionwebhook"]

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -38,7 +38,7 @@ RUN cd $DIR/cmd/fpga_crihook && \
 FROM scratch as final
 COPY --from=builder /install_root /
 
-ARG SRC_DIR=/usr/local/fpga-sw.src
+ARG SRC_DIR=/usr/local/fpga-sw
 ARG DST_DIR=/opt/intel/fpga-sw
 
 # CRI hook
@@ -64,4 +64,4 @@ ln -sf $HOOK_CONF_DST /etc/containers/oci/hooks.d/$HOOK_CONF\n\
 rm $DST_DIR/deploy.sh\n\
 ">> $SRC_DIR/deploy.sh && chmod +x $SRC_DIR/deploy.sh
 
-CMD [ "/opt/intel/fpga-sw.src/deploy.sh" ]
+ENTRYPOINT [ "/usr/local/fpga-sw/deploy.sh" ]

--- a/deployments/fpga_admissionwebhook/deployment-tpl.yaml
+++ b/deployments/fpga_admissionwebhook/deployment-tpl.yaml
@@ -15,8 +15,6 @@ spec:
         - name: fpga-mutator
           image: intel-fpga-admissionwebhook:devel
           imagePullPolicy: IfNotPresent
-          command:
-            - /usr/bin/intel_fpga_admissionwebhook
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-private-key-file=/etc/webhook/certs/key.pem

--- a/deployments/fpga_plugin/fpga_plugin.yaml
+++ b/deployments/fpga_plugin/fpga_plugin.yaml
@@ -19,7 +19,6 @@ spec:
       - name: intel-fpga-initcontainer
         image: intel-fpga-initcontainer:devel
         imagePullPolicy: IfNotPresent
-        command: ['/opt/intel/fpga-sw.src/deploy.sh']
         volumeMounts:
         - mountPath: /opt/intel/fpga-sw
           name: intel-fpga-sw


### PR DESCRIPTION
- used ENTRYPOINT instead of CMD in plugin and admission webhook
      Dockerfiles to avoid duplicating commands in the pod yamls
- fixed path to deploy.sh script in fpga initcontainer Dockerfile