### PR TITLE
Extend afu id max length to 40 for aocx Unique UUID

### DIFF
--- a/deployments/fpga_admissionwebhook/crd/bases/fpga.intel.com_af.yaml
+++ b/deployments/fpga_admissionwebhook/crd/bases/fpga.intel.com_af.yaml
@@ -23,7 +23,7 @@ spec:
           properties:
             afuId:
               type: string
-              pattern: '^[0-9a-f]{8,32}$'
+              pattern: '^[0-9a-f]{8,40}$'
             interfaceId:
               type: string
               pattern: '^[0-9a-f]{8,32}$'


### PR DESCRIPTION
OpenCL bitstream .aocx has longer than 32 unique ID. Extend to 40 to accommodate it.