### PR TITLE
Add interface ContainerPreStarter optionally implemented by device plugins

### DIFF
--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -94,3 +94,10 @@ type PostAllocator interface {
 	// adding annotations consumed by CRI hooks to the responses.
 	PostAllocate(*pluginapi.AllocateResponse) error
 }
+
+// ContainerPreStarter is an optional interface implemented by device plugins.
+type ContainerPreStarter interface {
+	// PreStartContainer  defines device initialization function before container is started.
+	// It might include operations like card reset.
+	PreStartContainer(*pluginapi.PreStartContainerRequest) error
+}

--- a/pkg/deviceplugin/manager_test.go
+++ b/pkg/deviceplugin/manager_test.go
@@ -160,6 +160,10 @@ func (*devicePluginStub) PostAllocate(*pluginapi.AllocateResponse) error {
 	return nil
 }
 
+func (*devicePluginStub) PreStartContainer(*pluginapi.PreStartContainerRequest) error {
+	return nil
+}
+
 func TestHandleUpdate(t *testing.T) {
 	tcases := []struct {
 		name            string
@@ -261,7 +265,7 @@ func TestHandleUpdate(t *testing.T) {
 		mgr := Manager{
 			devicePlugin: &devicePluginStub{},
 			servers:      tt.servers,
-			createServer: func(string, func(*pluginapi.AllocateResponse) error) devicePluginServer {
+			createServer: func(string, func(*pluginapi.AllocateResponse) error, func(*pluginapi.PreStartContainerRequest) error) devicePluginServer {
 				return &serverStub{}
 			},
 		}
@@ -275,7 +279,7 @@ func TestHandleUpdate(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	mgr := NewManager("testnamespace", &devicePluginStub{})
-	mgr.createServer = func(string, func(*pluginapi.AllocateResponse) error) devicePluginServer {
+	mgr.createServer = func(string, func(*pluginapi.AllocateResponse) error, func(*pluginapi.PreStartContainerRequest) error) devicePluginServer {
 		return &serverStub{}
 	}
 	mgr.Run()

--- a/pkg/deviceplugin/server.go
+++ b/pkg/deviceplugin/server.go
@@ -155,7 +155,7 @@ func (srv *server) PreStartContainer(ctx context.Context, rqt *pluginapi.PreStar
 		return new(pluginapi.PreStartContainerResponse), srv.preStartContainer(rqt)
 	}
 
-	return nil, errors.New("PreStartContainer() should not be called")
+	return nil, errors.New("PreStartContainer() should not be called as this device plugin doesn't implement it")
 }
 
 // Serve starts a gRPC server to serve pluginapi.PluginInterfaceServer interface.


### PR DESCRIPTION
Some plugins may require doing some work before a container starts. To allow such functionality the `deviceplugin` package adds one more optional interface - `ContainerPreStarter`. If a device plugin implements it then kubelet always calls `PreStartContainer()` gRPC call.  No other configuration is needed.

## Possible problems
Once the interface is implemented kubelet always calls `PreStartContainer()`. If there's a use case when this additional gRPC call causes a problem then `deviceplugin.Manager` should have something like `RegisterPreStartContainerFunc()`. But I'm not aware of any such use cases.

Also worth noting that one `devieplugin.Manager` may fire up multiple gRPC servers. Should we enable/disable `PreStartContainer` for all of them or need better granularity? I cannot come up with any use case when it could be needed.
