### PR TITLE
klog: Add klog logging to framework and qat plugins

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -62,3 +62,23 @@ Optionally, your device plugin may also implement the
 before they are sent to `kubelet`. To see an example, refer to the FPGA
 plugin which implements this interface to annotate its responses.
 
+Logging
+-------
+
+The framework uses [`klog`](https://github.com/kubernetes/klog) as its logging
+framework. It is encouraged for plugins to also use `klog` to maintain uniformity
+in the logs and command line options.
+
+The framework initialises `klog`, so further calls to `klog.InitFlags()` by
+plugins should not be necessary. This does add a number of log configuration
+options to your plugin, which can be viewed with the `-h` command line option of your
+plugin.
+
+The framework tries to adhere to the Kubernetes
+[Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md). The advise is to use the `V()` levels for `Info()` calls, as calling `Info()`
+with no set level will make configuration and filtering of logging via the command
+line more difficult.
+
+The default is to not log `Info()` calls. This can be changed using the plugin command
+line `-v` parameter. The additional annotations prepended to log lines by 'klog' can be disabled
+with the `-skip_headers` option.

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -50,11 +50,13 @@ The QAT plugin can take a number of command line arguments, summarised in the fo
 
 | Flag | Argument | Meaning |
 |:---- |:-------- |:------- |
-| -debug | | enable debug output
 | -dpdk-driver | string | DPDK Device driver for configuring the QAT device (default: `vfio-pci`) |
 | -kernel-vf-drivers | string | Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC,C62x,C3xxx and D15xx (default: `dh895xccvf,c6xxvf,c3xxxvf,d15xxvf`) |
 | -max-num-devices | int | maximum number of QAT devices to be provided to the QuickAssist device plugin (default: `32`) |
 | -mode | string | plugin mode which can be either `dpdk` or `kernel` (default: `dpdk`) |
+
+The plugin also accepts a number of other arguments related to logging. Please use the `-h` option to see
+the complete list of logging related options.
 
 The example [DaemonSet YAML](../../deployments/qat_plugin/base/intel-qat-plugin.yaml) passes a number of these
 arguments, and takes its default values from the
@@ -63,7 +65,6 @@ table summarises the defaults:
 
 | Argument | Variable | Default setting | Explanation |
 |:-------- |:-------- |:--------------- |:----------- |
-| -debug | `$DEBUG` | false | Debug is disabled by default |
 | -dpdk-driver | `$DPDK_DRIVER` | vfio-pci | A more robust and secure choice than the `igb_uio` alternative |
 | -kernel-vf-drivers | `$KERNEL_VF_DRIVERS` | dh895xccvf,c6xxvf,c3xxxvf,d15xxvf | Modify to suit your hardware setup |
 | -max-num-devices | `$MAX_NUM_DEVICES` | 32 | Modify to suit your hardware setup if necessary |
@@ -75,7 +76,7 @@ For more details on the available options to the `-kernel-vf-drivers` option, se
 vf drivers available in the [Linux Kernel](https://github.com/torvalds/linux/tree/master/drivers/crypto/qat).
 
 If the `-mode` parameter is set to `kerneldrv`, no other parameter documented above are valid,
-except `-debug` which is global for both modes.
+except the `klog` logging related parameters.
 `kerneldrv` mode implements resource allocation based on system configured [logical instances][7].
 
 > **Note**: `kerneldrv` mode is excluded by default from all builds (including those hosted on the Docker hub),

--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
@@ -117,7 +118,7 @@ func (dp *DevicePlugin) getDpdkDevice(id string) (string, error) {
 			return "", errors.WithStack(err)
 		}
 		s := path.Base(group)
-		fmt.Printf("The vfio device group detected is %v\n", s)
+		klog.V(1).Infof("The vfio device group detected is %v", s)
 		return s, nil
 	}
 
@@ -129,7 +130,7 @@ func (dp *DevicePlugin) getDpdkDeviceSpecs(id string) ([]pluginapi.DeviceSpec, e
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("%s device: corresponding DPDK device detected is %s\n", id, dpdkDeviceName)
+	klog.V(1).Infof("%s device: corresponding DPDK device detected is %s", id, dpdkDeviceName)
 
 	switch dp.dpdkDriver {
 	// TODO: case "pci-generic" and "kernel":
@@ -264,7 +265,7 @@ func (dp *DevicePlugin) scan() (dpapi.DeviceTree, error) {
 	for _, driver := range append([]string{dp.dpdkDriver}, dp.kernelVfDrivers...) {
 		files, err := ioutil.ReadDir(path.Join(dp.pciDriverDir, driver))
 		if err != nil {
-			fmt.Printf("Can't read sysfs for driver as Driver %s is not available: Skipping\n", driver)
+			klog.Warningf("Can't read sysfs for driver as Driver %s is not available: Skipping", driver)
 			continue
 		}
 

--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
@@ -15,6 +15,7 @@
 package dpdkdrv
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -24,12 +25,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") //Enable debug output
 }
 
 func createTestFiles(prefix string, dirs []string, files map[string][]byte, symlinks map[string]string) error {

--- a/cmd/qat_plugin/kerneldrv/kerneldrv.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv.go
@@ -27,10 +27,10 @@ import (
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	utilsexec "k8s.io/utils/exec"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
 )
 
@@ -162,7 +162,7 @@ func (dp *DevicePlugin) getOnlineDevices(iommuOn bool) ([]device, error) {
 			devtype: matches[1],
 			bsf:     matches[4],
 		})
-		debug.Print("New online device", devices[len(devices)-1])
+		klog.V(4).Info("New online device", devices[len(devices)-1])
 	}
 
 	return devices, nil
@@ -174,7 +174,7 @@ func getUIODeviceListPath(sysfs, devtype, bsf string) string {
 
 func getUIODevices(sysfs, devtype, bsf string) ([]string, error) {
 	sysfsDir := getUIODeviceListPath(sysfs, devtype, bsf)
-	debug.Print("Path to uio devices:", sysfsDir)
+	klog.V(4).Info("Path to uio devices:", sysfsDir)
 
 	devFiles, err := ioutil.ReadDir(sysfsDir)
 	if err != nil {
@@ -182,7 +182,7 @@ func getUIODevices(sysfs, devtype, bsf string) ([]string, error) {
 	}
 
 	if len(devFiles) == 0 {
-		fmt.Println("WARNING: no uio devices listed in", sysfsDir)
+		klog.Warning("no uio devices listed in", sysfsDir)
 	}
 
 	devices := []string{}
@@ -208,7 +208,7 @@ func (dp *DevicePlugin) parseConfigs(devices []device) (map[string]section, erro
 			if section.Name() == "GENERAL" || section.Name() == "KERNEL" || section.Name() == "KERNEL_QAT" || section.Name() == ini.DEFAULT_SECTION {
 				continue
 			}
-			debug.Print(section.Name())
+			klog.V(4).Info(section.Name())
 			if err := drvConfig.update(dev.id, section); err != nil {
 				return nil, err
 			}

--- a/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
@@ -18,6 +18,7 @@ package kerneldrv
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -27,11 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 const (
@@ -60,7 +60,7 @@ There is 7 QAT acceleration device(s) in the system:
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") //Enable debug output
 }
 
 func TestGetOnlineDevices(t *testing.T) {
@@ -386,6 +386,6 @@ func TestPostAllocate(t *testing.T) {
 		if !tc.expectedErr && err != nil {
 			t.Errorf("Test case '%s': Unexpected error: %+v", tc.name, err)
 		}
-		debug.Print(response)
+		klog.V(4).Info(response)
 	}
 }

--- a/cmd/qat_plugin/kerneldrv/stub.go
+++ b/cmd/qat_plugin/kerneldrv/stub.go
@@ -17,15 +17,15 @@
 package kerneldrv
 
 import (
-	"fmt"
 	"os"
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
+	"k8s.io/klog"
 )
 
 // NewDevicePlugin creates a non-functional stub for kernel mode device plugins.
 func NewDevicePlugin() dpapi.Scanner {
-	fmt.Println("kernel mode is not supported in this build. Use 'kerneldrv' build tag to have this mode enabled. Exiting...")
+	klog.Errorf("kernel mode is not supported in this build. Use 'kerneldrv' build tag to have this mode enabled. Exiting...")
 	os.Exit(1)
 
 	return nil

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/intel/intel-device-plugins-for-kubernetes/cmd/qat_plugin/dpdkdrv"
 	"github.com/intel/intel-device-plugins-for-kubernetes/cmd/qat_plugin/kerneldrv"
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
+	"k8s.io/klog"
 )
 
 const (
@@ -35,17 +35,12 @@ func main() {
 	var plugin deviceplugin.Scanner
 	var err error
 
-	debugEnabled := flag.Bool("debug", false, "enable debug output")
 	mode := flag.String("mode", "dpdk", "plugin mode which can be either dpdk (default) or kernel")
 
 	dpdkDriver := flag.String("dpdk-driver", "vfio-pci", "DPDK Device driver for configuring the QAT device")
 	kernelVfDrivers := flag.String("kernel-vf-drivers", "dh895xccvf,c6xxvf,c3xxxvf,d15xxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC,C62x,C3xxx and D15xx")
 	maxNumDevices := flag.Int("max-num-devices", 32, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
 	flag.Parse()
-
-	if *debugEnabled {
-		debug.Activate()
-	}
 
 	switch *mode {
 	case "dpdk":
@@ -60,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("QAT device plugin started in '%s' mode\n", *mode)
+	klog.V(1).Infof("QAT device plugin started in '%s' mode", *mode)
 	manager := deviceplugin.NewManager(namespace, plugin)
 	manager.Run()
 }

--- a/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
@@ -6,4 +6,4 @@ data:
   DPDK_DRIVER: "vfio-pci"
   KERNEL_VF_DRIVERS: "dh895xccvf,c6xxvf,c3xxxvf,d15xxvf"
   MAX_NUM_DEVICES: "32"
-  DEBUG: "false"
+  VERBOSITY: "0"

--- a/deployments/qat_plugin/base/intel-qat-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin.yaml
@@ -34,13 +34,14 @@ spec:
             configMapKeyRef:
               name: intel-qat-plugin-config
               key: MAX_NUM_DEVICES
-        - name: DEBUG
+        - name: VERBOSITY
           valueFrom:
             configMapKeyRef:
               name: intel-qat-plugin-config
-              key: DEBUG
+              key: VERBOSITY
+
         imagePullPolicy: IfNotPresent
-        args: ["-dpdk-driver", "$(DPDK_DRIVER)", "-kernel-vf-drivers", "$(KERNEL_VF_DRIVERS)", "-max-num-devices", "$(MAX_NUM_DEVICES)", "-debug", "$(DEBUG)"]
+        args: ["-dpdk-driver", "$(DPDK_DRIVER)", "-kernel-vf-drivers", "$(KERNEL_VF_DRIVERS)", "-max-num-devices", "$(MAX_NUM_DEVICES)", "-v", "$(VERBOSITY)"]
         volumeMounts:
         - name: devdir
           mountPath: /dev/vfio

--- a/deployments/qat_plugin/overlays/debug/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/debug/kustomization.yaml
@@ -5,4 +5,4 @@ configMapGenerator:
 - name: intel-qat-plugin-config
   behavior: merge
   literals:
-    - DEBUG="true"
+    - VERBOSITY="4"

--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -15,9 +15,8 @@
 package deviceplugin
 
 import (
-	"fmt"
-
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/topology"
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -28,6 +27,10 @@ type DeviceInfo struct {
 	mounts   []pluginapi.Mount
 	envs     map[string]string
 	topology *pluginapi.TopologyInfo
+}
+
+func init() {
+	klog.InitFlags(nil)
 }
 
 // NewDeviceInfo makes DeviceInfo struct and adds topology information to it
@@ -47,7 +50,7 @@ func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginap
 	if err == nil {
 		deviceInfo.topology = topologyInfo
 	} else {
-		fmt.Printf("WARNING: GetTopologyInfo: %v\n", err)
+		klog.Warningf("GetTopologyInfo: %v", err)
 	}
 
 	return deviceInfo

--- a/pkg/deviceplugin/manager.go
+++ b/pkg/deviceplugin/manager.go
@@ -15,13 +15,11 @@
 package deviceplugin
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 // updateInfo contains info for added, updated and deleted devices.
@@ -95,7 +93,7 @@ func (m *Manager) Run() {
 	go func() {
 		err := m.devicePlugin.Scan(newNotifier(updatesCh))
 		if err != nil {
-			fmt.Printf("Device scan failed: %+v\n", err)
+			klog.Errorf("Device scan failed: %+v", err)
 			os.Exit(1)
 		}
 		close(updatesCh)
@@ -107,7 +105,7 @@ func (m *Manager) Run() {
 }
 
 func (m *Manager) handleUpdate(update updateInfo) {
-	debug.Print("Received dev updates:", update)
+	klog.V(4).Info("Received dev updates:", update)
 	for devType, devices := range update.Added {
 		var postAllocate func(*pluginapi.AllocateResponse) error
 
@@ -119,7 +117,7 @@ func (m *Manager) handleUpdate(update updateInfo) {
 		go func(dt string) {
 			err := m.servers[dt].Serve(m.namespace)
 			if err != nil {
-				fmt.Printf("Failed to serve %s/%s: %+v\n", m.namespace, dt, err)
+				klog.Errorf("Failed to serve %s/%s: %+v", m.namespace, dt, err)
 				os.Exit(1)
 			}
 		}(devType)

--- a/pkg/deviceplugin/manager_test.go
+++ b/pkg/deviceplugin/manager_test.go
@@ -15,15 +15,14 @@
 package deviceplugin
 
 import (
+	"flag"
 	"testing"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") //Enable debug output
 }
 
 func TestNotify(t *testing.T) {

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -16,6 +16,7 @@ package deviceplugin
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -28,9 +29,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	"github.com/pkg/errors"
 )
 
@@ -50,7 +51,7 @@ type kubeletStub struct {
 }
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") //Enable debug output
 }
 
 // newKubeletStub returns an initialized kubeletStub for testing purpose.
@@ -190,7 +191,7 @@ func TestSetupAndServe(t *testing.T) {
 				break
 			}
 		}
-		fmt.Println("No plugin socket. Waiting...")
+		klog.V(1).Info("No plugin socket. Waiting...")
 		time.Sleep(1 * time.Second)
 	}
 	conn, err = grpc.Dial(pluginSocket, grpc.WithInsecure(),
@@ -368,11 +369,11 @@ type listAndWatchServerStub struct {
 func (s *listAndWatchServerStub) Send(resp *pluginapi.ListAndWatchResponse) error {
 	s.sendCounter = s.sendCounter + 1
 	if s.generateErr == s.sendCounter {
-		fmt.Println("listAndWatchServerStub::Send returns error")
+		klog.V(4).Info("listAndWatchServerStub::Send returns error")
 		return fmt.Errorf("Fake error")
 	}
 
-	fmt.Println("listAndWatchServerStub::Send", resp.Devices)
+	klog.V(4).Info("listAndWatchServerStub::Send", resp.Devices)
 	s.cdata <- resp.Devices
 	return nil
 }


### PR DESCRIPTION
Unify our logging across the repo to use klog.
This brings with it extra annotations to the log entries, as well as a bunch of command line arguments to the plugins to allow control of how and where to log.

Related-To: #323