### PR TITLE
gpu: do not fail if no GPU devices found

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -68,7 +68,7 @@ func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
 	for {
 		devTree, err := dp.scan()
 		if err != nil {
-			return err
+			fmt.Println("WARNING: Failed to scan: ", err)
 		}
 
 		notifier.Notify(devTree)


### PR DESCRIPTION
If we do not find any GPU devices, for whatever reason
(such as missing or unparsable /dev or /sys files), do not
error and quit, just return an empty device tree (indicating
we have no devices on this node).
This is preferable as we will then not enter a retry-death-spin
type scenario.

Fixes: #260

Signed-off-by: Graham Whaley <graham.whaley@intel.com>