### PR TITLE
ci: fix docs publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,24 +20,24 @@ jobs:
       run: |
         mkdir $HOME/output
         touch $HOME/output/.nojekyll
+    - name: Set up git
+      run: |
+        author=$(git log --merges --pretty=format:%an -n 1)
+        email=$(git log --merges --pretty=format:%ae -n 1)
+        git config --global user.name "$author"
+        git config --global user.email "$email"
     - name: Build latest
       run: |
         rm -rf _work/venv
         make vhtml
         mv _build/html/* $HOME/output/
     - name: Deploy the docs
-      run: |
-        cd $HOME/output
-        git init
-        author=$(git log --merges --pretty=format:%an -n 1)
-        email=$(git log --merges --pretty=format:%ae -n 1)
-        git config --global user.name "$author"
-        git config --global user.email "$email"
-        git add .
-        git commit -m "latest html output"
-    - name: Publish/force-push to gh-pages
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        cd $HOME/output
+        git init
+        git add .
+        git commit -m "latest html output"
         git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages


### PR DESCRIPTION
The initial publish.yml was a merger of two examples with
different ways to handle the publishing and resulted in
some inconsistencies.

v2 of the docs publishing correctly takes the git author
info from the original respository and uses that info to
create the docs-only repo ($HOME/output) that is then pushed
to gh-pages.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>