### PR TITLE
fpga: reimplement device discovering

### DIFF
--- a/cmd/fpga_plugin/dfl_test.go
+++ b/cmd/fpga_plugin/dfl_test.go
@@ -19,10 +19,10 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"strings"
 	"testing"
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
+	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpga"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
@@ -285,240 +285,139 @@ func TestGetAfuTreeDFL(t *testing.T) {
 	}
 }
 
+// genNewDFLPort generates newPortFunc function.
+func genNewDFLPort(sysFsPrefix, devDir string, sysFsInfo map[string][]string) newPortFunc {
+	return func(portName string) (fpga.Port, error) {
+		portPciDev := sysFsInfo[portName][0]
+		portPciDevSysFs := path.Join(sysFsPrefix, portPciDev)
+
+		fmeName := sysFsInfo[portName][1]
+		fmePciDev := sysFsInfo[portName][2]
+		fmePciDevSysFs := path.Join(sysFsPrefix, fmePciDev)
+
+		return &fpga.DflPort{
+			Name:      portName,
+			DevPath:   path.Join(devDir, portName),
+			SysFsPath: path.Join(portPciDevSysFs, "fpga_region", "region*", portName),
+			FME: &fpga.DflFME{
+				Name:      fmeName,
+				DevPath:   path.Join(devDir, fmeName),
+				SysFsPath: fmePciDevSysFs,
+				PCIDevice: &fpga.PCIDevice{SysFsPath: fmePciDevSysFs},
+			},
+		}, nil
+	}
+}
 func TestScanFPGAsDFL(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "TestScanFPGAsDFL")
 	if err != nil {
 		t.Fatalf("can't create temporary directory: %+v", err)
 	}
-	sysfs := path.Join(tmpdir, "sys", "class", "fpga_region")
-	devfs := path.Join(tmpdir, "dev")
+	sysfs := path.Join(tmpdir, "sys")
+	dev := path.Join(tmpdir, "dev")
 	tcases := []struct {
-		name            string
-		devfsdirs       []string
-		sysfsdirs       []string
-		sysfsfiles      map[string][]byte
-		errorContains   string
-		expectedDevTree map[string]map[string]dpapi.DeviceInfo
-		mode            string
+		name                string
+		mode                string
+		devs                []string
+		sysfsdirs           []string
+		sysfsfiles          map[string][]byte
+		newPort             newPortFunc
+		expectedDevTreeKeys map[string][]string
 	}{
 		{
-			name: "No sysfs folder exists",
+			name: "Valid DFL scan in af mode",
 			mode: afMode,
-		},
-		{
-			name: "Unexpected extra fme devices in the region",
-			mode: afMode,
+			devs: []string{
+				"dfl-fme.0", "dfl-port.0",
+				"dfl-fme.1", "dfl-port.1",
+			},
 			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-fme.1"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
-			devfsdirs:     []string{"dfl-fme.0"},
-			errorContains: "Detected more than one FPGA region for device region1. Only one region per FPGA device is supported",
-		},
-		{
-			name:          "AFU without ID",
-			mode:          afMode,
-			sysfsdirs:     []string{"region1/dfl-port.0"},
-			errorContains: "/sys/class/fpga_region/region1/dfl-port.0/afu_id: no such file or directory",
-		},
-		{
-			name:      "No device node for detected AFU",
-			mode:      afMode,
-			sysfsdirs: []string{"region1/dfl-port.0"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-			},
-			errorContains: "/dev/dfl-port.0: no such file or directory",
-		},
-		{
-			name:      "AFU without corresponding FME",
-			mode:      afMode,
-			sysfsdirs: []string{"region1/dfl-port.0"},
-			devfsdirs: []string{"dfl-port.0"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-			},
-			errorContains: "region1: AFU without corresponding FME found",
-		},
-		{
-			name: "More than one FME per FPGA device",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1/",
+				"class/fpga_region/region0/dfl-port.0",
+				"class/fpga_region/region1/dfl-port.1",
+				"class/fpga_region/dir", // this should be skipped by plugin.ScanFPGAs
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-port.0",
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-fme.0/dfl-fme-region.0/fpga_region/region0",
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-port.1",
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1",
 			},
 			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
-			devfsdirs: []string{
-				"dfl-fme.0",
-				"dfl-fme.1",
-			},
-			errorContains: "Detected more than one FPGA region",
-		},
-		{
-			name:          "No regionX/dfl-fme.k/dfl-fme-region.n entry found",
-			mode:          afMode,
-			sysfsdirs:     []string{"region1/dfl-fme.0", "region1/dfl-port.0", "region1/dfl-port.1"},
-			errorContains: "no compat_id found with pattern ",
-		},
-		{
-			name: "Duplicate regionX/dfl-fme.k/dfl-fme-region.n entry found",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-fme.0/dfl-fme-region.2/fpga_region/region1/",
-				"region1/dfl-port.0"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-fme.0/dfl-fme-region.2/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-port.1/afu_id": []byte("f7df405cbd7acf7222f144b0b93acd18\n"),
 
-			errorContains: "/sys/class/fpga_region/region1/dfl-fme.0/dfl-fme-region.*/fpga_region/region*/compat_id' matches multiple files",
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-fme.0/dfl-fme-region.0/fpga_region/region0/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
+			},
+			newPort: genNewDFLPort(sysfs, dev,
+				map[string][]string{
+					"dfl-port.0": {"devices/pci0000:80/0000:80:01.0/0000:81:00.0", "dfl-fme.0", "devices/pci0000:80/0000:80:01.0/0000:81:00.0"},
+					"dfl-port.1": {"devices/pci0000:40/0000:40:02.0/0000:42:00.0", "dfl-fme.1", "devices/pci0000:40/0000:40:02.0/0000:42:00.0"},
+				}),
+			expectedDevTreeKeys: map[string][]string{
+				"af-695.d84.aVKNtusxV3qMNmj5-qCB9thCTcSko8QT-J5DNoP5BAs": {"dfl-port.0"},
+				"af-695.f7d.aVKNtusxV3qMNmj5-qCB9vffQFy9es9yIvFEsLk6zRg": {"dfl-port.1"},
+			},
 		},
 		{
-			name: "fme device doesn't exist",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
-			errorContains: "/dev/dfl-fme.0 doesn't exist",
-		},
-		{
-			name: "region1/dfl-port.0/afu_id file doesn't exist",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
-			devfsdirs:     []string{"dfl-fme.0"},
-			errorContains: "region1/dfl-port.0/afu_id: no such file or directory",
-		},
-		{
-			name: "region1/dfl-port.0/afu_id is a directory",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0/afu_id",
-				"region1/dfl-port.1"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-			},
-			devfsdirs:     []string{"dfl-fme.0"},
-			errorContains: "region1/dfl-port.0/afu_id: is a directory",
-		},
-		{
-			name: "port device doesn't exist",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1"},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-port.0/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-			},
-			devfsdirs:     []string{"dfl-fme.0"},
-			errorContains: "/dev/dfl-port.0 doesn't exist",
-		},
-		{
-			name: "working af mode",
-			mode: afMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1",
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/",
-				"region2/dfl-port.2",
-				"region2/dfl-port.3",
-			},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-port.0/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region1/dfl-port.1/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region2/dfl-port.2/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-port.3/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-			},
-			devfsdirs: []string{"dfl-fme.0", "dfl-port.0", "dfl-port.1", "dfl-fme.1", "dfl-port.2", "dfl-port.3"},
-		},
-		{
-			name: "working region mode",
+			name: "Valid DFL scan in region mode",
 			mode: regionMode,
+			devs: []string{
+				"dfl-fme.0", "dfl-port.0",
+				"dfl-fme.1", "dfl-port.1",
+			},
 			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1",
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/",
-				"region2/dfl-port.2",
-				"region2/dfl-port.3",
+				"class/fpga_region/region0/dfl-port.0",
+				"class/fpga_region/region1/dfl-port.1",
+				"class/fpga_region/dir", // this should be skipped by plugin.ScanFPGAs
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-port.0",
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-fme.0/dfl-fme-region.0/fpga_region/region0",
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-port.1",
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1",
 			},
 			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-port.0/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region1/dfl-port.1/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region2/dfl-port.2/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-port.3/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-port.0/afu_id": []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-port.1/afu_id": []byte("f7df405cbd7acf7222f144b0b93acd18\n"),
+
+				"devices/pci0000:80/0000:80:01.0/0000:81:00.0/fpga_region/region0/dfl-fme.0/dfl-fme-region.0/fpga_region/region0/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
+				"devices/pci0000:40/0000:40:02.0/0000:42:00.0/fpga_region/region1/dfl-fme.1/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
 			},
-			devfsdirs: []string{"dfl-fme.0", "dfl-port.0", "dfl-port.1", "dfl-fme.1", "dfl-port.2", "dfl-port.3"},
-		},
-		{
-			name: "working regionDevel mode",
-			mode: regionDevelMode,
-			sysfsdirs: []string{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/",
-				"region1/dfl-port.0",
-				"region1/dfl-port.1",
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/",
-				"region2/dfl-port.2",
-				"region2/dfl-port.3",
+			newPort: genNewDFLPort(sysfs, dev,
+				map[string][]string{
+					"dfl-port.0": {"devices/pci0000:80/0000:80:01.0/0000:81:00.0", "dfl-fme.0", "devices/pci0000:80/0000:80:01.0/0000:81:00.0"},
+					"dfl-port.1": {"devices/pci0000:40/0000:40:02.0/0000:42:00.0", "dfl-fme.1", "devices/pci0000:40/0000:40:02.0/0000:42:00.0"},
+				}),
+			expectedDevTreeKeys: map[string][]string{
+				"region-69528db6eb31577a8c3668f9faa081f6": {"dfl-fme.0", "dfl-fme.1"},
 			},
-			sysfsfiles: map[string][]byte{
-				"region1/dfl-fme.0/dfl-fme-region.1/fpga_region/region1/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region1/dfl-port.0/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region1/dfl-port.1/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-fme.1/dfl-fme-region.2/fpga_region/region2/compat_id": []byte("69528db6eb31577a8c3668f9faa081f6\n"),
-				"region2/dfl-port.2/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-				"region2/dfl-port.3/afu_id":                                        []byte("d8424dc4a4a3c413f89e433683f9040b\n"),
-			},
-			devfsdirs: []string{"dfl-fme.0", "dfl-port.0", "dfl-port.1", "dfl-fme.1", "dfl-port.2", "dfl-port.3"},
 		},
 	}
 
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
-			err := createTestDirs(devfs, sysfs, tcase.devfsdirs, tcase.sysfsdirs, tcase.sysfsfiles)
+			err := createTestDirs(dev, sysfs, tcase.devs, tcase.sysfsdirs, tcase.sysfsfiles)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
 
-			plugin, err := newDevicePluginDFL(sysfs, devfs, tcase.mode)
+			plugin, err := newDevicePluginDFL(path.Join(sysfs, "class", "fpga_region"), dev, tcase.mode)
+
 			if err != nil {
-				t.Errorf("error creating DFL plugin: %+v", err)
-				return
-			}
-			plugin.getDevTree = func(devices []device) dpapi.DeviceTree {
-				return dpapi.NewDeviceTree()
+				t.Fatalf("%+v", err)
 			}
 
-			_, err = plugin.scanFPGAs()
-			if tcase.errorContains != "" {
-				if err == nil || !strings.Contains(err.Error(), tcase.errorContains) {
-					t.Errorf("expected error '%s', but got '%v'", tcase.errorContains, err)
+			plugin.newPort = tcase.newPort
+
+			devTree, err := plugin.scanFPGAs()
+			if err != nil {
+				t.Errorf("unexpected error: '%+v'", err)
+			} else {
+				// Validate devTree
+				if len(devTree) != len(tcase.expectedDevTreeKeys) {
+					t.Errorf("unexpected device tree size: %d, expected: %d", len(devTree), len(tcase.expectedDevTreeKeys))
 				}
-			} else if err != nil {
-				t.Errorf("expected no error, but got '%+v'", err)
+				err = validateDevTree(tcase.expectedDevTreeKeys, devTree)
+				if err != nil {
+					t.Errorf("device tree validation failed: %+v", err)
+				}
 			}
 
 			err = os.RemoveAll(tmpdir)


### PR DESCRIPTION
Reimplemented discovering FPGA devices using APIs from pkg/fpga/intel_fpga_linux.
The APis are also used in the fpga_tool utility.

The API is more advanced and supports SR-IOV among other things.

Fixes: #372 
