### PR TITLE
travis: Use vendored code for container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
   - make vet
   - make cyclomatic-check
   - make test BUILDTAGS=kerneldrv
+  - make -e vendor
+  - make pre-pull
   - make -j4 images
   - make images BUILDER=buildah
   - make demos

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,12 +98,19 @@ pipeline {
         }
       }
     }
+    stage('make pre-pull') {
+      steps {
+	dir(path: "$REPO_DIR") {
+          sh "make pre-pull"
+        }
+      }
+    }
     stage('make images') {
       parallel {
         stage("make images with docker") {
           steps {
             dir(path: "$REPO_DIR") {
-              sh "make images"
+              sh "make -j4 images"
             }
           }
         }

--- a/build/docker/build-image.sh
+++ b/build/docker/build-image.sh
@@ -18,11 +18,17 @@ fi
 TAG=${TAG:-devel}
 SRCREV=$(git rev-parse HEAD)
 
+BUILD_ARGS=
+if [ -d $(dirname $0)/../../vendor ] ; then
+    echo "Building images with vendored code"
+    BUILD_ARGS="--build-arg DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes --build-arg GO111MODULE=off"
+fi
+
 if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then
-    docker build --pull -t ${IMG}:${TAG} -f ${DOCKERFILE} .
+    docker build --pull -t ${IMG}:${TAG} ${BUILD_ARGS} -f ${DOCKERFILE} .
     docker tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 elif [ "${BUILDER}" = 'buildah' ] ; then
-    buildah bud --pull-always -t ${IMG}:${TAG} -f ${DOCKERFILE} .
+    buildah bud --pull-always -t ${IMG}:${TAG} ${BUILD_ARGS} -f ${DOCKERFILE} .
     buildah tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 else
     (>&2 echo "Unknown builder ${BUILDER}")

--- a/build/docker/build-image.sh
+++ b/build/docker/build-image.sh
@@ -16,7 +16,6 @@ if [ ! -e "${DOCKERFILE}" ]; then
 fi
 
 TAG=${TAG:-devel}
-SRCREV=$(git rev-parse HEAD)
 
 BUILD_ARGS=
 if [ -d $(dirname $0)/../../vendor ] ; then
@@ -26,10 +25,8 @@ fi
 
 if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then
     docker build --pull -t ${IMG}:${TAG} ${BUILD_ARGS} -f ${DOCKERFILE} .
-    docker tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 elif [ "${BUILDER}" = 'buildah' ] ; then
     buildah bud --pull-always -t ${IMG}:${TAG} ${BUILD_ARGS} -f ${DOCKERFILE} .
-    buildah tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 else
     (>&2 echo "Unknown builder ${BUILDER}")
     exit 1

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -13,6 +13,12 @@ FROM ${CLEAR_LINUX_BASE} as builder
 ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \
@@ -22,10 +28,7 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-ARG DIR=/intel-device-plugins-for-kubernetes
-WORKDIR $DIR
-COPY . .
-RUN cd cmd/fpga_admissionwebhook; go install
+RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} go install
 RUN chmod a+x /go/bin/fpga_admissionwebhook \
     && install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -13,6 +13,12 @@ FROM ${CLEAR_LINUX_BASE} as builder
 ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \
@@ -23,11 +29,8 @@ RUN mkdir /install_root \
     && rm -rf /install_root/var/lib/swupd/*
 
 # Build CRI Hook
-ARG DIR=/intel-device-plugins-for-kubernetes
-WORKDIR $DIR
-COPY . .
 RUN cd $DIR/cmd/fpga_crihook && \
-    go install && \
+    GO111MODULE=${GO111MODULE} go install && \
     chmod a+x /go/bin/fpga_crihook && \
     cd $DIR/cmd/fpga_tool && \
     go install && \

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -13,6 +13,12 @@ FROM ${CLEAR_LINUX_BASE} as builder
 ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \
@@ -22,10 +28,7 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-ARG DIR=/intel-device-plugins-for-kubernetes
-WORKDIR $DIR
-COPY . .
-RUN cd cmd/fpga_plugin; go install
+RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} go install
 RUN chmod a+x /go/bin/fpga_plugin \
     && install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -13,6 +13,12 @@ FROM ${CLEAR_LINUX_BASE} as builder
 ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \
@@ -22,10 +28,7 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-ARG DIR=/intel-device-plugins-for-kubernetes
-WORKDIR $DIR
-COPY . .
-RUN cd cmd/gpu_plugin; go install
+RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} go install
 RUN chmod a+x /go/bin/gpu_plugin \
     && install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -11,9 +11,16 @@ ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
 FROM ${CLEAR_LINUX_BASE} as builder
 
 ARG CLEAR_LINUX_VERSION=
-ARG TAGS_KERNELDRV=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
+ARG TAGS_KERNELDRV=
+
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \
@@ -34,10 +41,7 @@ RUN test -z "${TAGS_KERNELDRV}" \
     && cd /usr/src/qat/quickassist/utilities/adf_ctl \
     && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
     && install -D adf_ctl /install_root/usr/local/bin/adf_ctl )
-ARG DIR=/intel-device-plugins-for-kubernetes
-WORKDIR $DIR
-COPY . .
-RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; go install -tags "${TAGS_KERNELDRV}"
+RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; GO111MODULE=${GO111MODULE} go install -tags "${TAGS_KERNELDRV}"
 RUN chmod a+x /go/bin/qat_plugin \
     && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE

--- a/demo/build-image.sh
+++ b/demo/build-image.sh
@@ -16,14 +16,11 @@ fi
 
 CWD=`dirname $0`
 TAG=${TAG:-devel}
-SRCREV=$(git rev-parse HEAD)
 
 if [ -z "$BUILDER" -o "$BUILDER" = 'docker' ] ; then
     docker build --pull -t ${IMG}:${TAG} "$CWD/$DIR/"
-    docker tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 elif [ "$BUILDER" = 'buildah' ] ; then
     buildah bud  --pull-always -t ${IMG}:${TAG} "$CWD/$DIR/"
-    buildah tag ${IMG}:${TAG} ${IMG}:${SRCREV}
 else
     (>&2 echo "Unknown builder $BUILDER")
     exit 1


### PR DESCRIPTION

This takes ideas and changes from #212 but goes back to vendor/ with container builds. vendor/ is created from go mod cache.