### PR TITLE
RFC: improve gpu logging

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
@@ -94,7 +95,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 
 		dat, err := ioutil.ReadFile(path.Join(dp.sysfsDir, f.Name(), "device/vendor"))
 		if err != nil {
-			fmt.Println("WARNING: Skipping. Can't read vendor file: ", err)
+			klog.Warning("WARNING: Skipping. Can't read vendor file: ", err)
 			continue
 		}
 
@@ -146,6 +147,8 @@ func main() {
 	var sharedDevNum int
 	var debugEnabled bool
 
+	klog.InitFlags(nil)
+
 	flag.IntVar(&sharedDevNum, "shared-dev-num", 1, "number of containers sharing the same GPU device")
 	flag.BoolVar(&debugEnabled, "debug", false, "enable debug output")
 	flag.Parse()
@@ -155,11 +158,11 @@ func main() {
 	}
 
 	if sharedDevNum < 1 {
-		fmt.Println("The number of containers sharing the same GPU must greater than zero")
+		klog.Info("The number of containers sharing the same GPU must greater than zero")
 		os.Exit(1)
 	}
 
-	fmt.Println("GPU device plugin started")
+	klog.Info("GPU device plugin started")
 
 	plugin := newDevicePlugin(sysfsDrmDirectory, devfsDriDirectory, sharedDevNum)
 	manager := dpapi.NewManager(namespace, plugin)

--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -66,10 +66,18 @@ func newDevicePlugin(sysfsDir, devfsDir string, sharedDevNum int) *devicePlugin 
 }
 
 func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
+	var previouslyFound int = -1
+
 	for {
 		devTree, err := dp.scan()
 		if err != nil {
 			return err
+		}
+
+		found := len(devTree)
+		if found != previouslyFound {
+			klog.Info("GPU scan update: devices found: ", found)
+			previouslyFound = found
 		}
 
 		notifier.Notify(devTree)

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 	k8s.io/code-generator v0.17.0
+	k8s.io/klog v1.0.0
 	k8s.io/kubelet v0.0.0
 	k8s.io/kubernetes v1.17.0
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f


### PR DESCRIPTION
RFC, as this is just an idea, and there may be a number of other things that can be improved before this is landed.

Changes basically:
- move to using `klog` for logging, rather than directly hitting `fmt`.
- add a single extra log entry, that is particularly helpful when you have no GPUs to register

queries still pending in my head then:
- Overall, is this a move in the right direction
- I wonder if anything can, or should, be done at the generic device plugin code level?
- does this imply there are extra `klog` things that can be configured (on the command line maybe), that should now be documented for the plugin