### PR TITLE
qat: README: clarify crypto-perf usage

### DIFF
--- a/deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml
+++ b/deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml
@@ -9,11 +9,11 @@ spec:
     imagePullPolicy: IfNotPresent
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "while true; do sleep 300000; done;" ]
-    securityContext:
-      readOnlyRootFilesystem: true
     volumeMounts:
     - mountPath: /dev/hugepages
       name: hugepage
+    - mountPath: /var/run/dpdk
+      name: dpdk-runtime
     resources:
       requests:
         cpu: "3"
@@ -26,11 +26,15 @@ spec:
         qat.intel.com/generic: '4'
         hugepages-2Mi: "128Mi"
     securityContext:
+      readOnlyRootFilesystem: true
       capabilities:
         add:
           ["IPC_LOCK", "SYS_ADMIN"]
   restartPolicy: Never
   volumes:
+  - name: dpdk-runtime
+    emptyDir:
+      medium: Memory
   - name: hugepage
     emptyDir:
       medium: HugePages


### PR DESCRIPTION
crypto-perf instructions were outdated and hand implicit
assumptions about the environment. More specifically:

Clear Linux builds DPDK libraries as shared so for the
compress and crypto test applications to run, the memory and
QAT PMD libraries must be explicitly preloaded using '-d' parameter.

Also, the test-crypto1 and test-compress1 deployments expect the
cluster is configured with CPU Manager's static policy.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>