### PR TITLE
FPGA kustomization: fix signing certificate

### DIFF
--- a/scripts/fpga-plugin-prepare-for-kustomization.sh
+++ b/scripts/fpga-plugin-prepare-for-kustomization.sh
@@ -19,7 +19,7 @@ kustomize_secret_dir="${srcroot}/deployments/fpga_admissionwebhook/base/${secret
 mkdir -p "${kustomize_secret_dir}"
 
 # Create signed cert files to kustomize_secret_dir
-${script_dir}/webhook-create-signed-cert.sh --output-dir ${kustomize_secret_dir} --service=$service && {
+${script_dir}/webhook-create-signed-cert.sh --output-dir ${kustomize_secret_dir} --service $service && {
     echo ""
     echo created for kustomization:
     echo - "${kustomize_secret_dir}"


### PR DESCRIPTION
The certificate got signed for wrong service name (fallback default
"webhook-svc") due to incorrectly passed parameter. This showed as
    "http: TLS handshake error from ... tls: bad certificate"
error in webhook pod logs.

Fixes: #303

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>