### PR TITLE
topology: avoid unnecessary warning prints

### DIFF
--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -270,17 +270,19 @@ func GetTopologyInfo(devs []string) (*pluginapi.TopologyInfo, error) {
 		}
 
 		for _, hint := range hints {
-			for _, nNode := range strings.Split(hint.NUMAs, ",") {
-				nNodeID, err := strconv.ParseInt(strings.TrimSpace(nNode), 10, 64)
-				if err != nil {
-					return nil, errors.Wrapf(err, "unable to convert numa node %s into int64", nNode)
-				}
-				if nNodeID < 0 {
-					return nil, errors.Wrapf(err, "numa node is negative: %d", nNodeID)
-				}
-				if _, ok := nodeIDs[nNodeID]; !ok {
-					result.Nodes = append(result.Nodes, &pluginapi.NUMANode{ID: nNodeID})
-					nodeIDs[nNodeID] = struct{}{}
+			if hint.NUMAs != "" {
+				for _, nNode := range strings.Split(hint.NUMAs, ",") {
+					nNodeID, err := strconv.ParseInt(strings.TrimSpace(nNode), 10, 64)
+					if err != nil {
+						return nil, errors.Wrapf(err, "unable to convert numa node %s into int64", nNode)
+					}
+					if nNodeID < 0 {
+						return nil, errors.Wrapf(err, "numa node is negative: %d", nNodeID)
+					}
+					if _, ok := nodeIDs[nNodeID]; !ok {
+						result.Nodes = append(result.Nodes, &pluginapi.NUMANode{ID: nNodeID})
+						nodeIDs[nNodeID] = struct{}{}
+					}
 				}
 			}
 		}

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -373,10 +373,10 @@ func TestGetTopologyInfo(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "incorrect numa node ID",
+			name:        "valid: missing numa node ID",
 			input:       []string{"/dev/random"},
-			output:      nil,
-			expectedErr: true,
+			output:      &pluginapi.TopologyInfo{},
+			expectedErr: false,
 		},
 	}
 	for _, test := range cases {


### PR DESCRIPTION
Doing strings.Split with a non-empty separator against a potentially
empty string (hint.NUMAs) may return an empty string in a slice of
size one, which then doesn't parse nicely with ParseInt and results
in a repeating warning.

It is better to check for hint.NUMAs emptiness before trying to
split it.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>