### PR TITLE
fpga: move to using klog for logs and debug

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -82,3 +82,41 @@ line more difficult.
 The default is to not log `Info()` calls. This can be changed using the plugin command
 line `-v` parameter. The additional annotations prepended to log lines by 'klog' can be disabled
 with the `-skip_headers` option.
+
+Error Conventions
+-----------------
+
+The framework has a convention for producing and logging errors. Ideally plugins will also adhere
+to the convention.
+
+Errors generated within the framework and plugins are instantiated with the `New()` and
+`Errorf()` functions of the [errors package](https://golang.org/pkg/errors/):
+
+```golang
+    return errors.New("error message")
+```
+
+Errors generated from outside the plugins and framework are augmented with their stack dump with code such as
+
+```golang
+    return errors.WithStack(err)
+```
+
+or
+
+```golang
+    return errors.Wrap(err, "some additional error message")
+```
+
+These errors are then logged using a default struct value format like:
+
+```golang
+    klog.Errorf("Example of an internal error death: %+v", err)
+```
+
+at the line where it's certain that the error cannot be passed out farther nor handled gracefully.
+Otherwise, they can be logged as simple values:
+
+```golang
+    klog.Warningf("Example of a warning due to an external error: %v", err)
+```

--- a/cmd/fpga_admissionwebhook/controller_test.go
+++ b/cmd/fpga_admissionwebhook/controller_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"testing"
 	"time"
@@ -25,7 +26,6 @@ import (
 
 	v1 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga.intel.com/v1"
 	listers "github.com/intel/intel-device-plugins-for-kubernetes/pkg/client/listers/fpga.intel.com/v1"
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 type fakeAfNamespaceLister struct {
@@ -34,7 +34,7 @@ type fakeAfNamespaceLister struct {
 }
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") ///Enable debug output
 }
 
 func (nl *fakeAfNamespaceLister) Get(name string) (*v1.AcceleratorFunction, error) {

--- a/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
+++ b/cmd/fpga_admissionwebhook/fpga_admissionwebhook_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,12 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4")
 }
 
 func fakeMutatePods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {

--- a/cmd/fpga_admissionwebhook/patcher.go
+++ b/cmd/fpga_admissionwebhook/patcher.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 
 	fpgav1 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga.intel.com/v1"
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 const (
@@ -338,7 +338,7 @@ func (pm *patcherManager) getPatcher(namespace string) (*patcher, error) {
 	}
 
 	pm.patchers[namespace] = p
-	debug.Print("created new patcher for namespace", namespace)
+	klog.V(4).Info("created new patcher for namespace", namespace)
 
 	return p, nil
 }

--- a/cmd/fpga_admissionwebhook/patcher_test.go
+++ b/cmd/fpga_admissionwebhook/patcher_test.go
@@ -15,18 +15,19 @@
 package main
 
 import (
+	"flag"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 
 	fpgav1 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga.intel.com/v1"
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4")
 }
 
 func TestPatcherStorageFunctions(t *testing.T) {
@@ -376,7 +377,7 @@ func TestGetPatchOpsOrchestrated(t *testing.T) {
 			afMap:     tt.afMap,
 			regionMap: tt.regionMap,
 		}
-		debug.Print(tt.name)
+		klog.V(4).Info(tt.name)
 		ops, err := p.getPatchOpsOrchestrated(0, tt.container)
 		if tt.expectedErr && err == nil {
 			t.Errorf("Test case '%s': no error returned", tt.name)

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpga"
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpga/bitstream"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 	utilsexec "k8s.io/utils/exec"
 )
 
@@ -276,6 +277,10 @@ func (he *hookEnv) process(reader io.Reader) error {
 	return nil
 }
 
+func init() {
+	klog.InitFlags(nil)
+}
+
 func main() {
 	if os.Getenv("PATH") == "" { // runc doesn't set PATH when runs hooks
 		os.Setenv("PATH", "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin")
@@ -284,7 +289,7 @@ func main() {
 	he := newHookEnv(fpgaBitStreamDirectory, configJSON, utilsexec.New())
 
 	if err := he.process(os.Stdin); err != nil {
-		fmt.Printf("%+v\n", err)
+		klog.Errorf("%+v", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -22,12 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	"github.com/pkg/errors"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4")
 }
 
 func createTestDirs(sysfs string, sysfsDirs []string, sysfsFiles map[string][]byte) error {

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 	"path"
@@ -24,12 +25,11 @@ import (
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/debug"
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
 )
 
 func init() {
-	debug.Activate()
+	flag.Set("v", "4") // Enable debug output
 }
 
 func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFiles map[string][]byte) error {

--- a/deployments/fpga_admissionwebhook/base/intel-fpga-webhook-deployment.yaml
+++ b/deployments/fpga_admissionwebhook/base/intel-fpga-webhook-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-private-key-file=/etc/webhook/certs/key.pem
             - -mode=preprogrammed
-            - -debug
+            - -v 1
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/deployments/fpga_admissionwebhook/deployment-tpl.yaml
+++ b/deployments/fpga_admissionwebhook/deployment-tpl.yaml
@@ -30,7 +30,7 @@ spec:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-private-key-file=/etc/webhook/certs/key.pem
             - -mode={MODE}
-            - -debug
+            - -v 1
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs


### PR DESCRIPTION
Move all the fpga components to using klog for logging
and debug. This includes replacing our homebrew 'fatal()'
with klog.Error().

Modify the deployment files to move from `-debug` to
`-v`, and set their default level to '1' (Info), rather
than full debug mode ('4').

Signed-off-by: Graham Whaley <graham.whaley@intel.com>