### PR TITLE
images: add LICENSEs

### DIFF
--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -28,10 +28,11 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} go install
+RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} go install; cd -
 RUN chmod a+x /go/bin/fpga_admissionwebhook \
     && install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE
+    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && scripts/copy-modules-licenses.sh ./cmd/fpga_admissionwebhook /install_root/usr/local/share/package-licenses/
 
 FROM scratch as final
 COPY --from=builder /install_root /

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -35,7 +35,10 @@ RUN cd $DIR/cmd/fpga_crihook && \
     cd $DIR/cmd/fpga_tool && \
     go install && \
     chmod a+x /go/bin/fpga_tool && \
-    install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE
+    cd $DIR && \
+    install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE && \
+    scripts/copy-modules-licenses.sh ./cmd/fpga_crihook /install_root/usr/local/share/package-licenses/ && \
+    scripts/copy-modules-licenses.sh ./cmd/fpga_tool /install_root/usr/local/share/package-licenses/
 
 # Minimal result image
 FROM scratch as final

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -28,10 +28,11 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} go install
+RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} go install; cd -
 RUN chmod a+x /go/bin/fpga_plugin \
     && install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE
+    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && scripts/copy-modules-licenses.sh ./cmd/fpga_plugin /install_root/usr/local/share/package-licenses/
 
 FROM scratch as final
 COPY --from=builder /install_root /

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -28,10 +28,11 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} go install
+RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} go install; cd -
 RUN chmod a+x /go/bin/gpu_plugin \
     && install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE
+    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && scripts/copy-modules-licenses.sh ./cmd/gpu_plugin /install_root/usr/local/share/package-licenses/
 
 FROM scratch as final
 COPY --from=builder /install_root /

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -41,10 +41,11 @@ RUN test -z "${TAGS_KERNELDRV}" \
     && cd /usr/src/qat/quickassist/utilities/adf_ctl \
     && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
     && install -D adf_ctl /install_root/usr/local/bin/adf_ctl )
-RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; GO111MODULE=${GO111MODULE} go install -tags "${TAGS_KERNELDRV}"
+RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; GO111MODULE=${GO111MODULE} go install -tags "${TAGS_KERNELDRV}"; cd -
 RUN chmod a+x /go/bin/qat_plugin \
     && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE
+    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && scripts/copy-modules-licenses.sh ./cmd/qat_plugin /install_root/usr/local/share/package-licenses/
 
 FROM scratch as final
 COPY --from=builder /install_root /

--- a/scripts/copy-modules-licenses.sh
+++ b/scripts/copy-modules-licenses.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2019 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy the licenses of ".Deps" modules for a package to a target directory
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# != 2 ] || [ "$1" = "?" ] || [ "$1" = "--help" ]; then
+	echo "Usage: $0 <package> <license target dir>" >&2
+	exit 1
+fi
+
+if [ ! -d $2 ] || [ ! -w $2 ]; then
+	echo "Error: cannot use $2 as the license target directory"
+	exit 1
+fi
+
+export GO111MODULE=on
+
+if [ ! -d vendor ]; then
+	go mod vendor -v
+fi
+
+LICENSE_FILES=$(find vendor |grep -e LICENSE -e NOTICE|cut -d / -f 2-)
+PACKAGE_DEPS=$(go list -f '{{ join .Deps "\n" }}' $1 |grep "\.")
+
+pushd vendor > /dev/null
+
+for lic in $LICENSE_FILES; do
+	# Copy the license if its repository path is found in package .Deps
+	if [ $(echo $PACKAGE_DEPS | grep -c `dirname $lic`) -gt 0 ]; then
+		cp -t $2 --parent $lic
+	fi
+done
+
+popd > /dev/null


### PR DESCRIPTION
This commit adds a script that is (primarily) used in Dockerfiles
to install runtime Go dependencies' LICENSE/NOTICE files into the
image and modifies the Dockerfiles to use the script.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>