### PR TITLE
Support for FME port Release/Assign for SR-IOV configurations

### DIFF
--- a/pkg/fpga/dfl_linux.go
+++ b/pkg/fpga/dfl_linux.go
@@ -144,49 +144,7 @@ func (f *DflPort) CheckExtension() (int, error) {
 	return commonDflCheckExtension(f.DevPath)
 }
 
-// PortReset Reset the FPGA Port and its AFU. No parameters are supported.
-// Userspace can do Port reset at any time, e.g. during DMA or PR. But
-// it should never cause any system level issue, only functional failure
-// (e.g. DMA or PR operation failure) and be recoverable from the failure.
-// * Return: 0 on success, -errno of failure.
-func (f *DflPort) PortReset() error {
-	_, err := ioctlDev(f.DevPath, DFL_FPGA_PORT_RESET, 0)
-	return err
-}
-
-// PortGetInfo Retrieve information about the fpga port.
-// Driver fills the info in provided struct dfl_fpga_port_info.
-// * Return: 0 on success, -errno on failure.
-func (f *DflPort) PortGetInfo() (ret PortInfo, err error) {
-	var value DflFpgaPortInfo
-	value.Argsz = uint32(unsafe.Sizeof(value))
-	_, err = ioctlDev(f.DevPath, DFL_FPGA_PORT_GET_INFO, uintptr(unsafe.Pointer(&value)))
-	if err == nil {
-		ret.Flags = value.Flags
-		ret.Regions = value.Regions
-		ret.Umsgs = value.Umsgs
-	}
-	return
-}
-
-// PortGetRegionInfo Retrieve information about the fpga port.
-// * Retrieve information about a device memory region.
-// * Caller provides struct dfl_fpga_port_region_info with index value set.
-// * Driver returns the region info in other fields.
-// * Return: 0 on success, -errno on failure.
-func (f *DflPort) PortGetRegionInfo(index uint32) (ret PortRegionInfo, err error) {
-	var value DflFpgaPortRegionInfo
-	value.Argsz = uint32(unsafe.Sizeof(value))
-	value.Index = index
-	_, err = ioctlDev(f.DevPath, DFL_FPGA_PORT_GET_REGION_INFO, uintptr(unsafe.Pointer(&value)))
-	if err == nil {
-		ret.Flags = value.Flags
-		ret.Index = value.Index
-		ret.Offset = value.Offset
-		ret.Size = value.Size
-	}
-	return
-}
+// FME interfaces
 
 // PortPR does Partial Reconfiguration based on Port ID and Buffer (Image)
 // provided by caller.
@@ -204,7 +162,21 @@ func (f *DflFME) PortPR(port uint32, bitstream []byte) error {
 	return err
 }
 
-// FME interfaces
+// PortRelease releases the port per Port ID provided by caller.
+// * Return: 0 on success, -errno on failure.
+func (f *DflFME) PortRelease(port uint32) error {
+	value := port
+	_, err := ioctlDev(f.DevPath, FPGA_FME_PORT_RELEASE, uintptr(unsafe.Pointer(&value)))
+	return err
+}
+
+// PortAssign assigns the port back per Port ID provided by caller.
+// * Return: 0 on success, -errno on failure.
+func (f *DflFME) PortAssign(port uint32) error {
+	value := port
+	_, err := ioctlDev(f.DevPath, FPGA_FME_PORT_ASSIGN, uintptr(unsafe.Pointer(&value)))
+	return err
+}
 
 // GetDevPath returns path to device node.
 func (f *DflFME) GetDevPath() string {
@@ -309,6 +281,50 @@ func (f *DflFME) updateProperties() error {
 }
 
 // Port interfaces
+
+// PortReset Reset the FPGA Port and its AFU. No parameters are supported.
+// Userspace can do Port reset at any time, e.g. during DMA or PR. But
+// it should never cause any system level issue, only functional failure
+// (e.g. DMA or PR operation failure) and be recoverable from the failure.
+// * Return: 0 on success, -errno of failure.
+func (f *DflPort) PortReset() error {
+	_, err := ioctlDev(f.DevPath, DFL_FPGA_PORT_RESET, 0)
+	return err
+}
+
+// PortGetInfo Retrieve information about the fpga port.
+// Driver fills the info in provided struct dfl_fpga_port_info.
+// * Return: 0 on success, -errno on failure.
+func (f *DflPort) PortGetInfo() (ret PortInfo, err error) {
+	var value DflFpgaPortInfo
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	_, err = ioctlDev(f.DevPath, DFL_FPGA_PORT_GET_INFO, uintptr(unsafe.Pointer(&value)))
+	if err == nil {
+		ret.Flags = value.Flags
+		ret.Regions = value.Regions
+		ret.Umsgs = value.Umsgs
+	}
+	return
+}
+
+// PortGetRegionInfo Retrieve information about the fpga port.
+// * Retrieve information about a device memory region.
+// * Caller provides struct dfl_fpga_port_region_info with index value set.
+// * Driver returns the region info in other fields.
+// * Return: 0 on success, -errno on failure.
+func (f *DflPort) PortGetRegionInfo(index uint32) (ret PortRegionInfo, err error) {
+	var value DflFpgaPortRegionInfo
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	value.Index = index
+	_, err = ioctlDev(f.DevPath, DFL_FPGA_PORT_GET_REGION_INFO, uintptr(unsafe.Pointer(&value)))
+	if err == nil {
+		ret.Flags = value.Flags
+		ret.Index = value.Index
+		ret.Offset = value.Offset
+		ret.Size = value.Size
+	}
+	return
+}
 
 // GetDevPath returns path to device node.
 func (f *DflPort) GetDevPath() string {

--- a/pkg/fpga/intel_fpga_linux.go
+++ b/pkg/fpga/intel_fpga_linux.go
@@ -140,49 +140,7 @@ func (f *IntelFpgaPort) CheckExtension() (int, error) {
 	return commonIntelFpgaCheckExtension(f.DevPath)
 }
 
-// PortReset Reset the FPGA Port and its AFU. No parameters are supported.
-// Userspace can do Port reset at any time, e.g. during DMA or PR. But
-// it should never cause any system level issue, only functional failure
-// (e.g. DMA or PR operation failure) and be recoverable from the failure.
-// * Return: 0 on success, -errno of failure.
-func (f *IntelFpgaPort) PortReset() error {
-	_, err := ioctlDev(f.DevPath, FPGA_PORT_RESET, 0)
-	return err
-}
-
-// PortGetInfo Retrieve information about the fpga port.
-// Driver fills the info in provided struct IntelFpga_fpga_port_info.
-// * Return: 0 on success, -errno on failure.
-func (f *IntelFpgaPort) PortGetInfo() (ret PortInfo, err error) {
-	var value IntelFpgaPortInfo
-	value.Argsz = uint32(unsafe.Sizeof(value))
-	_, err = ioctlDev(f.DevPath, FPGA_PORT_GET_INFO, uintptr(unsafe.Pointer(&value)))
-	if err == nil {
-		ret.Flags = value.Flags
-		ret.Regions = value.Regions
-		ret.Umsgs = value.Umsgs
-	}
-	return
-}
-
-// PortGetRegionInfo Retrieve information about the fpga port.
-// * Retrieve information about a device memory region.
-// * Caller provides struct IntelFpga_fpga_port_region_info with index value set.
-// * Driver returns the region info in other fields.
-// * Return: 0 on success, -errno on failure.
-func (f *IntelFpgaPort) PortGetRegionInfo(index uint32) (ret PortRegionInfo, err error) {
-	var value IntelFpgaPortRegionInfo
-	value.Argsz = uint32(unsafe.Sizeof(value))
-	value.Index = index
-	_, err = ioctlDev(f.DevPath, FPGA_PORT_GET_REGION_INFO, uintptr(unsafe.Pointer(&value)))
-	if err == nil {
-		ret.Flags = value.Flags
-		ret.Index = value.Index
-		ret.Offset = value.Offset
-		ret.Size = value.Size
-	}
-	return
-}
+// FME interfaces
 
 // PortPR does Partial Reconfiguration based on Port ID and Buffer (Image)
 // provided by caller.
@@ -200,7 +158,25 @@ func (f *IntelFpgaFME) PortPR(port uint32, bitstream []byte) error {
 	return err
 }
 
-// FME interfaces
+// PortRelease releases the port per Port ID provided by caller.
+// * Return: 0 on success, -errno on failure.
+func (f *IntelFpgaFME) PortRelease(port uint32) error {
+	var value IntelFpgaFmePortRelease
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	value.Id = port
+	_, err := ioctlDev(f.DevPath, FPGA_FME_PORT_RELEASE, uintptr(unsafe.Pointer(&value)))
+	return err
+}
+
+// PortAssign assigns the port back per Port ID provided by caller.
+// * Return: 0 on success, -errno on failure.
+func (f *IntelFpgaFME) PortAssign(port uint32) error {
+	var value IntelFpgaFmePortAssign
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	value.Id = port
+	_, err := ioctlDev(f.DevPath, FPGA_FME_PORT_ASSIGN, uintptr(unsafe.Pointer(&value)))
+	return err
+}
 
 // GetDevPath returns path to device node.
 func (f *IntelFpgaFME) GetDevPath() string {
@@ -305,6 +281,50 @@ func (f *IntelFpgaFME) updateProperties() error {
 }
 
 // Port interfaces
+
+// PortReset Reset the FPGA Port and its AFU. No parameters are supported.
+// Userspace can do Port reset at any time, e.g. during DMA or PR. But
+// it should never cause any system level issue, only functional failure
+// (e.g. DMA or PR operation failure) and be recoverable from the failure.
+// * Return: 0 on success, -errno of failure.
+func (f *IntelFpgaPort) PortReset() error {
+	_, err := ioctlDev(f.DevPath, FPGA_PORT_RESET, 0)
+	return err
+}
+
+// PortGetInfo Retrieve information about the fpga port.
+// Driver fills the info in provided struct IntelFpga_fpga_port_info.
+// * Return: 0 on success, -errno on failure.
+func (f *IntelFpgaPort) PortGetInfo() (ret PortInfo, err error) {
+	var value IntelFpgaPortInfo
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	_, err = ioctlDev(f.DevPath, FPGA_PORT_GET_INFO, uintptr(unsafe.Pointer(&value)))
+	if err == nil {
+		ret.Flags = value.Flags
+		ret.Regions = value.Regions
+		ret.Umsgs = value.Umsgs
+	}
+	return
+}
+
+// PortGetRegionInfo Retrieve information about the fpga port.
+// * Retrieve information about a device memory region.
+// * Caller provides struct IntelFpga_fpga_port_region_info with index value set.
+// * Driver returns the region info in other fields.
+// * Return: 0 on success, -errno on failure.
+func (f *IntelFpgaPort) PortGetRegionInfo(index uint32) (ret PortRegionInfo, err error) {
+	var value IntelFpgaPortRegionInfo
+	value.Argsz = uint32(unsafe.Sizeof(value))
+	value.Index = index
+	_, err = ioctlDev(f.DevPath, FPGA_PORT_GET_REGION_INFO, uintptr(unsafe.Pointer(&value)))
+	if err == nil {
+		ret.Flags = value.Flags
+		ret.Index = value.Index
+		ret.Offset = value.Offset
+		ret.Size = value.Size
+	}
+	return
+}
 
 // GetDevPath returns path to device node.
 func (f *IntelFpgaPort) GetDevPath() string {

--- a/pkg/fpga/interfaces.go
+++ b/pkg/fpga/interfaces.go
@@ -53,6 +53,12 @@ type FME interface {
 	//   some errors during PR, under this case, the user can fetch HW error info
 	//   from the status of FME's fpga manager.
 	PortPR(uint32, []byte) error
+	// PortRelease releases the port per Port ID provided by caller.
+	// * Return: 0 on success, -errno on failure.
+	PortRelease(uint32) error
+	// PortAssign assigns the port back per Port ID provided by caller.
+	// * Return: 0 on success, -errno on failure.
+	PortAssign(uint32) error
 	// TODO: (not implemented IOCTLs)
 	// Port release / assign
 	// Get Info


### PR DESCRIPTION
fpgatool now understands two new commands `release` and `assign` that are needed to prepare FME for SR-IOV configurations.
