### PR TITLE
fpga: update mapping collection

### DIFF
--- a/demo/screencast.sh
+++ b/demo/screencast.sh
@@ -148,7 +148,7 @@ screen6()
   out "Summary:" 15
   out "This screencast demonstrated 'Orchestration programmed' use case for FPGA:" 15
   out " - FPGA device was programmed by the kubernetes machinery" 15
-  out " - desired bitstream resource was specified in the pod spec as fpga.intel.com/arria10-nlb3" 15
+  out " - desired bitstream resource was specified in the pod spec as fpga.intel.com/arria10.dcp1.2-nlb3" 15
   out " - the machinery mapped arria10-nlb3 into the pair of region id/AFU id using admission controller webhook" 15
   out " - programming was done by OPAE tools installed by the init container into /opt/intel/fpga-sw" 15
   out

--- a/demo/test-fpga-region.yml
+++ b/demo/test-fpga-region.yml
@@ -14,7 +14,7 @@ spec:
           [IPC_LOCK]
     resources:
       limits:
-        fpga.intel.com/arria10-nlb3: 1
+        fpga.intel.com/arria10.dcp1.2-nlb3: 1
         cpu: 1
         hugepages-2Mi: 20Mi
 

--- a/deployments/fpga_admissionwebhook/mappings-collection.yaml
+++ b/deployments/fpga_admissionwebhook/mappings-collection.yaml
@@ -1,16 +1,17 @@
+# DCP 1.0
 apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
+kind: FpgaRegion
 metadata:
-  name: arria10-nlb0
+  name: arria10.dcp1.0
 spec:
-  afuId: d8424dc4a4a3c413f89e433683f9040b
+  interfaceId: ce48969398f05f33946d560708be108a
 ---
 apiVersion: fpga.intel.com/v1
 kind: AcceleratorFunction
 metadata:
-  name: arria10.dcp1.1-nlb0
+  name: arria10.dcp1.0-compress
 spec:
-  afuId: d8424dc4a4a3c413f89e433683f9040b
+  afuId: 946c21d1e49704a5e5daa0805bc6b0785e1765bf
 ---
 apiVersion: fpga.intel.com/v1
 kind: AcceleratorFunction
@@ -22,59 +23,11 @@ spec:
 apiVersion: fpga.intel.com/v1
 kind: AcceleratorFunction
 metadata:
-  name: d5005-nlb0
-spec:
-  afuId: d8424dc4a4a3c413f89e433683f9040b
----
-apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
-metadata:
-  name: arria10-nlb3
-spec:
-  afuId: f7df405cbd7acf7222f144b0b93acd18
----
-apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
-metadata:
-  name: arria10.dcp1.1-nlb3
-spec:
-  afuId: f7df405cbd7acf7222f144b0b93acd18
----
-apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
-metadata:
   name: arria10.dcp1.0-nlb3
 spec:
   afuId: f7df405cbd7acf7222f144b0b93acd18
 ---
-apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
-metadata:
-  name: d5005-nlb3
-spec:
-  afuId: f7df405cbd7acf7222f144b0b93acd18
----
-apiVersion: fpga.intel.com/v1
-kind: AcceleratorFunction
-metadata:
-  name: arria10.dcp1.0-compress
-spec:
-  afuId: 946c21d1e49704a5e5daa0805bc6b0785e1765bf
----
-apiVersion: fpga.intel.com/v1
-kind: FpgaRegion
-metadata:
-  name: d5005
-spec:
-  interfaceId: bfac4d851ee856fe8c95865ce1bbaa2d
----
-apiVersion: fpga.intel.com/v1
-kind: FpgaRegion
-metadata:
-  name: arria10
-spec:
-  interfaceId: 69528db6eb31577a8c3668f9faa081f6
----
+# DCP 1.1
 apiVersion: fpga.intel.com/v1
 kind: FpgaRegion
 metadata:
@@ -83,8 +36,59 @@ spec:
   interfaceId: 9926ab6d6c925a68aabca7d84c545738
 ---
 apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: arria10.dcp1.1-nlb0
+spec:
+  afuId: d8424dc4a4a3c413f89e433683f9040b
+---
+apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: arria10.dcp1.1-nlb3
+spec:
+  afuId: f7df405cbd7acf7222f144b0b93acd18
+---
+# DCP 1.2
+apiVersion: fpga.intel.com/v1
 kind: FpgaRegion
 metadata:
-  name: arria10.dcp1.0
+  name: arria10.dcp1.2
 spec:
-  interfaceId: ce48969398f05f33946d560708be108a
+  interfaceId: 69528db6eb31577a8c3668f9faa081f6
+---
+apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: arria10.dcp1.2-nlb0
+spec:
+  afuId: d8424dc4a4a3c413f89e433683f9040b
+---
+apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: arria10.dcp1.2-nlb3
+spec:
+  afuId: f7df405cbd7acf7222f144b0b93acd18
+---
+# D5005
+apiVersion: fpga.intel.com/v1
+kind: FpgaRegion
+metadata:
+  name: d5005
+spec:
+  interfaceId: bfac4d851ee856fe8c95865ce1bbaa2d
+---
+apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: d5005-nlb0
+spec:
+  afuId: d8424dc4a4a3c413f89e433683f9040b
+---
+apiVersion: fpga.intel.com/v1
+kind: AcceleratorFunction
+metadata:
+  name: d5005-nlb3
+spec:
+  afuId: f7df405cbd7acf7222f144b0b93acd18


### PR DESCRIPTION
- Ordered collection in DCP release/region/afus order for simpler
maintenance.

- Got rid of ambiguous entries without dcp releases, e.g. Arria10,
Arria10-nlb3 etc.