### PR TITLE
READMEs: use git clone to get the code

### DIFF
--- a/cmd/fpga_admissionwebhook/README.md
+++ b/cmd/fpga_admissionwebhook/README.md
@@ -59,7 +59,8 @@ controller webhook plugin.
 ## Getting the source code
 
 ```bash
-$ go get -d -u github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Deploying via the script
@@ -86,7 +87,7 @@ The script has some pre-requisite tools that must be installed on your system:
 Before the webhook can be deployed, its container image needs to be built:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make intel-fpga-admissionwebhook
 ...
 Successfully tagged intel/intel-fpga-admissionwebhook:devel
@@ -98,7 +99,7 @@ To deploy the webhook, run the [`scripts/webhook-deploy.sh`](../../scripts/webho
  script:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ ./scripts/webhook-deploy.sh
 Create secret including signed key/cert pair for the webhook
 ...

--- a/cmd/fpga_crihook/README.md
+++ b/cmd/fpga_crihook/README.md
@@ -48,13 +48,14 @@ prestart hook.
 ## Getting the source code
 
 ```bash
-$ go get -d -u github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Building the image
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make intel-fpga-initcontainer
 ...
 Successfully tagged intel/intel-fpga-initcontainer:devel

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -161,7 +161,8 @@ To obtain the YAML files used for deployment, or to obtain the source tree if yo
 do a hand-deployment or build your own image, you will require access to the source code:
 
 ```bash
-$ go get -d -u github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Verify node kubelet config
@@ -286,7 +287,7 @@ When deploying by hand, you only need to build the plugin itself, and not the wh
 container image:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make fpga_plugin
 ```
 
@@ -295,7 +296,7 @@ $ make fpga_plugin
 ```bash
 $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
 $ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode af -kubeconfig $KUBE_CONF
+$ sudo -E $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode af -kubeconfig $KUBE_CONF
 FPGA device plugin started in af mode
 device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-af-f7df405cbd7acf7222f144b0b93acd18.sock
 device-plugin registered
@@ -310,7 +311,7 @@ Furthermore, the deployments `securityContext` must be configured with appropria
 ```bash
 $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
 $ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode region -kubeconfig $KUBE_CONF
+$ sudo -E $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/fpga_plugin/fpga_plugin -mode region -kubeconfig $KUBE_CONF
 FPGA device plugin started in region mode
 device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-region-ce48969398f05f33946d560708be108a.sock
 device-plugin registered

--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -48,7 +48,8 @@ Examples are provided showing how to deploy the plugin either using a DaemonSet 
 > that meets the minimum required version.
 
 ```bash
-$ go get -d -u github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Verify node kubelet config
@@ -76,7 +77,7 @@ The image build tool can be changed from the default `docker` by setting the `BU
 to the [`Makefile`](Makefile).
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make intel-gpu-plugin
 ...
 Successfully tagged intel/intel-gpu-plugin:devel
@@ -117,7 +118,7 @@ In this case, you do not need to build the complete container image, and can bui
 First we build the plugin:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make gpu_plugin
 ```
 
@@ -126,7 +127,7 @@ $ make gpu_plugin
 Now we can run the plugin directly on the node:
 
 ```bash
-$ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/gpu_plugin/gpu_plugin
+$ sudo $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/gpu_plugin/gpu_plugin
 device-plugin start server at: /var/lib/kubelet/device-plugins/gpu.intel.com-i915.sock
 device-plugin registered
 ```
@@ -158,7 +159,7 @@ We can test the plugin is working by deploying the provided example OpenCL image
 1. Create a job running unit tests off the local Docker image:
 
     ```bash
-    $ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+    $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
     $ kubectl apply -f demo/intelgpu-job.yaml
     job.batch/intelgpu-demo-job created
     ```

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -127,7 +127,8 @@ The demonstrations have their own requirements, listed in their own specific sec
 ## Getting the source code
 
 ```bash
-$ go get -d -u https://github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Verify node kubelet config
@@ -154,7 +155,7 @@ with the tag `devel`. The image build tool can be changed from the default docke
 `BUILDER` argument to the [Makefile](../../Makefile).
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make intel-qat-plugin
 ...
 Successfully tagged intel/intel-qat-plugin:devel
@@ -171,7 +172,7 @@ Deploying the plugin involves first the deployment of a
 
 There is a kustomization for deploying both:
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ kubectl apply -k deployments/qat_plugin
 ```
 and an alternative kustomization for deploying the plugin in the debug mode:
@@ -211,7 +212,7 @@ In this case, you do not need to build the complete container image, and can bui
 ### Build QAT device plugin
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make qat_plugin
 ```
 
@@ -221,7 +222,7 @@ Deploy the plugin on a node by running it as `root`. The below is just an exampl
 paramaters as necessary for your setup:
 
 ```bash
-$ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/qat_plugin/qat_plugin \
+$ sudo $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/qat_plugin/qat_plugin \
 -dpdk-driver igb_uio -kernel-vf-drivers dh895xccvf -max-num-devices 10 -debug
 QAT device plugin started
 Discovered Devices below:
@@ -269,7 +270,7 @@ The demo uses a container image. You can either use the
 To build the DPDK demo image:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/demo
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/demo
 $ ./build-image.sh crypto-perf
 ...
 Successfully tagged crypto-perf:devel
@@ -283,7 +284,7 @@ For example, `qat.intel.com/generic: <number of devices>` for a container reques
 For a DPDK-based workload, you may need to add hugepage request and limit.
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ kubectl apply -k deployments/qat_dpdk_app/base/
 $ kubectl get pods
   NAME                     READY     STATUS    RESTARTS   AGE
@@ -318,7 +319,7 @@ It is also possible to deploy and run `crypto-perf` using the following
 `kustomize` overlays:
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ kubectl apply -k deployments/qat_dpdk_app/test-crypto1
 $ kubectl apply -k deployments/qat_dpdk_app/test-compress1
 $ kubectl logs qat-dpdk-test-crypto-perf-tc1

--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -47,7 +47,8 @@ Examples are provided showing how to deploy the plugin either using a DaemonSet 
 > that meets the minimum required version.
 
 ```bash
-$ go get -d -u github.com/intel/intel-device-plugins-for-kubernetes
+$ mkdir -p $(go env GOPATH)/src/github.com/intel
+$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
 ## Verify node kubelet config
@@ -75,7 +76,7 @@ The image build tool can be changed from the default `docker` by setting the `BU
 to the [`Makefile`](Makefile).
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make intel-vpu-plugin
 ...
 Successfully tagged intel/intel-vpu-plugin:devel
@@ -106,7 +107,7 @@ First we build the plugin:
 > **Note:** this vpu plugin has dependency of libusb-1.0-0-dev, you need install it before building vpu plugin
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make vpu_plugin
 ```
 
@@ -115,7 +116,7 @@ $ make vpu_plugin
 Now we can run the plugin directly on the node:
 
 ```bash
-$ sudo $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/vpu_plugin/vpu_plugin
+$ sudo $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes/cmd/vpu_plugin/vpu_plugin
 VPU device plugin started
 ```
 
@@ -146,7 +147,7 @@ Successfully tagged ubuntu-demo-openvino:devel
 ### Create a job running unit tests off the local Docker image
 
 ```bash
-$ cd $GOPATH/src/github.com/intel/intel-device-plugins-for-kubernetes
+$ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ kubectl apply -f demo/intelvpu-job.yaml
 job.batch/intelvpu-demo-job created
 ```


### PR DESCRIPTION
go get'ing does not work due to our k8s.io/kubernetes dependency
so guide users to use git clone to get the code.

Fixes: #290

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>