### PR TITLE
deployments: qat: add an overlay for Apparmor annotations

### DIFF
--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -17,6 +17,8 @@ RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION} && \
 # Fetch dependencies and source code
 ARG OPAE_RELEASE=1.4.0-1
 
+# workaround for a swupd failure discussed in https://github.com/clearlinux/distribution/issues/831
+RUN ldconfig
 RUN mkdir -p /usr/src/opae && \
     cd /usr/src/opae && \
     wget https://github.com/OPAE/opae-sdk/archive/${OPAE_RELEASE}.tar.gz && \

--- a/deployments/qat_plugin/overlays/apparmor_unconfined/add-apparmor-unconfined-intel-qat.yaml
+++ b/deployments/qat_plugin/overlays/apparmor_unconfined/add-apparmor-unconfined-intel-qat.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-qat-plugin
+spec:
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/intel-qat-plugin: unconfined

--- a/deployments/qat_plugin/overlays/apparmor_unconfined/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/apparmor_unconfined/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ../../base
+patches:
+- add-apparmor-unconfined-intel-qat.yaml


### PR DESCRIPTION
Some Ubuntu systems may run with Apparmor LSM policy enformements making
the default QAT daemonset to fail with (un)bind errors.

This commit adds a sample kustomize overlay to deploy the QAT daemonset with
Apparmor uconfined policy.

Fixes: #381

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>