### PR TITLE
fix image build failure

### DIFF
--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -12,6 +12,7 @@ ARG CLEAR_LINUX_VERSION=
 
 RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
 RUN swupd bundle-add devpkg-libusb
+RUN ldconfig
 RUN mkdir /install_root \
     && swupd os-install \
     ${CLEAR_LINUX_VERSION} \


### PR DESCRIPTION
Running ldconfig seems to fix last build issue(vpu plugin image):
```
...
# pkg-config --cflags  -- libusb-1.0
pkg-config: error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file: No such file or directory
...
##[error]Process completed with exit code 2.
```

This blocks a lot of pending PRs, so please review & merge. Thanks.

Fixes #336 
