### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ Makefile            @rojkov @bart0sh @kad @mythi
 # Binaries
 /cmd/               @rojkov @bart0sh
 /cmd/fpga_tool/     @bart0sh @kad @rojkov
+/cmd/gpu_plugin/    @rojkov @bart0sh @uniemimu
 /cmd/qat_plugin/    @rojkov @mythi
 /cmd/vpu_plugin/    @rojkov @mythi @alekdu 
 


### PR DESCRIPTION
This adds @uniemimu for gpu_plugin, but keeps @rojkov and @bart0sh
as reviewers also.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>