### PR TITLE
vpu: mount myd_ion device for topology hints to work

### DIFF
--- a/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
+++ b/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
@@ -25,6 +25,9 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:
+        - name: devion
+          mountPath: /dev/ion
+          readOnly: true
         - name: devfs
           mountPath: /dev/bus/usb
           readOnly: true
@@ -39,6 +42,10 @@ spec:
         - name: kubeletsockets
           mountPath: /var/lib/kubelet/device-plugins
       volumes:
+      - name: devion
+        hostPath:
+           path: /dev/ion
+           type: CharDevice
       - name: devfs
         hostPath:
           path: /dev/bus/usb


### PR DESCRIPTION
 vpu: mount myd_ion device for topology hints to work

    Previously, /dev/ion device was just arbitrary string and the plugin
    did not need the device for anything. After adding the checks for
    topology hints, the device node must be bind mounted in the plugin
    container.

    Signed-off-by: Alek Du <alek.du@intel.com>
