### PR TITLE
Fix opae-demo-nlb build

### DIFF
--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -13,7 +13,7 @@ FROM ${CLEAR_LINUX_BASE} as builder
 ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION} && \
-    swupd bundle-add wget c-basic devpkg-json-c devpkg-util-linux devpkg-hwloc doxygen Sphinx patch
+    swupd bundle-add wget c-basic devpkg-json-c devpkg-util-linux devpkg-hwloc doxygen patch
 # Fetch dependencies and source code
 ARG OPAE_RElEASE=1.3.2-1
 


### PR DESCRIPTION
- Removed Sphynx from the list of bundles as it brings python-basic3,
  which triggers this exception:
```
Step 9/18 : RUN cd /usr/src/opae/opae-sdk-${OPAE_RElEASE} \
      &&  patch -p1 < 0001-OPAE-in-containers-don-t-enumerate-missing-device.patch \
     &&   mkdir build &&     cd build \
     &&     cmake .. -DBUILD_ASE=0 -DCMAKE_INSTALL_PREFIX=/usr \
               -DCMAKE_SKIP_RPATH=true &&     make xfpga nlb0 nlb3
...
-- Found Sphinx: /usr/sbin/sphinx-build
-- Found PythonInterp: /usr/sbin/python (found suitable version "3.8.1", minimum required is "2.7")
-- Found Perl: /usr/sbin/perl (found version "5.28.2")
-- Found PythonInterp: /usr/sbin/python (found version "3.8.1")
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/platforms/scripts/afu_platform_config_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/platforms/scripts/afu_platform_info_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/tools/extra/packager/packager_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/tools/extra/packager/afu_json_mgr_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/tools/extra/fpgadiag/fpgalpbk_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/tools/extra/fpgadiag/mactest_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/src/opae/opae-sdk-1.3.2-1/build/tools/extra/fpgadiag/fpgastats_main/do_zip.py", line 8, in <module>
    wr_buf.write('#!/usr/bin/env python' + os.linesep)
TypeError: a bytes-like object is required, not 'str'
```

- Added python-basic2 to the list of bundles to install in order
  to explicitly use python2 for the build.