### PR TITLE
deployments/gpu_plugin: limit host mounts

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -41,6 +41,10 @@ $ kubectl create -f ./deployments/gpu_plugin/gpu_plugin.yaml
 daemonset.apps/intel-gpu-plugin created
 ```
 
+**Note**: It is also possible to run the GPU device plugin using a non-root user. To do this,
+the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
+Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
+
 ### Verify GPU device plugin is registered on master:
 ```
 $ kubectl describe node <node name> | grep gpu.intel.com

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -78,6 +78,11 @@ kubectl create -f deployments/qat_plugin/qat_plugin_default_configmap.yaml
 kubectl create -f deployments/qat_plugin/qat_plugin.yaml
 ```
 
+**Note**: It is also possible to run the QAT device plugin using a non-root user. To do this,
+the nodes' DAC rules must be configured to allow PCI driver unbinding/binding, device plugin
+socket creation and kubelet registration. Furthermore, the deployments `securityContext` must
+be configured with appropriate `runAsUser/runAsGroup`.
+
 ### Verify QAT device plugin is registered on master:
 ```
 $ kubectl describe node <node name> | grep qat.intel.com/generic

--- a/deployments/gpu_plugin/gpu_plugin.yaml
+++ b/deployments/gpu_plugin/gpu_plugin.yaml
@@ -27,18 +27,20 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: devfs
-          mountPath: /dev
+          mountPath: /dev/dri
+          readOnly: true
         - name: sysfs
-          mountPath: /sys
+          mountPath: /sys/class/drm
+          readOnly: true
         - name: kubeletsockets
           mountPath: /var/lib/kubelet/device-plugins
       volumes:
       - name: devfs
         hostPath:
-          path: /dev
+          path: /dev/dri
       - name: sysfs
         hostPath:
-          path: /sys
+          path: /sys/class/drm
       - name: kubeletsockets
         hostPath:
           path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
The default deployment gives rather wide host mounts. We can limit
the mounts only to the subdirectories the plugin needs and mount
them read-only.

Also, add notes that both QAT and GPU plugins can be run as non-root
user.

Fixes: #228

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>