### PR TITLE
gpu_nfdhook memory amount reading from sysfs

### DIFF
--- a/cmd/gpu_nfdhook/README.md
+++ b/cmd/gpu_nfdhook/README.md
@@ -11,10 +11,13 @@ types. Selected numeric labels can be turned into kubernetes extended resources
 by the NFD, allowing for finer grained resource management for GPU-using PODs.
 
 In the NFD deployment, the hook requires /host-sys -folder to have the host /sys
--folder content mounted, and /host-dev to have the host /dev/ -folder content
+-folder content mounted, and /host-dev to have the host /dev -folder content
 mounted. Write access is not necessary.
 
-There is one supported environment variable named GPU_MEMORY_OVERRIDE, which is
-supposed to hold a numeric value. For systems with GPUs which do not support
-reading the GPU memory amount, the environment variable memory value is turned
-into a GPU memory amount label instead of a read value.
+GPU memory amount is read from sysfs gt/gt* files and turned into a label.
+There are two supported environment variables named GPU_MEMORY_OVERRIDE and
+GPU_MEMORY_RESERVED. Both are supposed to hold numeric values. For systems with
+older kernel drivers or GPUs which do not support reading the GPU memory
+amount, the GPU_MEMORY_OVERRIDE environment variable value is turned into a GPU
+memory amount label instead of a read value. GPU_MEMORY_RESERVED value will be
+scoped out from the GPU memory amount found from sysfs.

--- a/cmd/gpu_nfdhook/main.go
+++ b/cmd/gpu_nfdhook/main.go
@@ -23,13 +23,13 @@ import (
 const (
 	sysfsDirectory      = "/host-sys"
 	devfsDirectory      = "/host-dev"
-	sysfsDrmDirectory   = sysfsDirectory + "/class/drm"
-	devfsDriDirectory   = devfsDirectory + "/dri"
+	sysfsDRMDirectory   = sysfsDirectory + "/class/drm"
+	devfsDRIDirectory   = devfsDirectory + "/dri"
 	debugfsDRIDirectory = sysfsDirectory + "/kernel/debug/dri"
 )
 
 func main() {
-	l := newLabeler(sysfsDrmDirectory, devfsDriDirectory, debugfsDRIDirectory)
+	l := newLabeler(sysfsDRMDirectory, devfsDRIDirectory, debugfsDRIDirectory)
 	err := l.createLabels()
 	if err != nil {
 		klog.Errorf("%+v", err)


### PR DESCRIPTION
This adds reading of the GPU memory amount from the sysfs. As a
fallback the environment variable GPU_MEMORY_OVERRIDE remains.

Another environment variable GPU_MEMORY_RESERVED can be used to
reserve a dedicated byte amount outside of kubernetes usage.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>