### PR TITLE
FPGA demo: add screencast for preprogrammed mode

### DIFF
--- a/demo/readme.md
+++ b/demo/readme.md
@@ -53,23 +53,29 @@ Only one worker node has a GPU. The time difference in transcoding speed is capt
 ## Intel® FPGA Device Plugin demo videos
 
 The screencasts demonstrate the deployment of the Intel® FPGA Device Plugin for
-Kubernetes. Demo 1 executes a native loopback 3 (NLB3) workload, and demo 2 runs an [OpenCL workload](https://www.intel.com/content/www/us/en/programmable/support/support-resources/design-examples/design-software/opencl/matrix-multiplication.html) to do English letters recognition, and compares time used with and without FPGA to show the acceleration. The demos begin
-with a fully [configured Kubernetes cluster](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/)
-with the [Go runtime](https://golang.org/doc/install).
+Kubernetes.
 
-### Demo 1 (NLB3) platform configuration
+- Demo 1 executes a native loopback 3 (NLB3) workload in preprogrammed mode
+- Demo 2 executes NLB3 workload in orchestrated mode
+- Demo 3 runs an [OpenCL workload](https://www.intel.com/content/www/us/en/programmable/support/support-resources/design-examples/design-software/opencl/matrix-multiplication.html) to do English letters recognition, and compares time used with and without FPGA to show the acceleration.
+
+The demos begin with a fully [configured Kubernetes cluster](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/).
+
+### Demo 1 and 2 (NLB3) platform configuration
 
 - Hardware
-    - 1-node, 2x Intel@ Xeon@ Gold 6140M CPU @ 2.30GHz
-    - Total memory 377 GB
-    - Intel® Arria® 10 GX FPGA
+    - 1-node, Intel(R) Xeon(R) CPU E5-2650 0 @ 2.00GHz
+    - Total memory 62 GB
+    - 2 x Intel® Arria® 10 GX FPGA Programmable Acceleration Card(PAC)
 - Software
-    - Ubuntu 18.04.2 LTS (Kernel: 4.15.0-60-generic)
-    - Kubernetes* 1.13
-    - CRI-O 1.13.1
+    - openSUSE Leap 15.1 (Kernel: 5.4.5-1.g47eef04-default)
+    - Kubernetes* 1.17
+    - CRI-O 1.13.1 (for orchestrated mode)
+    - Docker 19.03.1 (for preprogrammed mode)
+    - runc 1.0.0-rc8
     - Intel® FPGA Device Plugin built from master branch
 
-### Demo 2 (OpenCL) platform configuration
+### Demo 3 (OpenCL) platform configuration
 
 - Hardware
     - Multi-node, FPGA host has 24 cores Intel(R) Xeon(R) Gold 6252N CPU @ 2.30GHz
@@ -86,17 +92,21 @@ with the [Go runtime](https://golang.org/doc/install).
 1. Validate the status of the [Kubernetes cluster](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/).
 2. Clone the [Intel Device Plugins for Kubernetes source](https://github.com/intel/intel-device-plugins-for-kubernetes).
 3. Provision the [admission controller webhook](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_admissionwebhook/README.md).
-4. Provision the [Intel® FPGA Device Plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_plugin/README.md).
-5. Build the opae-nlb-demo or fpga-opencl-centos image
+4. Create bitstream storage (for orchestrated mode only)
+5. Provision the [Intel® FPGA Device Plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_plugin/README.md).
 6. Run the NLB3 or OpenCL workload.
 
 ### Screencasts
 
-Intel® FPGA Device Plugin deployment with orchestrated/region mode and NLB workload:
+- Intel® FPGA Device Plugin deployment in preprogrammed mode
+
+[<img src="https://asciinema.org/a/78iLCNz4W344vm4oSrDuJ6g6i.svg" width="700">](https://asciinema.org/a/78iLCNz4W344vm4oSrDuJ6g6i)
+
+- Intel® FPGA Device Plugin deployment with orchestrated/region mode and NLB workload:
 
 [<img src="https://asciinema.org/a/JuYzNxx9n0eQ1vQBzy86GYBki.svg" width="700">](https://asciinema.org/a/JuYzNxx9n0eQ1vQBzy86GYBki)
 
-Intel® FPGA Device Plugin deployment with orchestrated/region mode and OpenCL workload:
+- Intel® FPGA Device Plugin deployment with orchestrated/region mode and OpenCL workload:
 
 [<img src="https://asciinema.org/a/344184.svg" width="700">](https://asciinema.org/a/344184)
 

--- a/demo/screencast-fpga-preprogrammed.sh
+++ b/demo/screencast-fpga-preprogrammed.sh
@@ -1,0 +1,149 @@
+#!/bin/bash -e
+
+PV='pv -qL'
+
+# check if FPGA devices exist
+if [ -d /sys/class/fpga ] ; then
+    DRIVER=OPAE
+    DEVICE_PREFIX=/dev/intel-fpga-port
+elif [ -d /sys/class/fpga_region ] ; then
+    DRIVER=DFL
+    DEVICE_PREFIX=/dev/dfl-port
+else
+    >&2 echo 'ERROR: FPGA devices not found or kernel drivers not loaded'
+    exit 1
+fi
+
+command()
+{
+  speed=$2
+  [ -z "$speed" ] && speed=10
+
+  echo "> $1" | $PV $speed
+  sh -c "$1"
+  echo | $PV $speed
+}
+
+out()
+{
+  speed=$2
+  [ -z "$speed" ] && speed=10
+
+  echo "$1" | $PV $speed
+  echo | $PV $speed
+}
+
+cleanup()
+{
+  clear
+  out 'Cleanup demo artifacts' 200
+  command 'kubectl delete pod test-fpga-preprogrammed || true' 200
+  command 'kubectl delete -f plugins/deployments/fpga_admissionwebhook/mappings-collection.yaml || true' 200
+  command 'kubectl delete -k plugins/deployments/fpga_admissionwebhook/default || true' 200
+  command './plugins/scripts/deploy-fpgaplugin.sh cleanup' 200
+  command 'kubectl annotate node --all fpga.intel.com/device-plugin-mode-' 200
+  command 'rm -rf plugins' 200
+}
+
+record()
+{
+  clear
+  out 'Record this screencast'
+  command "asciinema rec -t 'Intel FPGA Device Plugin for Kubernetes in preprogrammed mode with $DRIVER kernel driver.'  Intel-FPGA-Device-Plugin-for-Kubernetes-preprogrammed-$DRIVER-Demo.cast -c 'sh ./screencast-fpga-preprogrammed.sh play'" 300
+}
+
+screen1()
+{
+  clear
+  out "This screencast demonstrates deployment of the Intel FPGA Plugin for Kubernetes in preprogrammed mode with $DRIVER kernel driver"
+  out "Let's get started!"
+  out '1. Check if Kubernetes node is in good shape:'
+  command 'kubectl get nodes'
+  command 'kubectl get pods -n kube-system'
+  sleep 2
+  out 'Check if cert-manager is running:'
+  command 'kubectl get pods -n cert-manager'
+  sleep 2
+  out 'Check if docker is running k8s pods:'
+  command 'docker ps --format "table {{.Names}}"'
+  sleep 2
+}
+
+screen2()
+{
+  clear
+  rm -rf plugins
+  out '2. Clone Intel Device Plugins for Kubernetes repository'
+  command "git clone https://github.com/intel/intel-device-plugins-for-kubernetes plugins" 15
+}
+
+screen3()
+{
+  clear
+  out '3. Deploy admission controller webhook'
+  command 'kubectl apply -k plugins/deployments/fpga_admissionwebhook/default'
+  sleep 3
+  out 'Deploy example mappings:'
+  command 'kubectl apply -f plugins/deployments/fpga_admissionwebhook/mappings-collection.yaml'
+  sleep 3
+  out 'Check if webhook pod is running:'
+  command 'kubectl get pods -n intelfpgawebhook-system'
+  sleep 2
+  out 'Check its logs:'
+  command "kubectl logs $(kubectl get pods -n intelfpgawebhook-system| grep intelfpgawebhook-controller-manager | awk '{print $1}') -n intelfpgawebhook-system"
+  sleep 2
+}
+
+screen4()
+{
+  clear
+  out '5. Deploy FPGA plugin'
+  command './plugins/scripts/deploy-fpgaplugin.sh'
+  sleep 4
+  out 'Check if its pod is runnning:'
+  command 'kubectl get pod | grep intel-fpga-plugin'
+  sleep 2
+  out 'Check if resource fpga.intel.com/af-<af id> is allocatable:'
+  command 'kubectl describe node  |grep -A4 Allocatable'
+  sleep 2
+}
+
+screen5()
+{
+  clear
+  out '6. Run OPAE workload that uses NLB3 bitstream'
+  out 'Check if devices are programmed with NLB3:'
+  command 'cat /sys/class/*/*/*/afu_id'
+  out 'Run workload:'
+  command 'cat plugins/demo/test-fpga-preprogrammed.yaml'
+  command 'kubectl create -f plugins/demo/test-fpga-preprogrammed.yaml'
+  sleep 5
+  out 'Look at the test output'
+  command 'kubectl logs test-fpga-preprogrammed'
+}
+
+screen6()
+{
+  clear
+  out 'Summary:' 15
+  out "This screencast demonstrated 'Preprogrammed' use case for FPGA:" 15
+  out ' - FPGA device was already programmed with NLB3 bitstream' 15
+  out ' - desired bitstream resource was specified in the pod spec as fpga.intel.com/arria10.dcp1.2-nlb3-preprogrammed' 15
+  out ' - the machinery mapped fpga.intel.com/arria10.dcp1.2-nlb3-preprogrammed into the pair of region id/AFU id using admission controller webhook' 15
+  out
+  out 'More detailed information about Intel Device Plugins can be found at https://github.com/intel/intel-device-plugins-for-kubernetes' 15
+}
+
+if [ "$1" == 'play' ] ; then
+  if [ -n "$2" ] ; then
+    screen$2
+  else
+    for n in $(seq 6) ; do screen$n ; sleep 3; done
+  fi
+elif [ "$1" == 'cleanup' ] ; then
+  cleanup
+elif [ "$1" == 'record' ] ; then
+  record
+else
+   echo 'Usage: screencast-fpga-preprogrammed.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+fi

--- a/demo/test-fpga-preprogrammed.yaml
+++ b/demo/test-fpga-preprogrammed.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-fpga-preprogrammed
+spec:
+  containers:
+  - name: test-container
+    image: intel/opae-nlb-demo:devel
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      capabilities:
+        add:
+          [IPC_LOCK]
+    resources:
+      limits:
+        fpga.intel.com/arria10.dcp1.2-nlb3-preprogrammed: 1
+        cpu: 1
+        hugepages-2Mi: 20Mi
+
+  restartPolicy: Never


### PR DESCRIPTION
This screencast demonstrates deployment scenario for FPGA
preprogrammed mode. It uses Docker as a runtime to show that
CRI-O is not required in this mode.