### PR TITLE
vpu_plugin: add kustomizations

### DIFF
--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -14,6 +14,9 @@
         * [Run the plugin as administrator](#run-the-plugin-as-administrator)
     * [Verify plugin registration](#verify-plugin-registration)
     * [Testing the plugin](#testing-the-plugin)
+        * [Build a Docker image with an classification example](#build-a-docker-image-with-an-classification-example)
+        * [Create a job running unit tests off the local Docker image](#create-a-job-running-unit-tests-off-the-local-docker-image)
+        * [Review the job logs](#review-the-job-logs)
 
 # Introduction
 
@@ -84,10 +87,11 @@ Successfully tagged intel/intel-vpu-plugin:devel
 
 ### Deploy plugin DaemonSet
 
-You can then use the example DaemonSet YAML file provided to deploy the plugin.
+You can then use the [example DaemonSet YAML](../../deployments/vpu_plugin/base/intel-vpu-plugin.yaml)
+file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
 
 ```bash
-$ kubectl create -f ./deployments/vpu_plugin/vpu_plugin.yaml
+$ kubectl apply -k deployments/vpu_plugin
 daemonset.apps/intel-vpu-plugin created
 ```
 
@@ -152,7 +156,7 @@ $ kubectl apply -f demo/intelvpu-job.yaml
 job.batch/intelvpu-demo-job created
 ```
 
-### Review the job's logs
+### Review the job logs
 
 ```bash
 $ kubectl get pods | fgrep intelvpu

--- a/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
+++ b/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: intel-vpu-plugin
-  namespace: kube-system
   labels:
     app: intel-vpu-plugin
 spec:
@@ -21,17 +20,20 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel-vpu-plugin:devel
+        image: intel/intel-vpu-plugin:devel
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:
         - name: devfs
           mountPath: /dev/bus/usb
+          readOnly: true
         - name: sysfs1
           mountPath: /sys/bus/usb
+          readOnly: true
         - name: sysfs2
           mountPath: /sys/devices
+          readOnly: true
         - name: tmpfs
           mountPath: /var/tmp
         - name: kubeletsockets

--- a/deployments/vpu_plugin/base/kustomization.yaml
+++ b/deployments/vpu_plugin/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - intel-vpu-plugin.yaml

--- a/deployments/vpu_plugin/kustomization.yaml
+++ b/deployments/vpu_plugin/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - base

--- a/deployments/vpu_plugin/overlays/namespace_kube-system/add-namespace-kube-system.yaml
+++ b/deployments/vpu_plugin/overlays/namespace_kube-system/add-namespace-kube-system.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-vpu-plugin
+  namespace: kube-system

--- a/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../base
+patches:
+  - add-namespace-kube-system.yaml


### PR DESCRIPTION
- Default deployment: `kubectl apply -k deployments/vpu_plugin`
- Default deployment does not specify namespace anymore
  (was: `kube-system`)
- Variant: deploy to `kube-system` instead of user-defined namespace
  (or `default`)
  `kubectl apply -k deployments/vpu_plugin/overlays/namespace_kube-system`
- VPU plugin README updated.
- Change volume mounts to readonly when possible

Signed-off-by: Alek Du <alek.du@intel.com>