### PR TITLE
sgx-sdk-demo: install packages without recommendations

### DIFF
--- a/demo/sgx-sdk-demo/Dockerfile
+++ b/demo/sgx-sdk-demo/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && \
 RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main" >> /etc/apt/sources.list.d/intel-sgx.list \
  && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
  && apt-get update \
- && apt-get install -y \
+ && apt-get install -y --no-install-recommends \
     libsgx-enclave-common \
     libsgx-urts \
     libsgx-quote-ex \


### PR DESCRIPTION
The client side packages Recommends aesmd service and that gets pulled
in the image. aesmd service is expected to run in its own container so
we build the sample apps container without it.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>