### PR TITLE
gpu_plugin: add kustomizations

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -84,10 +84,22 @@ Successfully tagged intel/intel-gpu-plugin:devel
 
 ### Deploy plugin DaemonSet
 
-You can then use the example DaemonSet YAML file provided to deploy the plugin.
+You can then use the [example DaemonSet YAML](../../deployments/gpu_plugin/base/intel-gpu-plugin.yaml)
+file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
 
 ```bash
-$ kubectl create -f ./deployments/gpu_plugin/gpu_plugin.yaml
+$ kubectl apply -k deployments/gpu_plugin
+daemonset.apps/intel-gpu-plugin created
+```
+
+Alternatively, if your cluster runs
+[Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery),
+you can deploy the device plugin only on nodes with Intel GPU.
+The [nfd_labeled_nodes](../../deployments/gpu_plugin/overlays/nfd_labeled_nodes/)
+kustomization adds the nodeSelector to the DaemonSet:
+
+```bash
+$ kubectl apply -k deployments/gpu_plugin/overlays/nfd_labeled_nodes
 daemonset.apps/intel-gpu-plugin created
 ```
 

--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: intel-gpu-plugin
-  namespace: kube-system
   labels:
     app: intel-gpu-plugin
 spec:

--- a/deployments/gpu_plugin/base/kustomization.yaml
+++ b/deployments/gpu_plugin/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - intel-gpu-plugin.yaml

--- a/deployments/gpu_plugin/kustomization.yaml
+++ b/deployments/gpu_plugin/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - base

--- a/deployments/gpu_plugin/overlays/namespace_kube-system/add-namespace-kube-system.yaml
+++ b/deployments/gpu_plugin/overlays/namespace_kube-system/add-namespace-kube-system.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+  namespace: kube-system

--- a/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../base
+patches:
+  - add-namespace-kube-system.yaml

--- a/deployments/gpu_plugin/overlays/nfd_labeled_nodes/add-nodeselector-intel-gpu.yaml
+++ b/deployments/gpu_plugin/overlays/nfd_labeled_nodes/add-nodeselector-intel-gpu.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+spec:
+  template:
+    spec:
+      nodeSelector:
+        feature.node.kubernetes.io/pci-0300_8086.present: "true"

--- a/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../base
+patches:
+  - add-nodeselector-intel-gpu.yaml


### PR DESCRIPTION
- Default deployment: `kubectl apply -k deployments/gpu_plugin`
- Variant: deploy only on nodes with Intel GPU label by NFD
  `kubectl apply -k deployments/gpu_plugin/overlays/nfd_labeled_nodes`
- GPU plugin README updated.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>