### PR TITLE
Docs add sphinx support

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,6 +24,8 @@ jobs:
         export PATH="$HOME/.local/bin:$PATH"
         make html
     - name: Deploy docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mkdir $HOME/output
         mv -v _build/html/* $HOME/output

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         PATH="$HOME/.local/bin:$PATH" make html
         mkdir $HOME/output
-        mv -v _build/html* $HOME/output
+        mv -v _build/html/* $HOME/output
         cd $HOME/output
         touch .nojekyll
         git init

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,6 +24,7 @@ jobs:
         export PATH="$HOME/.local/bin:$PATH"
         make html
     - name: Deploy docs
+      run: |
         mkdir $HOME/output
         mv -v _build/html/* $HOME/output
         touch $HOME/output/.nojekyll

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -19,24 +19,18 @@ jobs:
       run: |
         git branch gh-pages
         git checkout gh-pages
-    - name: Add latest generated docs to gh-pages
-      shell: bash
+    - name: Build docs
       run: |
-        PATH="$HOME/.local/bin:$PATH" make html
+        export PATH="$HOME/.local/bin:$PATH"
+        make html
+    - name: Deploy docs
         mkdir $HOME/output
         mv -v _build/html/* $HOME/output
+        touch $HOME/output/.nojekyll
         cd $HOME/output
-        touch .nojekyll
         git init
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@github.com"
         git add .
-        author=$(git log --merges --pretty=format:%an -n 1)
-        email=$(git log --merges --pretty=format:%ae -n 1)
-        git config --global user.name "$author"
-        git config --global user.email "$email"
-        git commit -m "publish-docs.yml: generated latest html output." .
-    - name: Publish/force-push to gh-pages
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
+        git commit -m "generated latest html output."
         git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         sudo apt-get install -y python3-setuptools
-        pip3 install --user -r docs/requirements.txt
+        pip3 install --user -r requirements.txt
     - name: Branch off base for updated gh-pages
       run: |
         git branch gh-pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -28,6 +28,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mkdir $HOME/output
+        cp index.html _build/html/index.html
         mv -v _build/html/* $HOME/output
         touch $HOME/output/.nojekyll
         cd $HOME/output

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,8 +24,8 @@ jobs:
         export PATH="$HOME/.local/bin:$PATH"
         make html
     - name: Deploy docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mkdir $HOME/output
         mv -v _build/html/* $HOME/output

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  push:
+    branches:
+        - docs-add-sphinx-support
+
+jobs:
+  update-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get install -y python3-setuptools
+        pip3 install --user -r docs/requirements.txt
+    - name: Branch off base for updated gh-pages
+      run: |
+        git branch gh-pages
+        git checkout gh-pages
+    - name: Add latest generated docs to gh-pages
+      shell: bash
+      run: |
+        PATH="$HOME/.local/bin:$PATH" make html
+        mkdir $HOME/output
+        mv -v _build/html* $HOME/output
+        cd $HOME/output
+        touch .nojekyll
+        git init
+        git add .
+        author=$(git log --merges --pretty=format:%an -n 1)
+        email=$(git log --merges --pretty=format:%ae -n 1)
+        git config --global user.name "$author"
+        git config --global user.email "$email"
+        git commit -m "publish-docs.yml: generated latest html output." .
+    - name: Publish/force-push to gh-pages
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ deployments/fpga_admissionwebhook/base/intel-fpga-webhook-certs-secret
 *.gbs.*
 *.aocx
 *.aocx.*
+
+_build/html
+_build/doctrees

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -1,5 +1,7 @@
-How to develop simple device plugins
-====================================
+# Development
+
+
+## How to develop simple device plugins
 
 To create a simple device plugin without the hassle of developing your own gRPC
 server, you can use a package included in this repository called
@@ -62,8 +64,7 @@ Optionally, your device plugin may also implement the
 before they are sent to `kubelet`. To see an example, refer to the FPGA
 plugin which implements this interface to annotate its responses.
 
-Logging
--------
+### Logging
 
 The framework uses [`klog`](https://github.com/kubernetes/klog) as its logging
 framework. It is encouraged for plugins to also use `klog` to maintain uniformity
@@ -83,8 +84,7 @@ The default is to not log `Info()` calls. This can be changed using the plugin c
 line `-v` parameter. The additional annotations prepended to log lines by 'klog' can be disabled
 with the `-skip_headers` option.
 
-Error Conventions
------------------
+### Error Conventions
 
 The framework has a convention for producing and logging errors. Ideally plugins will also adhere
 to the convention.
@@ -121,8 +121,7 @@ Otherwise, they can be logged as simple values:
     klog.Warningf("Example of a warning due to an external error: %v", err)
 ```
 
-How to build against a newer version of Kubernetes
-==================================================
+## How to build against a newer version of Kubernetes
 
 First you need to update module dependencies. The easiest way is to use the
 script copied from https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-521493597:

--- a/Makefile
+++ b/Makefile
@@ -143,3 +143,26 @@ check-github-actions:
 	(echo "Make sure all images are listed in .github/workflows/ci.yaml"; exit 1)
 
 .PHONY: all format test lint build images $(cmds) $(images) lock-images vendor pre-pull set-version check-github-actions run-operator envtest deploy-operator undeploy-operator
+
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Generate doc site under _build/html with Sphinx.
+vhtml: _work/venv/.stamp
+	. _work/venv/bin/activate && \
+		$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+html:
+		$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean-html:
+	rm -rf $(BUILDDIR)/html
+
+# Set up a Python3 environment with the necessary tools for document creation.
+_work/venv/.stamp: docs/requirements.txt
+	rm -rf ${@D}
+	python3 -m venv ${@D}
+	. ${@D}/bin/activate && pip install -r $<
+	touch $@

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Intel® Device Plugins for Kubernetes
+# Overview
 [![Build Status](https://github.com/intel/intel-device-plugins-for-kubernetes/workflows/CI/badge.svg?branch=master)](https://github.com/intel/intel-device-plugins-for-kubernetes/actions?query=workflow%3ACI)
 [![Go Report Card](https://goreportcard.com/badge/github.com/intel/intel-device-plugins-for-kubernetes)](https://goreportcard.com/report/github.com/intel/intel-device-plugins-for-kubernetes)
 [![GoDoc](https://godoc.org/github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin?status.svg)](https://godoc.org/github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin)
+
+This repository contains a framework for developing plugins for the Kubernetes
+[device plugins framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/),
+along with a number of device plugin implementations utilising that framework.
 
 ## Table of Contents
 
@@ -21,12 +25,6 @@
 * [Running e2e Tests](#running-e2e-tests)
 * [Supported Kubernetes versions](#supported-kubernetes-versions)
 * [Related code](#related-code)
-
-## About
-
-This repository contains a framework for developing plugins for the Kubernetes
-[device plugins framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/),
-along with a number of device plugin implementations utilising that framework.
 
 ## Prerequisites
 
@@ -212,7 +210,7 @@ $ KUBEBUILDER_ASSETS=${HOME}/work/kubebuilder-assets make envtest
 
 ## Supported Kubernetes versions
 
-Releases are made under the github [releases area](../../releases). Supported releases and
+Releases are made under the github [releases area](https://github.com/intel/intel-device-plugins-for-kubernetes/releases). Supported releases and
 matching Kubernetes versions are listed below:
 
 | Branch            | Kubernetes branch/version      |

--- a/cmd/extensions.rst
+++ b/cmd/extensions.rst
@@ -1,0 +1,14 @@
+Extensions
+##########
+
+.. toctree::
+
+   fpga_admissionwebhook/README.md
+   fpga_crihook/README.md
+   fpga_plugin/README.md
+   fpga_tool/README.md
+   gpu_plugin/README.md
+   operator/README.md
+   qat_plugin/README.md
+   sgx_plugin/README.md
+   vpu_plugin/README.md

--- a/cmd/fpga_admissionwebhook/README.md
+++ b/cmd/fpga_admissionwebhook/README.md
@@ -1,6 +1,6 @@
 # Intel FPGA admission controller for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)
@@ -10,7 +10,7 @@
 * [Mappings](#mappings)
 * [Next steps](#next-steps)
 
-# Introduction
+## Introduction
 
 The FPGA admission controller is one of the components used to add support for Intel FPGA
 devices to Kubernetes.
@@ -31,7 +31,7 @@ The admission controller also keeps the user from bypassing namespaced mapping r
 by denying admission of any pods that are trying to use internal knowledge of InterfaceID or
 Bitstream ID environment variables used by the prestart hook.
 
-# Dependencies
+## Dependencies
 
 This component is one of a set of components that work together. You may also want to
 install the following:
@@ -42,12 +42,12 @@ install the following:
 All components have the same basic dependencies as the
 [generic plugin framework dependencies](../../README.md#about)
 
-# Installation
+## Installation
 
 The following sections detail how to obtain, build and deploy the admission
 controller webhook plugin.
 
-## Pre-requisites
+### Pre-requisites
 
 The webhook depends on having [cert-manager](https://cert-manager.io/)
 installed:
@@ -89,7 +89,7 @@ spec:
     ...
 ```
 
-## Deployment
+### Deployment
 
 To deploy the webhook, run
 
@@ -108,7 +108,7 @@ issuer.cert-manager.io/intelfpgawebhook-selfsigned-issuer created
 ```
 Now you can deploy your mappings.
 
-# Mappings
+## Mappings
 
 Mappings is a an essential part of the setup that gives a flexible instrument to a cluster
 administrator to manage FPGA bitstreams and to control access to them. Being a set of
@@ -148,12 +148,12 @@ bitstream to a region before the container is started.
 
 Mappings of resource names are configured with objects of `AcceleratorFunction` and
 `FpgaRegion` custom resource definitions found respectively in
-[`./deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_af.yaml`](../../deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_af.yaml)
-and [`./deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_region.yaml`](../../deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_region.yaml).
+[`./deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_af.yaml`](/deployments/fpga_admissionwebhook/crd/bases/fpga.intel.com_acceleratorfunctions.yaml)
+and [`./deployment/fpga_admissionwebhook/crd/bases/fpga.intel.com_region.yaml`](/deployments/fpga_admissionwebhook/crd/bases/fpga.intel.com_fpgaregions.yaml).
 
 Mappings between 'names' and 'ID's are controlled by the admission controller
 mappings collection file found in
-[`./deployments/fpga_admissionwebhook/mappings-collection.yaml`](../../deployments/fpga_admissionwebhook/mappings-collection.yaml).
+[`./deployments/fpga_admissionwebhook/mappings-collection.yaml`](/deployments/fpga_admissionwebhook/mappings-collection.yaml).
 This mappings file can be deployed with
 
 ```bash
@@ -163,6 +163,6 @@ $ kubectl apply -f https://raw.githubusercontent.com/intel/intel-device-plugins-
 Note that the mappings are scoped to the namespaces they were created in
 and they are applicable to pods created in the corresponding namespaces.
 
-# Next steps
+## Next steps
 
 Continue with [FPGA prestart CRI-O hook](../fpga_crihook/README.md).

--- a/cmd/fpga_crihook/README.md
+++ b/cmd/fpga_crihook/README.md
@@ -1,6 +1,6 @@
 # Intel FPGA prestart CRI-O webhook for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)
@@ -9,27 +9,27 @@
     * [Building the image](#building-the-image)
 * [Configuring CRI-O](#configuring-cri-o)
 
-# Introduction
+## Introduction
 
 The FPGA CRI-O webhook is one of the components used to add support for Intel FPGA
 devices to Kubernetes.
 
 The FPGA prestart CRI-O hook is triggered by container annotations, such as set by the
-[FPGA device plugin](../fpga_plugin).  It performs discovery of the requested FPGA
+[FPGA device plugin](../fpga_plugin/README.md).  It performs discovery of the requested FPGA
 function bitstream and then programs FPGA devices based on the environment variables
 in the workload description.
 
 The CRI-O prestart hook is only *required* when the
-[FPGA admission webhook](../fpga_admissionwebhook) is configured for orchestration
+[FPGA admission webhook](../fpga_admissionwebhook/README.md) is configured for orchestration
 programmed mode, and is benign (un-used) otherwise.
 
 > **Note:** The fpga CRI-O webhook is usually installed by the same DaemonSet as the
 > FPGA device plugin. If building and installing the CRI-O webhook by hand, it is
 > recommended you reference the
-> [fpga plugin DaemonSet YAML](../../deployments/fpga_plugin/fpga_plugin.yaml) for
+> [fpga plugin DaemonSet YAML](/deployments/fpga_plugin/fpga_plugin.yaml) for
 > more details.
 
-# Dependencies
+## Dependencies
 
 This component is one of a set of components that work together. You may also want to
 install the following:
@@ -40,19 +40,19 @@ install the following:
 All components have the same basic dependencies as the
 [generic plugin framework dependencies](../../README.md#about)
 
-# Building
+## Building
 
 The following sections detail how to obtain, build and deploy the CRI-O
 prestart hook.
 
-## Getting the source code
+### Getting the source code
 
 ```bash
 $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Building the image
+### Building the image
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
@@ -61,7 +61,7 @@ $ make intel-fpga-initcontainer
 Successfully tagged intel/intel-fpga-initcontainer:devel
 ```
 
-# Configuring CRI-O
+## Configuring CRI-O
 
 Recent versions of [CRI-O](https://github.com/cri-o/cri-o) are shipped with default configuration
 file that prevents CRI-O to discover and configure hooks automatically.

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -1,6 +1,6 @@
 # Intel FPGA device plugin for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Component overview](#component-overview)
@@ -18,7 +18,7 @@
         * [Run FPGA device plugin in af mode](#run-fpga-device-plugin-in-af-mode)
         * [Run FPGA device plugin in region mode](#run-fpga-device-plugin-in-region-mode)
 
-# Introduction
+## Introduction
 
 This FPGA device plugin is part of a collection of Kubernetes components found within this
 repository that enable integration of Intel FPGA hardware into Kubernetes.
@@ -38,7 +38,7 @@ The components together implement the following features:
 - orchestration of FPGA programming
 - access control for FPGA hardware
 
-# Component overview
+## Component overview
 
 The following components are part of this repository, and work together to support Intel FPGAs under
 Kubernetes:
@@ -70,7 +70,7 @@ Kubernetes:
 The repository also contains an [FPGA helper tool](../fpga_tool/README.md) that may be useful during
 development, initial deployment and debugging.
 
-# FPGA modes
+## FPGA modes
 
 The FPGA plugin set can run in one of two modes:
 
@@ -95,14 +95,14 @@ af mode:
 
 ![Overview of `af` mode](pictures/FPGA-af.png)
 
-# Installation
+## Installation
 
 The below sections cover how to obtain, build and install this component.
 
 Components can generally be installed either using DaemonSets or running them
 'by hand' on each node.
 
-## Pre-built images
+### Pre-built images
 
 Pre-built images of the components are available on the [Docker hub](https://hub.docker.com/u/intel).
 These images are automatically built and uploaded to the hub from the latest `master` branch of
@@ -123,7 +123,7 @@ The following images are available on the Docker hub:
 - [The FPGA admisson webhook](https://hub.docker.com/r/intel/intel-fpga-admissionwebhook)
 - [The FPGA CRI-O prestart hook (in the `initcontainer` image)](https://hub.docker.com/r/intel/intel-fpga-initcontainer)
 
-## Dependencies
+### Dependencies
 
 All components have the same basic dependencies as the
 [generic plugin framework dependencies](../../README.md#about)
@@ -136,7 +136,7 @@ major components:
 -   [FPGA prestart CRI-O hook](../fpga_crihook/README.md)
 
 The CRI-O hook is only *required* if `region` mode is being used, but is installed by default by the
-[FPGA plugin DaemonSet YAML](../../deployments/fpga_plugin/fpga_plugin.yaml), and is benign
+[FPGA plugin DaemonSet YAML](/deployments/fpga_plugin/fpga_plugin.yaml), and is benign
 in `af` mode.
 
 If using the `af` mode, and therefore *not* using the
@@ -153,7 +153,7 @@ which is present and thus to use:
 Install this component (FPGA device plugin) first, and then follow the links
 and instructions to install the other components.
 
-## Getting the source code
+### Getting the source code
 
 To obtain the YAML files used for deployment, or to obtain the source tree if you intend to
 do a hand-deployment or build your own image, you will require access to the source code:
@@ -163,7 +163,7 @@ $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Verify node kubelet config
+### Verify node kubelet config
 
 Every node that will be running the FPGA plugin must have the
 [kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
@@ -174,7 +174,7 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
-## Deploying as a DaemonSet
+### Deploying as a DaemonSet
 
 As a pre-requisite you need to have [cert-manager](https://cert-manager.io)
 up and running:
@@ -249,11 +249,11 @@ $ kubectl annotate node <node_name> 'fpga.intel.com/device-plugin-mode=af'
 ```
 And restart the pods on the nodes.
 
-> **Note:** The FPGA plugin [DaemonSet YAML](../../deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml)
-> also deploys the [FPGA CRI-O hook](../fpga_criohook) `initcontainer` image, but it will be
+> **Note:** The FPGA plugin [DaemonSet YAML](/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml)
+> also deploys the [FPGA CRI-O hook](../fpga_crihook/README.md) `initcontainer` image, but it will be
 > benign (un-used) when running the FPGA plugin in `af` mode.
 
-### Verify plugin registration
+#### Verify plugin registration
 
 Verify the FPGA plugin has been deployed on the nodes. The below shows the output
 you can expect in `region` mode, but similar output should be expected for `af`
@@ -265,20 +265,20 @@ fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
 fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
 ```
 
-### Building the plugin image
+#### Building the plugin image
 
 If you need to build your own image from sources, and are not using the images
 available on the Docker Hub, follow the below details.
 
-> **Note:** The FPGA plugin [DaemonSet YAML](../../deployments/fpga_plugin/fpga_plugin.yaml)
-> also deploys the [FPGA CRI-O hook](../fpga_criohook) `initcontainer` image as well. You may
+> **Note:** The FPGA plugin [DaemonSet YAML](/deployments/fpga_plugin/fpga_plugin.yaml)
+> also deploys the [FPGA CRI-O hook](../fpga_crihook/README.md) `initcontainer` image as well. You may
 > also wish to build that image locally before deploying the FPGA plugin to avoid deploying
 > the Docker hub default image.
 
 The following will use `docker` to build a local container image called
 `intel/intel-fpga-plugin` with the tag `devel`.
 The image build tool can be changed from the default docker by setting the `BUILDER` argument
-to the [Makefile](../../Makefile).
+to the [Makefile](/Makefile).
 
 ```bash
 $ make intel-fpga-plugin
@@ -289,10 +289,10 @@ Successfully tagged intel/intel-fpga-plugin:devel
 This image launches `fpga_plugin` in `af` mode by default.
 
 To use your own container image, create you own kustomization overlay patching
-[`deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml`](../../deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml)
+[`deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml`](/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml)
 file.
 
-## Deploy by hand
+### Deploy by hand
 
 For development purposes, it is sometimes convenient to deploy the plugin 'by hand'
 on a node. In this case, you do not need to build the complete container image,
@@ -302,7 +302,7 @@ and can build just the plugin.
 > to be configured or installed. It is recommended you reference the actions of the
 > DaemonSet YAML deployment for more details.
 
-### Build FPGA device plugin
+#### Build FPGA device plugin
 
 When deploying by hand, you only need to build the plugin itself, and not the whole
 container image:
@@ -312,7 +312,7 @@ $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make fpga_plugin
 ```
 
-### Run FPGA device plugin in af mode
+#### Run FPGA device plugin in af mode
 
 ```bash
 $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
@@ -327,7 +327,7 @@ device-plugin registered
 the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
 Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
 
-### Run FPGA device plugin in region mode
+#### Run FPGA device plugin in region mode
 
 ```bash
 $ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials

--- a/cmd/fpga_tool/README.md
+++ b/cmd/fpga_tool/README.md
@@ -1,11 +1,11 @@
 # Intel FPGA test tool
 
-# Introduction
+## Introduction
 
 This directory contains an FPGA test tool that can be used to locate, examine and program Intel
 FPGAs.
 
-## Command line and usage
+### Command line and usage
 
 The tool has the following command line arguments:
 

--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -1,6 +1,6 @@
 # Intel GPU device plugin for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
@@ -15,7 +15,7 @@
     * [Verify plugin registration](#verify-plugin-registration)
     * [Testing the plugin](#testing-the-plugin)
 
-# Introduction
+## Introduction
 
 The GPU device plugin for Kubernetes supports acceleration using the following Intel GPU hardware families:
 
@@ -34,13 +34,13 @@ For example, the Intel Media SDK can offload video transcoding operations, and t
 The device plugin can also be used with [GVT-d](https://github.com/intel/gvt-linux/wiki/GVTd_Setup_Guide) device
 passthrough and acceleration.
 
-# Installation
+## Installation
 
 The following sections detail how to obtain, build, deploy and test the GPU device plugin.
 
 Examples are provided showing how to deploy the plugin either using a DaemonSet or by hand on a per-node basis.
 
-## Getting the source code
+### Getting the source code
 
 > **Note:** It is presumed you have a valid and configured [golang](https://golang.org/) environment
 > that meets the minimum required version.
@@ -50,7 +50,7 @@ $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Verify node kubelet config
+### Verify node kubelet config
 
 Every node that will be running the gpu plugin must have the
 [kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
@@ -61,12 +61,12 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
-## Deploying as a DaemonSet
+### Deploying as a DaemonSet
 
 To deploy the gpu plugin as a daemonset, you first need to build a container image for the
 plugin and ensure that is visible to your nodes.
 
-### Build the plugin image
+#### Build the plugin image
 
 The following will use `docker` to build a local container image called
 `intel/intel-gpu-plugin` with the tag `devel`.
@@ -81,9 +81,9 @@ $ make intel-gpu-plugin
 Successfully tagged intel/intel-gpu-plugin:devel
 ```
 
-### Deploy plugin DaemonSet
+#### Deploy plugin DaemonSet
 
-You can then use the [example DaemonSet YAML](../../deployments/gpu_plugin/base/intel-gpu-plugin.yaml)
+You can then use the [example DaemonSet YAML](/deployments/gpu_plugin/base/intel-gpu-plugin.yaml)
 file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
 
 ```bash
@@ -94,7 +94,7 @@ daemonset.apps/intel-gpu-plugin created
 Alternatively, if your cluster runs
 [Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery),
 you can deploy the device plugin only on nodes with Intel GPU.
-The [nfd_labeled_nodes](../../deployments/gpu_plugin/overlays/nfd_labeled_nodes/)
+The [nfd_labeled_nodes](/deployments/gpu_plugin/overlays/nfd_labeled_nodes/)
 kustomization adds the nodeSelector to the DaemonSet:
 
 ```bash
@@ -106,12 +106,12 @@ daemonset.apps/intel-gpu-plugin created
 the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
 Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
 
-## Deploy by hand
+### Deploy by hand
 
 For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
 In this case, you do not need to build the complete container image, and can build just the plugin.
 
-### Build the plugin
+#### Build the plugin
 
 First we build the plugin:
 
@@ -120,7 +120,7 @@ $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make gpu_plugin
 ```
 
-### Run the plugin as administrator
+#### Run the plugin as administrator
 
 Now we can run the plugin directly on the node:
 
@@ -130,7 +130,7 @@ device-plugin start server at: /var/lib/kubelet/device-plugins/gpu.intel.com-i91
 device-plugin registered
 ```
 
-## Verify plugin registration
+### Verify plugin registration
 
 You can verify the plugin has been registered with the expected nodes by searching for the relevant
 resource allocation status on the nodes:
@@ -141,7 +141,7 @@ master
  i915: 1
 ```
 
-## Testing the plugin
+### Testing the plugin
 
 We can test the plugin is working by deploying the provided example OpenCL image with FFT offload enabled.
 

--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -1,18 +1,18 @@
 # Intel One Operator for Device Plugins
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
 
-# Introduction
+## Introduction
 
 This One Operator is a Kubernetes custom controller whose goal is to serve the
 installation and lifecycle management of Intel device plugins for Kubernetes.
 It provides a single point of control for GPU, QAT and FPGA devices to a cluster
 administrators.
 
-# Installation
+## Installation
 
 The operator depends on [cert-manager](https://cert-manager.io/) running in the cluster.
 To install it run:
@@ -71,4 +71,4 @@ $ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/
 ```
 
 Now you can deploy the device plugins by creating corresponding custom resources.
-The samples for them are available [here](../../deployments/operator/samples/).
+The samples for them are available [here](/deployments/operator/samples/).

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -1,6 +1,6 @@
 # Intel QuickAssist Technology (QAT) device plugin for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
     * [Modes and Configuration options](#modes-and-configuration-options)
@@ -26,7 +26,7 @@
         * [OpenSSL QAT demo](#openssl-qat-demo)
 * [Checking for hardware](#checking-for-hardware)
 
-# Introduction
+## Introduction
 
 This Intel QAT device plugin provides support for Intel QAT devices under Kubernetes.
 The supported devices are determined by the VF device drivers available in your Linux
@@ -44,7 +44,7 @@ Demonstrations are provided utilising [DPDK](https://doc.dpdk.org/) and [OpenSSL
 [Kata Containers](https://katacontainers.io/) QAT integration is documented in the
 [Kata Containers documentation repository][6].
 
-## Modes and Configuration options
+### Modes and Configuration options
 
 The QAT plugin can take a number of command line arguments, summarised in the following table:
 
@@ -58,9 +58,9 @@ The QAT plugin can take a number of command line arguments, summarised in the fo
 The plugin also accepts a number of other arguments related to logging. Please use the `-h` option to see
 the complete list of logging related options.
 
-The example [DaemonSet YAML](../../deployments/qat_plugin/base/intel-qat-plugin.yaml) passes a number of these
+The example [DaemonSet YAML](/deployments/qat_plugin/base/intel-qat-plugin.yaml) passes a number of these
 arguments, and takes its default values from the
-[QAT default ConfigMap](../../deployments/qat_plugin/base/intel-qat-plugin-config.yaml). The following
+[QAT default ConfigMap](/deployments/qat_plugin/base/intel-qat-plugin-config.yaml). The following
 table summarises the defaults:
 
 | Argument | Variable | Default setting | Explanation |
@@ -86,13 +86,13 @@ The `kerneldrv` mode does not guarantee full device isolation between containers
 and therefore it's not recommended. This mode will be deprecated and removed once `libqat`
 implements non-UIO based device access.
 
-# Installation
+## Installation
 
 The below sections cover how to obtain, build and install this component.
 
 The component can be installed either using a DaemonSet or running 'by hand' on each node.
 
-## Pre-built image
+### Pre-built image
 
 [Pre-built images](https://hub.docker.com/r/intel/intel-qat-plugin)
 of this component are available on the Docker hub. These images are automatically built and uploaded
@@ -107,10 +107,10 @@ tag by default. If you do not build your own local images, your Kubernetes clust
 the devel images from the Docker hub by default.
 
 To use the release tagged versions of the images, edit the
-[YAML deployment files](../../deployments/qat_plugin/base/)
+[YAML deployment files](/deployments/qat_plugin/base/)
 appropriately.
 
-## Prerequisites
+### Prerequisites
 
 The component has the same basic dependancies as the
 [generic plugin framework dependencies](../../README.md#about).
@@ -125,14 +125,14 @@ are available via two methods. One of them must be installed and enabled:
 
 The demonstrations have their own requirements, listed in their own specific sections.
 
-## Getting the source code
+### Getting the source code
 
 ```bash
 $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Verify node kubelet config
+### Verify node kubelet config
 
 Every node that will be running the plugin must have the
 [kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
@@ -143,17 +143,17 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
-## Deploying as a DaemonSet
+### Deploying as a DaemonSet
 
 To deploy the plugin as a DaemonSet, you first need to build a container image for the plugin and
 ensure that is visible to your nodes. If you do not build your own plugin, your cluster may pull
 the image from the pre-built Docker Hub images, depending on your configuration.
 
-### Build the plugin image
+#### Build the plugin image
 
 The following will use `docker` to build a local container image called `intel/intel-qat-plugin`
 with the tag `devel`. The image build tool can be changed from the default docker by setting the
-`BUILDER` argument to the [Makefile](../../Makefile).
+`BUILDER` argument to the [Makefile](/Makefile).
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
@@ -165,11 +165,11 @@ Successfully tagged intel/intel-qat-plugin:devel
 > **Note**: `kerneldrv` mode is excluded from the build by default. Add `EXTRA_BUILD_ARGS="--build-arg TAGS_KERNELDRV=kerneldrv"` to `make`
 > to get `kerneldrv` functionality added to the build.
 
-### Deploy the DaemonSet
+#### Deploy the DaemonSet
 
 Deploying the plugin involves first the deployment of a
-[ConfigMap](../../deployments/qat_plugin/base/intel-qat-plugin-config.yaml) and the
-[DaemonSet YAML](../../deployments/qat_plugin/base/intel-qat-plugin.yaml).
+[ConfigMap](/deployments/qat_plugin/base/intel-qat-plugin-config.yaml) and the
+[DaemonSet YAML](/deployments/qat_plugin/base/intel-qat-plugin.yaml).
 
 There is a kustomization for deploying both:
 ```bash
@@ -194,7 +194,7 @@ $ kubectl create -f deployments/qat_plugin/base/intel-qat-plugin.yaml
 > socket creation and kubelet registration. Furthermore, the deployments `securityContext` must
 > be configured with appropriate `runAsUser/runAsGroup`.
 
-### Verify QAT device plugin is registered on master:
+#### Verify QAT device plugin is registered on master:
 
 Verification of the plugin deployment and detection of QAT hardware can be confirmed by
 examining the resource allocations on the nodes:
@@ -205,19 +205,19 @@ $ kubectl describe node <node name> | grep qat.intel.com/generic
  qat.intel.com/generic: 10
 ```
 
-## Deploying by hand
+### Deploying by hand
 
 For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
 In this case, you do not need to build the complete container image, and can build just the plugin.
 
-### Build QAT device plugin
+#### Build QAT device plugin
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make qat_plugin
 ```
 
-### Deploy QAT plugin
+#### Deploy QAT plugin
 
 Deploy the plugin on a node by running it as `root`. The below is just an example - modify the
 paramaters as necessary for your setup:
@@ -243,12 +243,12 @@ device-plugin registered
 ListAndWatch: Sending device response
 ```
 
-## QAT device plugin Demos
+### QAT device plugin Demos
 
 The below sections cover `DPDK` and `OpenSSL` demos, both of which utilise the
 QAT device plugin under Kubernetes.
 
-### DPDK QAT demos
+#### DPDK QAT demos
 
 The Data Plane Development Kit (DPDK) QAT demos use DPDK
 [crypto-perf](https://doc.dpdk.org/guides/tools/cryptoperf.html) and
@@ -256,14 +256,14 @@ The Data Plane Development Kit (DPDK) QAT demos use DPDK
 DPDK QAT Poll-Mode Drivers (PMD). For more information on the tools' parameters, refer to the
 website links.
 
-#### DPDK Prerequisites
+##### DPDK Prerequisites
 
 For the DPDK QAT demos to work, the DPDK drivers must be loaded and configured.
 For more information, refer to:
 [DPDK Getting Started Guide for Linux](https://doc.dpdk.org/guides/linux_gsg/index.html) and
 [DPDK Getting Started Guide, Linux Drivers section](http://dpdk.org/doc/guides/linux_gsg/linux_drivers.html)
 
-#### Build the image
+##### Build the image
 
 The demo uses a container image. You can either use the
 [pre-built image from the Docker Hub](https://hub.docker.com/r/intel/crypto-perf), or build your own local copy.
@@ -277,7 +277,7 @@ $ ./build-image.sh crypto-perf
 Successfully tagged crypto-perf:devel
 ```
 
-#### Deploy the pod
+##### Deploy the pod
 
 In the pod specification file, add container resource request and limit.
 For example, `qat.intel.com/generic: <number of devices>` for a container requesting QAT devices.
@@ -297,7 +297,7 @@ $ kubectl get pods
 > **Note**: The deployment example above uses [kustomize](https://github.com/kubernetes-sigs/kustomize)
 > that is available in kubectl since Kubernetes v1.14 release.
 
-#### Manual test run
+##### Manual test run
 
 Manually execute the `dpdk-test-crypto-perf` application to review the logs:
 
@@ -314,7 +314,7 @@ $ dpdk-test-crypto-perf -l 6-7 -w $QAT1 \
 
 > **Note**: Adapt the `.so` versions to what the DPDK version in the container provides.
 
-#### Automated test run
+##### Automated test run
 
 It is also possible to deploy and run `crypto-perf` using the following
 `kustomize` overlays:
@@ -330,12 +330,12 @@ $ kubectl logs qat-dpdk-test-compress-perf-tc1
 > **Note**: for `test-crypto1` and `test-compress1` to work, the cluster must enable
 [Kubernetes CPU manager's](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/) `static` policy.
 
-### OpenSSL QAT demo
+#### OpenSSL QAT demo
 
 Please refer to the [Kata Containers documentation][8] for details on the OpenSSL
 QAT acceleration demo.
 
-# Checking for hardware
+## Checking for hardware
 
 In order to utilise the QAT device plugin, QuickAssist SR-IOV virtual functions must be configured.
 You can verify this on your nodes by checking for the relevant PCI identifiers:

--- a/cmd/sgx_plugin/README.md
+++ b/cmd/sgx_plugin/README.md
@@ -1,6 +1,6 @@
 # Intel Software Guard Extensions (SGX) device plugin for Kubernetes
 
-# Table of Contents
+Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
@@ -15,7 +15,7 @@
         * [Build SGX device plugin](#build-sgx-device-plugin)
         * [Deploy SGX plugin](#deploy-sgx-plugin)
 
-# Introduction
+## Introduction
 
 **Note:** The work is still WIP. The SGX device plugin can be tested to run simple enclaves
 but the full e2e deployment (including the SGX remote attestation) is not yet finished. See
@@ -23,7 +23,7 @@ the open issues for details.
 
 This Intel SGX device plugin provides support for Intel SGX TEE under Kubernetes.
 
-## Modes and Configuration options
+### Modes and Configuration options
 
 The SGX plugin can take a number of command line arguments, summarised in the following table:
 
@@ -35,13 +35,13 @@ The SGX plugin can take a number of command line arguments, summarised in the fo
 The plugin also accepts a number of other arguments related to logging. Please use the `-h` option to see
 the complete list of logging related options.
 
-# Installation
+## Installation
 
 The below sections cover how to obtain, build and install this component.
 
 The component can be installed either using a DaemonSet or running 'by hand' on each node.
 
-## Prerequisites
+### Prerequisites
 
 The component has the same basic dependancies as the
 [generic plugin framework dependencies](../../README.md#about).
@@ -49,14 +49,14 @@ The component has the same basic dependancies as the
 The SGX plugin requires Linux Kernel SGX drivers to be available. These drivers
 are currently available via RFC patches on Linux Kernel Mailing List.
 
-## Getting the source code
+### Getting the source code
 
 ```bash
 $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Verify node kubelet config
+### Verify node kubelet config
 
 Every node that will be running the plugin must have the
 [kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
@@ -67,16 +67,16 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
-## Deploying as a DaemonSet
+### Deploying as a DaemonSet
 
 To deploy the plugin as a DaemonSet, you first need to build a container image for the plugin and
 ensure that is visible to your nodes.
 
-### Build the plugin and EPC source images
+#### Build the plugin and EPC source images
 
 The following will use `docker` to build a local container images called `intel/intel-sgx-plugin`
 and `intel/intel-sgx-initcontainer` with the tag `devel`. The image build tool can be changed from the
-default docker by setting the `BUILDER` argument to the [Makefile](../../Makefile).
+default docker by setting the `BUILDER` argument to the [Makefile](/Makefile).
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
@@ -88,11 +88,11 @@ $ make intel-sgx-initcontainer
 Successfully tagged intel/intel-sgx-initcontainer:devel
 ```
 
-### Deploy the DaemonSet
+#### Deploy the DaemonSet
 
 Deploying the plugin involves the deployment of a
-[NFD EPC Source InitContainer Job](../../deployments/sgx_plugin/base/intel-sgx-hookinstall.yaml) the
-[DaemonSet YAML](../../deployments/sgx_plugin/base/intel-sgx-plugin.yaml), and node-feature-discovery
+[NFD EPC Source InitContainer Job](/deployments/sgx_plugin/base/intel-sgx-hookinstall.yaml) the
+[DaemonSet YAML](/deployments/sgx_plugin/base/intel-sgx-plugin.yaml), and node-feature-discovery
 with the necessary configuration.
 
 There is a kustomization for deploying everything:
@@ -101,7 +101,7 @@ $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ kubectl apply -k deployments/sgx_plugin/overlays/nfd
 ```
 
-### Verify SGX device plugin is registered on master:
+#### Verify SGX device plugin is registered on master:
 
 Verification of the plugin deployment and detection of SGX hardware can be confirmed by
 examining the resource allocations on the nodes:
@@ -120,19 +120,19 @@ $ kubectl describe node <node name> | grep sgx.intel.com
  sgx.intel.com/provision  1           1
 ```
 
-## Deploying by hand
+### Deploying by hand
 
 For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
 In this case, you do not need to build the complete container image, and can build just the plugin.
 
-### Build SGX device plugin
+#### Build SGX device plugin
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make sgx_plugin
 ```
 
-### Deploy SGX plugin
+#### Deploy SGX plugin
 
 Deploy the plugin on a node by running it as `root`. The below is just an example - modify the
 paramaters as necessary for your setup:

--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -1,6 +1,6 @@
 # Intel VPU device plugin for Kubernetes
 
-# Table of Contents
+Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
@@ -18,7 +18,7 @@
         * [Create a job running unit tests off the local Docker image](#create-a-job-running-unit-tests-off-the-local-docker-image)
         * [Review the job logs](#review-the-job-logs)
 
-# Introduction
+## Introduction
 
 The VPU device plugin supports below cards:
 
@@ -38,13 +38,13 @@ This card has:
 >      To get VCAC-A or Mustang card running hddl, please refer to:
 > https://github.com/OpenVisualCloud/Dockerfiles/blob/master/VCAC-A/script/setup_hddl.sh
 
-# Installation
+## Installation
 
 The following sections detail how to obtain, build, deploy and test the VPU device plugin.
 
 Examples are provided showing how to deploy the plugin either using a DaemonSet or by hand on a per-node basis.
 
-## Getting the source code
+### Getting the source code
 
 > **Note:** It is presumed you have a valid and configured [golang](https://golang.org/) environment
 > that meets the minimum required version.
@@ -54,7 +54,7 @@ $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-## Verify node kubelet config
+### Verify node kubelet config
 
 Every node that will be running the vpu plugin must have the
 [kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
@@ -65,12 +65,12 @@ $ ls /var/lib/kubelet/device-plugins/kubelet.sock
 /var/lib/kubelet/device-plugins/kubelet.sock
 ```
 
-## Deploying as a DaemonSet
+### Deploying as a DaemonSet
 
 To deploy the vpu plugin as a daemonset, you first need to build a container image for the
 plugin and ensure that is visible to your nodes.
 
-### Build the plugin image
+#### Build the plugin image
 
 The following will use `docker` to build a local container image called
 `intel/intel-vpu-plugin` with the tag `devel`.
@@ -85,9 +85,9 @@ $ make intel-vpu-plugin
 Successfully tagged intel/intel-vpu-plugin:devel
 ```
 
-### Deploy plugin DaemonSet
+#### Deploy plugin DaemonSet
 
-You can then use the [example DaemonSet YAML](../../deployments/vpu_plugin/base/intel-vpu-plugin.yaml)
+You can then use the [example DaemonSet YAML](/deployments/vpu_plugin/base/intel-vpu-plugin.yaml)
 file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
 
 ```bash
@@ -99,12 +99,12 @@ daemonset.apps/intel-vpu-plugin created
 the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
 Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
 
-## Deploy by hand
+### Deploy by hand
 
 For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
 In this case, you do not need to build the complete container image, and can build just the plugin.
 
-### Build the plugin
+#### Build the plugin
 
 First we build the plugin:
 
@@ -115,7 +115,7 @@ $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 $ make vpu_plugin
 ```
 
-### Run the plugin as administrator
+#### Run the plugin as administrator
 
 Now we can run the plugin directly on the node:
 
@@ -124,7 +124,7 @@ $ sudo $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 VPU device plugin started
 ```
 
-## Verify plugin registration
+### Verify plugin registration
 
 You can verify the plugin has been registered with the expected nodes by searching for the relevant
 resource allocation status on the nodes:
@@ -135,11 +135,11 @@ vcaanode00
  hddl: 12
 ```
 
-## Testing the plugin
+### Testing the plugin
 
 We can test the plugin is working by deploying the provided example OpenVINO image with HDDL plugin enabled.
 
-### Build a Docker image with an classification example
+#### Build a Docker image with an classification example
 
 ```bash
 $ cd demo
@@ -148,7 +148,7 @@ $ ./build-image.sh ubuntu-demo-openvino
 Successfully tagged ubuntu-demo-openvino:devel
 ```
 
-### Create a job running unit tests off the local Docker image
+#### Create a job running unit tests off the local Docker image
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
@@ -156,7 +156,7 @@ $ kubectl apply -f demo/intelvpu-job.yaml
 job.batch/intelvpu-demo-job created
 ```
 
-### Review the job logs
+#### Review the job logs
 
 ```bash
 $ kubectl get pods | fgrep intelvpu

--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -76,7 +76,7 @@ The following will use `docker` to build a local container image called
 `intel/intel-vpu-plugin` with the tag `devel`.
 
 The image build tool can be changed from the default `docker` by setting the `BUILDER` argument
-to the [`Makefile`](Makefile).
+to the [`Makefile`](/Makefile).
 
 ```bash
 $ cd $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,103 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+from docutils import nodes
+from os.path import isdir, isfile, join, basename, dirname
+from os import makedirs, getenv
+from shutil import copyfile
+from pygments.lexers.go import GoLexer
+from sphinx.highlighting import lexers
+
+#############
+#
+# Add a special lexer to add a class to console lexer
+#
+#############
+
+class goLangLexer (GoLexer):
+    name = 'golang'
+
+lexers['golang'] = goLangLexer(startinLine=True)
+
+# -- Project information -----------------------------------------------------
+
+project = 'Intel® Device Plugins for Kubernetes'
+copyright = '2020, various'
+author = 'various'
+
+
+##############################################################################
+#
+# This section determines the behavior of links to local items in .md files.
+#
+#  if useGitHubURL == True:
+#
+#     links to local files and directories will be turned into github URLs
+#     using either the baseBranch defined here or using the commit SHA.
+#
+#  if useGitHubURL == False:
+#
+#     local files will be moved to the website directory structure when built
+#     local directories will still be links to github URLs
+#
+#  if built with GitHub workflows:
+#
+#     the GitHub URLs will use the commit SHA (GITHUB_SHA environment variable
+#     is defined by GitHub workflows) to link to the specific commit.
+#
+##############################################################################
+
+baseBranch = "master"
+useGitHubURL = True
+commitSHA = getenv('GITHUB_SHA')
+githubBaseURL = "https://github.com/intel/intel-device-plugins-for-kubernetes/"
+githubFileURL = githubBaseURL + "blob/"
+githubDirURL = githubBaseURL + "tree/"
+if commitSHA:
+    githubFileURL = githubFileURL + commitSHA + "/"
+    githubDirURL = githubDirURL + commitSHA + "/"
+else:
+    githubFileURL = githubFileURL + baseBranch + "/"
+    githubDirURL = githubDirURL + baseBranch + "/"
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['recommonmark','sphinx_markdown_tables','sphinx_md']
+source_suffix = {'.rst': 'restructuredtext','.md': 'markdown'}
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store','_work','cmd/fpga_plugin/pictures']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']

--- a/demo/readme.md
+++ b/demo/readme.md
@@ -1,4 +1,4 @@
-# Intel Device Plugin Demo for Kubernetes
+# Demo
 
 ## Table of Contents
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='README.html'" />

--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,10 @@
+Intel® Device Plugins for Kubernetes
+####################################
+
+.. toctree::
+
+   README.md
+   DEVEL.md
+   cmd/extensions.rst
+   demo/readme.md
+   Project GitHub repository <https://github.com/intel/intel-device-plugins-for-kubernetes>

--- a/processMDFiles.py
+++ b/processMDFiles.py
@@ -1,0 +1,27 @@
+import os
+import os.path
+from pathlib import Path
+from shutil import copyfile
+
+fileExtension = ".md"
+files = []
+buildDir = "_build"
+
+
+def getFiles():
+    Path(buildDir).mkdir(parents=True, exist_ok=True)
+    for dirpath, dirnames, filenames in os.walk("."):
+        for filename in [f for f in filenames if f.endswith(fileExtension)]:
+            if buildDir not in dirpath:
+                lastDirName = os.path.split(dirpath)[1]
+                if "." != lastDirName:
+                    newFileName = lastDirName + "-" + filename
+                else:
+                    newFileName = filename
+                filepath = os.path.join(dirpath,filename)
+                print(filepath)
+                newFilePath = os.path.join(buildDir,newFileName)
+                #copyfile(filepath,newFilePath)
+                files.append(newFileName)
+
+getFiles()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+sphinx
+sphinx_rtd_theme
+recommonmark
+sphinx-markdown-tables
+sphinx-md


### PR DESCRIPTION
**I'll flatten the history once we agree on any changes needed before merge.**

Preview of the site here: https://intelkevinputnam.github.io/intel-device-plugins-for-kubernetes

I made quite a few changes to headings (several documents have multiple level one headers) and links to docs throughout. 

There are a few links that are still broken as the files may have moved or changed name:

* cmd/fpga_crihook/README.md:26: target not found: /deployments/fpga_plugin/fpga_plugin.yaml
* cmd/fpga_plugin/README.md:138:  target not found: /deployments/fpga_plugin/fpga_plugin.yaml
* cmd/fpga_plugin/README.md:273:  target not found: /deployments/fpga_plugin/fpga_plugin.yaml
* cmd/sgx_plugin/README.md:110:  target not found: /deployments/sgx_plugin/base/intel-sgx-hookinstall.yaml

One other warning pops up related to parsing this bash code block:

cmd/fpga_tool/README.md: WARNING: Could not lex literal_block as "bash". Highlighting skipped.

I'd recommend making a generic code block.