### PR TITLE
fpga: Migrate webhook deployment to use the apps/v1 API

### DIFF
--- a/deployments/fpga_admissionwebhook/deployment-tpl.yaml
+++ b/deployments/fpga_admissionwebhook/deployment-tpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
       name: intel-fpga-webhook-deployment
@@ -6,6 +6,9 @@ metadata:
         app: intel-fpga-webhook
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: intel-fpga-webhook
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since Kubernetes v1.16 release, DaemonSet, Deployment, StatefulSet, and ReplicaSet in the extensions/v1beta1 and apps/v1beta2 API groups have been deprecated. This PR migrates the webhook deployment to use apps/v1 instead of extensions/v1beta1 and add the selector part also required by the migration.

Signed-off-by: Hector Augusto Garcia Baleon <hector.augusto.garcia.baleon@intel.com>