### PR TITLE
fpga: fixed documentation and demo

### DIFF
--- a/cmd/fpga_admissionwebhook/README.md
+++ b/cmd/fpga_admissionwebhook/README.md
@@ -21,9 +21,9 @@ You must install and set up the following FPGA plugin modules for correct operat
     $ cd $SRC
     $ make intel-fpga-admissionwebhook
     $ docker images
-    REPOSITORY                    TAG                                        IMAGE ID            CREATED          SIZE
-    intel-fpga-admissionwebhook   10efe163a5091e8b2ceaa9baad236d3a41063c88   6c3bce0b8693        0 sec ago        25.2MB
-    intel-fpga-admissionwebhook   devel                                      6c3bce0b8693        0 sec ago        25.2MB
+    REPOSITORY                          TAG                                        IMAGE ID            CREATED          SIZE
+    intel/intel-fpga-admissionwebhook   01b11d9d6d18bbe7df987a738efb20ae22ce795e   eb8f95f87ee4        0 sec ago        81.9MB
+    intel/intel-fpga-admissionwebhook   devel                                      eb8f95f87ee4        0 sec ago        81.9MB
     ...
 ```
 
@@ -35,19 +35,29 @@ Run the `scripts/webhook-deploy.sh` script.
     $ cd $SRC
     $ ./scripts/webhook-deploy.sh
     Create secret including signed key/cert pair for the webhook
-    Creating certs in /tmp/tmp.Ebb77GBKqm
+    Creating certs in /tmp/tmp.XGTpddQBwP
     certificatesigningrequest.certificates.k8s.io/intel-fpga-webhook-svc.default created
-    NAME                             AGE       REQUESTOR      CONDITION
-    intel-fpga-webhook-svc.default   0s        system:admin   Pending
+    NAME                             AGE   REQUESTOR          CONDITION
+    intel-fpga-webhook-svc.default   0s    kubernetes-admin   Pending
     certificatesigningrequest.certificates.k8s.io/intel-fpga-webhook-svc.default approved
     secret/intel-fpga-webhook-certs created
-    Removing /tmp/tmp.Ebb77GBKqm
+    Removing /tmp/tmp.XGTpddQBwP
     Create FPGA CRDs
     customresourcedefinition.apiextensions.k8s.io/acceleratorfunctions.fpga.intel.com created
     customresourcedefinition.apiextensions.k8s.io/fpgaregions.fpga.intel.com created
-    acceleratorfunction.fpga.intel.com/arria10-nlb0 created
-    acceleratorfunction.fpga.intel.com/arria10-nlb3 created
-    fpgaregion.fpga.intel.com/arria10 created
+    fpgaregion.fpga.intel.com/arria10.dcp1.0 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.0-compress created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.0-nlb0 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.0-nlb3 created
+    fpgaregion.fpga.intel.com/arria10.dcp1.1 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.1-nlb0 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.1-nlb3 created
+    fpgaregion.fpga.intel.com/arria10.dcp1.2 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.2-nlb0 created
+    acceleratorfunction.fpga.intel.com/arria10.dcp1.2-nlb3 created
+    fpgaregion.fpga.intel.com/d5005 created
+    acceleratorfunction.fpga.intel.com/d5005-nlb0 created
+    acceleratorfunction.fpga.intel.com/d5005-nlb3 created
     clusterrole.rbac.authorization.k8s.io/fpga-reader created
     clusterrolebinding.rbac.authorization.k8s.io/default-fpga-reader created
     Create webhook deployment

--- a/cmd/fpga_crihook/README.md
+++ b/cmd/fpga_crihook/README.md
@@ -10,15 +10,20 @@ You must install and set up the following FPGA plugin modules for correct operat
 
 ### Get source code:
 ```
-$ mkdir -p $GOPATH/src/github.com/intel/
-$ cd $GOPATH/src/github.com/intel/
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes.git
+    $ mkdir -p $GOPATH/src/github.com/intel/
+    $ cd $GOPATH/src/github.com/intel/
+    $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes.git
 ```
 
 ### Build CRI-O hook:
 ```
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
-$ make fpga_crihook
+    $ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+    $ make intel-fpga-initcontainer
+    $ docker images
+    REPOSITORY                      TAG                                        IMAGE ID            CREATED          SIZE
+    intel/intel-fpga-initcontainer  01b11d9d6d18bbe7df987a738efb20ae22ce795e   2e7586fe0fa6        0 sec ago        57.6MB
+    intel/intel-fpga-initcontainer  devel                                      2e7586fe0fa6        0 sec ago        57.6MB
+    ...
 ```
 
 ### Ensure that CRI-O is configured to allow OCI hooks

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -11,21 +11,21 @@ You must install and set up the following FPGA plugin modules for correct operat
 
 ### Get source code:
 ```
-$ mkdir -p $GOPATH/src/github.com/intel/
-$ cd $GOPATH/src/github.com/intel/
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes.git
+    $ mkdir -p $GOPATH/src/github.com/intel/
+    $ cd $GOPATH/src/github.com/intel/
+    $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes.git
 ```
 
 ### Build FPGA device plugin:
 ```
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
-$ make fpga_plugin
+    $ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+    $ make fpga_plugin
 ```
 
 ### Verify kubelet socket exists in /var/lib/kubelet/device-plugins/ directory:
 ```
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
+    $ ls /var/lib/kubelet/device-plugins/kubelet.sock
+    /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
 ### Choose mode for FPGA device plugin
@@ -46,38 +46,38 @@ translated to resources of the same type.
 
 1. Run FPGA device plugin as administrator:
 ```
-$ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
-$ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode af -kubeconfig $KUBE_CONF
-FPGA device plugin started in af mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-af-f7df405cbd7acf7222f144b0b93acd18.sock
-device-plugin registered
+    $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
+    $ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
+    $ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode af -kubeconfig $KUBE_CONF
+    FPGA device plugin started in af mode
+    device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-af-f7df405cbd7acf7222f144b0b93acd18.sock
+    device-plugin registered
 ```
 
 2. Check if FPGA device plugin is registered on master:
 ```
-$ kubectl describe node <node name> | grep fpga.intel.com
- fpga.intel.com/af-f7df405cbd7acf7222f144b0b93acd18:  1
- fpga.intel.com/af-f7df405cbd7acf7222f144b0b93acd18:  1
+    $ kubectl describe node <node name> | grep fpga.intel.com
+    fpga.intel.com/af-f7df405cbd7acf7222f144b0b93acd18:  1
+    fpga.intel.com/af-f7df405cbd7acf7222f144b0b93acd18:  1
 ```
 
 #### Run FPGA device plugin in region mode
 
 1. Run FPGA device plugin as administrator:
 ```
-$ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
-$ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode region -kubeconfig $KUBE_CONF
-FPGA device plugin started in region mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-region-ce48969398f05f33946d560708be108a.sock
-device-plugin registered
+    $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
+    $ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
+    $ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode region -kubeconfig $KUBE_CONF
+    FPGA device plugin started in region mode
+    device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-region-ce48969398f05f33946d560708be108a.sock
+    device-plugin registered
 ```
 
 2. Check if FPGA device plugin is registered on master:
 ```
-$ kubectl describe node <node name> | grep fpga.intel.com
- fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
- fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
+    $ kubectl describe node <node name> | grep fpga.intel.com
+    fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
+    fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
 ```
 
 ### Deploy FPGA device plugin as DaemonSet
@@ -85,27 +85,27 @@ $ kubectl describe node <node name> | grep fpga.intel.com
 1. To deploy the plugin in a production cluster, create a service account
 for the plugin:
     ```
-    $ kubectl create -f deployments/fpga_plugin/fpga_plugin_service_account.yaml
-    serviceaccount/intel-fpga-plugin-controller created
-    clusterrole.rbac.authorization.k8s.io/node-getter created
-    clusterrolebinding.rbac.authorization.k8s.io/get-nodes created
+        $ kubectl create -f deployments/fpga_plugin/fpga_plugin_service_account.yaml
+        serviceaccount/intel-fpga-plugin-controller created
+        clusterrole.rbac.authorization.k8s.io/node-getter created
+        clusterrolebinding.rbac.authorization.k8s.io/get-nodes created
     ```
 
 2. Create the DaemonSet:
     ```
-    $ kubectl create -f deployments/fpga_plugin/fpga_plugin.yaml
-    daemonset.apps/intel-fpga-plugin created
+        $ kubectl create -f deployments/fpga_plugin/fpga_plugin.yaml
+        daemonset.apps/intel-fpga-plugin created
     ```
 
 3. Build an image from sources:
     ```
-    $ make intel-fpga-plugin
+        $ make intel-fpga-plugin
     ```
     This image launches `fpga_plugin` in `af` mode by default.
 
     You can override the mode on a per-node basis using this annotation:
     ```
-    $ kubectl annotate node mynode "fpga.intel.com/device-plugin-mode=region"
+        $ kubectl annotate node mynode "fpga.intel.com/device-plugin-mode=region"
     ```
     To use your own container image, modify the
     `deployments/fpga_plugin/fpga_plugin.yaml` file.

--- a/demo/opae-nlb-demo/test_fpga.sh
+++ b/demo/opae-nlb-demo/test_fpga.sh
@@ -2,8 +2,8 @@
 
 # Test FPGA by running 2 OPAE samples: nlb3 and nlb0
 # nlb3 is expected to succeed, nlb0 - to fail
-green () { echo "\033[0;32m$1\033[0m";}
-red () { echo "\033[0;31m$1\033[0m";}
+green () { echo -e "\033[0;32m$1\033[0m";}
+red () { echo -e "\033[0;31m$1\033[0m";}
 
 green 'Running nlb3'
 if nlb3; then

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -53,20 +53,20 @@ Only one worker node has a GPU. The time difference in transcoding speed is capt
 ## Intel® FPGA Device Plugin demo video
 
 The screencast demonstrates the deployment of the Intel® FPGA Device Plugin for
-Kubernetes and executes a sample GZIP compression workload. The demo begins
+Kubernetes and executes a native loopback 3 (NLB3) workload. The demo begins
 with a fully [configured Kubernetes cluster](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/)
 with the [Go runtime](https://golang.org/doc/install).
 
 ### Demo platform configuration
 
 - Hardware
-    - 1-node, 2x Intel® Xeon® E5-2680 CPU @ 2.4 GHz
-    - Total memory 251 GB
+    - 1-node, 2x Intel@ Xeon@ Gold 6140M CPU @ 2.30GHz
+    - Total memory 377 GB
     - Intel® Arria® 10 GX FPGA
 - Software
-    - OpenSUSE* 15 (Kernel: 4.18.9-200.fc28.x86_64)
-    - Kubernetes* 1.11
-    - CRI-O 1.11.1
+    - Ubuntu 18.04.2 LTS (Kernel: 4.15.0-60-generic)
+    - Kubernetes* 1.13
+    - CRI-O 1.13.1
     - Intel® FPGA Device Plugin built from master branch
 
 ### Demo steps
@@ -75,14 +75,14 @@ with the [Go runtime](https://golang.org/doc/install).
 2. Clone the [Intel Device Plugins for Kubernetes source](https://github.com/intel/intel-device-plugins-for-kubernetes).
 3. Provision the [admission controller webhook](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_admissionwebhook/README.md).
 4. Provision the [Intel® FPGA Device Plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_plugin/README.md).
-5. Create bitstream storage for the Intel® FPGA.
-6. Run the sample GZIP compression workload.
+5. Build the opae-nlb-demo image
+6. Run the NLB3 workload.
 
 ### Screencast
 
 Intel® FPGA Device Plugin deployment
 
-[![Intel® FPGA Device Plugin deployment](https://asciinema.org/a/mRn15bkRRUzTG4kp2UeHQX6gk.png)](https://asciinema.org/a/mRn15bkRRUzTG4kp2UeHQX6gk)
+[![Intel® FPGA Device Plugin deployment](https://asciinema.org/a/7FK8WDwyoL5g1T5HOa2vekKU2.png)](https://asciinema.org/a/7FK8WDwyoL5g1T5HOa2vekKU2)
 
 ## Intel® QuickAssist Technology Device Plugin OpenSSL demo video
 

--- a/demo/screencast.sh
+++ b/demo/screencast.sh
@@ -79,7 +79,7 @@ screen3()
   out "Build intel-fpga-admissionwebhook image:"
   command "cd intel-device-plugins-for-kubernetes; make intel-fpga-admissionwebhook" 15
   out "Import image from docker to CRI-O:"
-  command "docker save intel-fpga-admissionwebhook:devel | sudo podman load"
+  command "docker save intel/intel-fpga-admissionwebhook:devel | sudo podman load"
   cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
   out "Deploy the webhook:"
   command "cd scripts ; ./webhook-deploy.sh --namespace kube-system --mode orchestrated; cd ../"
@@ -96,14 +96,11 @@ screen4()
   out "Build intel-fpga-plugin image"
   command "make intel-fpga-plugin" 15
   out "Import image from docker to CRI-O:"
-  command "docker save intel-fpga-plugin:devel | sudo podman load"
+  command "docker save intel/intel-fpga-plugin:devel | sudo podman load"
   out "Build intel-fpga-initcontainer image"
-  out "NOTE! This image requires 'Acceleration Stack for Runtime' tarball from https://www.intel.com/content/www/us/en/programmable/solutions/acceleration-hub/downloads.html" 15
-  out "We'll skip download part as it takes time and simply copy the tarball to the required location and build the image:" 15
-  command "cp /srv/demo/a10_gx_pac_ias_1_1_pv_rte_installer.tar.gz deployments/fpga_plugin/" 15
-  command "cd deployments/fpga_plugin/ ; ./build-initcontainer-image.sh" 15
+  command "make intel-fpga-initcontainer" 15
   out "Import image from docker to CRI-O:"
-  command "docker save intel-fpga-initcontainer:devel | sudo podman load"
+  command "docker save intel/intel-fpga-initcontainer:devel | sudo podman load"
   out "Check that both images are imported:"
   command "sudo crictl images|grep 'intel-fpga-\(i\|p\)'"
   out "Create a service account for the plugin"
@@ -126,9 +123,9 @@ screen5()
   cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
   out "5. Run OPAE workload that uses NLB3 bitstream"
   out "Build opae-nlb-demo image:"
-  command "cd demo; ./build-image.sh opae-nlb-demo ; cd ../" 15
+  command "cd demo; ./build-image.sh intel/opae-nlb-demo ; cd ../" 15
   out "Import image from docker to CRI-O:"
-  command "docker save opae-nlb-demo:devel | sudo podman load"
+  command "docker save intel/opae-nlb-demo:devel | sudo podman load"
   out "Program bitstream that is not wanted by the workload:"
   command "sudo /opt/intel/fpga-sw/opae/fpgaconf-wrapper -s0 /srv/intel.com/fpga/9926ab6d6c925a68aabca7d84c545738/d8424dc4a4a3c413f89e433683f9040b.gbs"
   out "Check if device is programmed with it:"


### PR DESCRIPTION
- Fixed documentation for the CRI-O hook
- Updated the screencast.sh to remove references to the 'Acceleration Stack for Runtime' tarball which is not needed anymore
- Created and updated the link to a new screencast for the NLB3 demo