### PR TITLE
images: make os-core install implicit

### DIFF
--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -24,7 +24,6 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core,rsync \
+    --bundles=rsync \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -24,7 +24,6 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -24,7 +24,6 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core$(test -z "${TAGS_KERNELDRV}" || echo ",libstdcpp") \
+    $(test -z "${TAGS_KERNELDRV}" || echo "--bundles=libstdcpp") \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -17,7 +17,6 @@ RUN mkdir /install_root \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 

--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir /install_root && \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root \
     --statedir /swupd-state \
-    --bundles=os-core,dpdk \
+    --bundles=dpdk \
     --no-boot-update && \
     rm -rf /install_root/var/lib/swupd/*
 

--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -17,8 +17,6 @@ RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION} && \
 # Fetch dependencies and source code
 ARG OPAE_RELEASE=1.4.0-1
 
-# workaround for a swupd failure discussed in https://github.com/clearlinux/distribution/issues/831
-RUN ldconfig
 RUN mkdir -p /usr/src/opae && \
     cd /usr/src/opae && \
     wget https://github.com/OPAE/opae-sdk/archive/${OPAE_RELEASE}.tar.gz && \
@@ -38,7 +36,8 @@ RUN mkdir /install_root \
     && swupd os-install  \
     ${CLEAR_LINUX_VERSION} \
     --path /install_root --statedir /swupd-state \
-    --bundles=os-core,libstdcpp --no-boot-update \
+    --bundles=libstdcpp \
+    --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
 # Minimal result image


### PR DESCRIPTION
swupd os-install fails (clearlinux/swupd-client/issues/1369) if
"--bundles=os-core" is used. It was confirmed that os-core is
always installed first regardless of what other --bundles are
specified.

To get the builds working, we move to rely on that implicit os-core
install.

Fixes: #330

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>