### PR TITLE
build: pass extra builder arguments from users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PODMAN ?= podman
 
 BUILDTAGS ?= ""
 BUILDER ?= "docker"
+EXTRA_BUILD_ARGS ?= ""
 
 WEBHOOK_IMAGE_FILE = intel-fpga-admissionwebhook-devel.tgz
 
@@ -83,7 +84,7 @@ endif
 images = $(shell ls build/docker/*.Dockerfile | sed 's/.*\/\(.\+\)\.Dockerfile/\1/')
 
 $(images):
-	@build/docker/build-image.sh $(REG)$@ $(BUILDER)
+	@build/docker/build-image.sh $(REG)$@ $(BUILDER) $(EXTRA_BUILD_ARGS)
 
 images: $(images)
 

--- a/build/docker/build-image.sh
+++ b/build/docker/build-image.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -e
 
 IMG=$1
-BUILDER=$2
 
 DOCKERFILE="$(dirname $0)/$(basename ${IMG}).Dockerfile"
 
@@ -15,12 +14,19 @@ if [ ! -e "${DOCKERFILE}" ]; then
     exit 1
 fi
 
+shift
+
+if [ "$1" = 'docker' -o "$1" = 'buildah' ]; then
+    BUILDER=$1
+    shift
+fi
+
 TAG=${TAG:-devel}
 
-BUILD_ARGS=
+BUILD_ARGS=$@
 if [ -d $(dirname $0)/../../vendor ] ; then
     echo "Building images with vendored code"
-    BUILD_ARGS="--build-arg DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes --build-arg GO111MODULE=off"
+    BUILD_ARGS="${BUILD_ARGS} --build-arg DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes --build-arg GO111MODULE=off"
 fi
 
 if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then


### PR DESCRIPTION
Users had no options to specify extra builder arguments to $BUILDER.

With this patch it's possible, e.g., to build QAT plugin with kernel
mode support:

make intel-qat-plugin EXTRA_BUILD_ARGS="--build-arg TAGS_KERNELDRV=kernel

Fixes: #234

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>