### PR TITLE
qat: add kustomize overlay to enable SR-IOV

### DIFF
--- a/deployments/qat_plugin/overlays/sriov_numvfs/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/sriov_numvfs/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- sriov_numvfs_init.yaml

--- a/deployments/qat_plugin/overlays/sriov_numvfs/sriov_numvfs_init.yaml
+++ b/deployments/qat_plugin/overlays/sriov_numvfs/sriov_numvfs_init.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-qat-plugin
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: vfio-pci
+        image: busybox
+        command: ["/bin/sh", "-c", "modprobe vfio-pci"]
+        securityContext:
+          capabilities:
+            add:
+              ["SYS_MODULE"]
+        volumeMounts:
+        - name: moddir
+          mountPath: /lib/modules/
+      - name: sriov-numvfs
+        image: busybox
+        command: ["/bin/sh", "-c"]
+        args:
+        - >
+          for dev in `for pf in 0434 0435 19a3 37c8 6f54; do lspci | awk -v dev="8086:$pf" '$0 ~ dev {print "0000:" $1}'; done`; do
+            DEVPATH="/sys/bus/pci/devices/$dev"
+            NUMVFS="$DEVPATH/sriov_numvfs"
+            if [ -w "$NUMVFS" -a $(cat "$NUMVFS") -eq 0 ]; then
+              cat "$DEVPATH/sriov_totalvfs" | tee "$NUMVFS"
+            fi
+          done
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: sysfs
+          mountPath: /sys
+      volumes:
+      - name: moddir
+        hostPath:
+          path: /lib/modules/
+      - name: sysfs
+        hostPath:
+          path: /sys


### PR DESCRIPTION
This commit adds two initcontainers in a kustomize overlay to QAT
deployment. The overlay can be used to prepare QAT setup on a freshly
booted system.

Note: containerd/cri-o seem to have issues mounting sysfs rw in even
if the container is privileged. Therefore, we do a special /sys:/sys
bind mount for 'cat sriov_totalvs | tee sriov_numvfs' to work.

Fixes: #320 