### PR TITLE
Fix golangci-lint findings

### DIFF
--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -97,13 +97,13 @@ type fpgaParams struct {
 	portDevice string
 }
 
-func newHookEnv(sysFsPrefix, bitstreamDir string, config string, execer utilsexec.Interface) (*hookEnv, error) {
+func newHookEnv(sysFsPrefix, bitstreamDir string, config string, execer utilsexec.Interface) *hookEnv {
 	return &hookEnv{
 		sysFsPrefix:  sysFsPrefix,
 		bitstreamDir: bitstreamDir,
 		config:       config,
 		execer:       execer,
-	}, nil
+	}
 }
 
 func (he *hookEnv) getConfig(stdinJ *Stdin) (*Config, error) {
@@ -283,12 +283,9 @@ func main() {
 		os.Setenv("PATH", "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin")
 	}
 
-	he, err := newHookEnv("", fpgaBitStreamDirectory, configJSON, utilsexec.New())
-	if err == nil {
-		err = he.process(os.Stdin)
-	}
+	he := newHookEnv("", fpgaBitStreamDirectory, configJSON, utilsexec.New())
 
-	if err != nil {
+	if err := he.process(os.Stdin); err != nil {
 		fmt.Printf("%+v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -52,12 +52,6 @@ type Config struct {
 		Env []string `json:"env"`
 	} `json:"process"`
 	Linux struct {
-		Resources struct {
-			Devices []struct {
-				Major int `json:"major,omitempty"`
-				Minor int `json:"minor,omitempty"`
-			} `json:"devices"`
-		} `json:"resources"`
 		Devices []Device `json:"devices"`
 	} `json:"linux"`
 }

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -270,6 +270,9 @@ func (he *hookEnv) process(reader io.Reader) error {
 		defer bitstream.Close()
 
 		err = port.PR(bitstream, false)
+		if err != nil {
+			return err
+		}
 
 		programmedAfu = port.GetAcceleratorTypeUUID()
 

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -167,7 +167,7 @@ func (he *hookEnv) getFPGAParams(config *Config) ([]fpgaParams, error) {
 	for num, region := range regionEnv {
 		afu, ok := afuEnv[num]
 		if !ok {
-			errors.Errorf("Environment variable %s%s is not set", fpgaAfuEnvPrefix, num)
+			return nil, errors.Errorf("Environment variable %s%s is not set", fpgaAfuEnvPrefix, num)
 		}
 
 		// Find a device suitable for the region/interface id

--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -158,10 +158,7 @@ func TestGetConfig(t *testing.T) {
 				t.Fatalf("can't decode %s: %+v", fname, err)
 			}
 
-			he, err := newHookEnv("", "", tc.configJSON, nil)
-			if err != nil {
-				t.Fatalf("can't create HookEnv for config JSON %s: %+v", tc.configJSON, err)
-			}
+			he := newHookEnv("", "", tc.configJSON, nil)
 
 			config, err := he.getConfig(stdinJ)
 			if err != nil {
@@ -287,10 +284,7 @@ func TestGetFPGAParams(t *testing.T) {
 				t.Fatalf("can't create temp files: %+v", err)
 			}
 
-			he, err := newHookEnv(tmpdir, "", tc.configJSON, nil)
-			if err != nil {
-				t.Fatalf("can't create HookEnv for config JSON %s: %+v", tc.configJSON, err)
-			}
+			he := newHookEnv(tmpdir, "", tc.configJSON, nil)
 
 			stdinJ, err := getStdin(stdin)
 			if err != nil {


### PR DESCRIPTION
Fixed the following warnings:
- main.go:170:17: Error return value of `errors.Errorf` is not checked (errcheck)
			errors.Errorf("Environment variable %s%s is not set", fpgaAfuEnvPrefix, num)
			             ^
- main.go:272:3: ineffectual assignment to `err` (ineffassign)
		err = port.PR(bitstream, false)
		^
- main.go:55:3: U1000: field `Resources` is unused (unused)
		Resources struct {

- main.go:100:105: newHookEnv - result 1 (error) is always nil (unparam)
func newHookEnv(sysFsPrefix, bitstreamDir string, config string, execer utilsexec.Interface) (*hookEnv, error) {