### PR TITLE
deployments/fpga_plugin: limit host mounts

### DIFF
--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -54,6 +54,10 @@ translated to resources of the same type.
     device-plugin registered
 ```
 
+**Note**: It is also possible to run the FPGA device plugin using a non-root user. To do this,
+the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
+Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
+
 2. Check if FPGA device plugin is registered on master:
 ```
     $ kubectl describe node <node name> | grep fpga.intel.com

--- a/deployments/fpga_plugin/fpga_plugin.yaml
+++ b/deployments/fpga_plugin/fpga_plugin.yaml
@@ -40,8 +40,10 @@ spec:
         volumeMounts:
         - name: devfs
           mountPath: /dev
+          readOnly: true
         - name: sysfs
-          mountPath: /sys
+          mountPath: /sys/class
+          readOnly: true
         - name: kubeletsockets
           mountPath: /var/lib/kubelet/device-plugins
       volumes:
@@ -50,7 +52,7 @@ spec:
           path: /dev
       - name: sysfs
         hostPath:
-          path: /sys
+          path: /sys/class
       - name: kubeletsockets
         hostPath:
           path: /var/lib/kubelet/device-plugins


### PR DESCRIPTION
The default deployment gives rather wide host mounts.

Limited sysfs mount only to the subdirectory the plugin
needs.

Mounted sysfs and dev  mounts read-only.

Added notes that FPGA plugin can be run as non-root user.