### PR TITLE
ci: fix docs publishing again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y python3-venv git
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up doc directory
       run: |
         mkdir $HOME/output


### PR DESCRIPTION
$author and $email do not get set because actions/checkout@v2
fetches only a single commit by default.

Pull full history by setting fetch-depth according to checkout
documentation.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>