### PR TITLE
qat: kerneldrv: fix device registration when run in VMs

### DIFF
--- a/cmd/qat_plugin/kerneldrv/kerneldrv.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv.go
@@ -153,14 +153,14 @@ func (dp *DevicePlugin) getOnlineDevices(iommuOn bool) ([]device, error) {
 		}
 
 		// "Cannot use PF with IOMMU enabled"
-		if iommuOn != strings.HasSuffix(matches[1], "vf") {
+		if iommuOn && !strings.HasSuffix(matches[1], "vf") {
 			continue
 		}
 
 		devices = append(devices, device{
 			id:      fmt.Sprintf("dev%s", matches[2]),
 			devtype: matches[1],
-			bsf:     matches[4],
+			bsf:     fmt.Sprintf("%s%s", matches[3], matches[4]),
 		})
 		debug.Print("New online device", devices[len(devices)-1])
 	}
@@ -169,7 +169,7 @@ func (dp *DevicePlugin) getOnlineDevices(iommuOn bool) ([]device, error) {
 }
 
 func getUIODeviceListPath(sysfs, devtype, bsf string) string {
-	return filepath.Join(sysfs, "bus", "pci", "drivers", devtype, "0000:"+bsf, "uio")
+	return filepath.Join(sysfs, "bus", "pci", "drivers", devtype, bsf, "uio")
 }
 
 func getUIODevices(sysfs, devtype, bsf string) ([]string, error) {


### PR DESCRIPTION
Kerneldrv checks for available devices based on adf_ctl output.
We only accepted two cases: PFs if IOMMU is off and VFs if IOMMU
is on.

The right check is to only skip PFs if IOMMU is on and allow other
cases. This fixes two scenarios: when run in VMs, we accept VFs
regardless of (v)IOMMU presence.

Moreover, do not hard code domain '0000:' because it is not the
case always.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>