### PR TITLE
gpu: move to using klog

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8s.io/klog"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
 )
 
@@ -65,10 +65,18 @@ func newDevicePlugin(sysfsDir, devfsDir string, sharedDevNum int) *devicePlugin 
 }
 
 func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
+	var previouslyFound int = -1
+
 	for {
 		devTree, err := dp.scan()
 		if err != nil {
-			fmt.Println("WARNING: Failed to scan: ", err)
+			klog.Warning("Failed to scan: ", err)
+		}
+
+		found := len(devTree)
+		if found != previouslyFound {
+			klog.V(1).Info("GPU scan update: devices found: ", found)
+			previouslyFound = found
 		}
 
 		notifier.Notify(devTree)
@@ -88,18 +96,18 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 		var nodes []pluginapi.DeviceSpec
 
 		if !dp.gpuDeviceReg.MatchString(f.Name()) {
-			debug.Print("Not compatible device", f.Name())
+			klog.V(4).Info("Not compatible device", f.Name())
 			continue
 		}
 
 		dat, err := ioutil.ReadFile(path.Join(dp.sysfsDir, f.Name(), "device/vendor"))
 		if err != nil {
-			fmt.Println("WARNING: Skipping. Can't read vendor file: ", err)
+			klog.Warning("Skipping. Can't read vendor file: ", err)
 			continue
 		}
 
 		if strings.TrimSpace(string(dat)) != vendorString {
-			debug.Print("Non-Intel GPU", f.Name())
+			klog.V(4).Info("Non-Intel GPU", f.Name())
 			continue
 		}
 
@@ -118,7 +126,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 				continue
 			}
 
-			debug.Printf("Adding %s to GPU %s", devPath, f.Name())
+			klog.V(4).Infof("Adding %s to GPU %s", devPath, f.Name())
 			nodes = append(nodes, pluginapi.DeviceSpec{
 				HostPath:      devPath,
 				ContainerPath: devPath,
@@ -141,22 +149,16 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 
 func main() {
 	var sharedDevNum int
-	var debugEnabled bool
 
 	flag.IntVar(&sharedDevNum, "shared-dev-num", 1, "number of containers sharing the same GPU device")
-	flag.BoolVar(&debugEnabled, "debug", false, "enable debug output")
 	flag.Parse()
 
-	if debugEnabled {
-		debug.Activate()
-	}
-
 	if sharedDevNum < 1 {
-		fmt.Println("The number of containers sharing the same GPU must greater than zero")
+		klog.Warning("The number of containers sharing the same GPU must greater than zero")
 		os.Exit(1)
 	}
 
-	fmt.Println("GPU device plugin started")
+	klog.V(1).Info("GPU device plugin started")
 
 	plugin := newDevicePlugin(sysfsDrmDirectory, devfsDriDirectory, sharedDevNum)
 	manager := dpapi.NewManager(namespace, plugin)

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -15,18 +15,17 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 	"time"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") //Enable debug output
 }
 
 func TestScan(t *testing.T) {


### PR DESCRIPTION
Move from fmt to klog for logging and debug.
Also add an extra info level message noting when we find
new devices.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>