### PR TITLE
fpga_plugin: move termination-log out of /dev

### DIFF
--- a/deployments/fpga_plugin/fpga_plugin.yaml
+++ b/deployments/fpga_plugin/fpga_plugin.yaml
@@ -35,6 +35,7 @@ spec:
                 fieldPath: spec.nodeName
         image: intel/intel-fpga-plugin:devel
         imagePullPolicy: IfNotPresent
+        terminationMessagePath: /tmp/termination-log
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:


### PR DESCRIPTION
runtime uses /dev/termination-log to write container termination
messages. If this file doesn't exist on the host the runtime tries
to create it. As /dev is read-only for intel-fpga-plugin container
attempt to create /dev/termination-log fails with this error:

```
Warning Failed kubelet, device-plugins-kubernetes-clearlinux-14-4.novalocal  Error:
  container create failed: container_linux.go:345: starting container process caused
  "process_linux.go:430: container init caused \"rootfs_linux.go:58:
  mounting \\\"/var/lib/kubelet/pods/d7262db5-e3fc-4b7b-bc2e-da245f600c4b/containers/intel-fpga-plugin/cddd0f76\\\"
  to rootfs \\\"/var/lib/containers/storage/overlay/edd75bb94b1b4cf93ae1ea5c064945169fb329d0abdb56b7621cddfc721f6eda/merged\\\"
  at \\\"/var/lib/containers/storage/overlay/edd75bb94b1b4cf93ae1ea5c064945169fb329d0abdb56b7621cddfc721f6eda/merged/dev/termination-log\\\"
  caused \\\"open /var/lib/containers/storage/overlay/edd75bb94b1b4cf93ae1ea5c064945169fb329d0abdb56b7621cddfc721f6eda/merged/dev/termination-log: read-only file system\\\"\""
```

Setting terminationMessagePath to rw-mounted file system
/tmp/termination-log for the plugin container should fix this.

Fixes: #259