### PR TITLE
Add node selector to restrict to x86

### DIFF
--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -43,3 +43,5 @@ spec:
       - name: kubeletsockets
         hostPath:
           path: /var/lib/kubelet/device-plugins
+      nodeSelector:
+        kubernetes.io/arch: amd64


### PR DESCRIPTION
Without the node selector this will deploy on arm nodes with a constantly retrying pod.