### PR TITLE
qat: mount VFIO devices for topology hints to work

### DIFF
--- a/deployments/qat_plugin/base/intel-qat-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin.yaml
@@ -42,11 +42,17 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["-dpdk-driver", "$(DPDK_DRIVER)", "-kernel-vf-drivers", "$(KERNEL_VF_DRIVERS)", "-max-num-devices", "$(MAX_NUM_DEVICES)", "-debug", "$(DEBUG)"]
         volumeMounts:
+        - name: devdir
+          mountPath: /dev/vfio
+          readOnly: true
         - name: pcidir
           mountPath: /sys/bus/pci
         - name: kubeletsockets
           mountPath: /var/lib/kubelet/device-plugins
       volumes:
+      - name: devdir
+        hostPath:
+          path: /dev/vfio
       - name: pcidir
         hostPath:
           path: /sys/bus/pci

--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -15,6 +15,8 @@
 package deviceplugin
 
 import (
+	"fmt"
+
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/topology"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
@@ -44,6 +46,8 @@ func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginap
 	topologyInfo, err := topology.GetTopologyInfo(devPaths)
 	if err == nil {
 		deviceInfo.topology = topologyInfo
+	} else {
+		fmt.Printf("WARNING: GetTopologyInfo: %v\n", err)
 	}
 
 	return deviceInfo


### PR DESCRIPTION
Previously, /dev/vfio/xx devices were just arbitrary strings and the
plugin did not need the devices for anything. After adding the checks
for topology hints, we need to read the devices attached to those so
the device nodes must be bind mounted in the plugin container.

Moreover, be more verbose about any errors coming from the topology code.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>