### PR TITLE
fpga: improve port init

### DIFF
--- a/cmd/fpga_plugin/dfl.go
+++ b/cmd/fpga_plugin/dfl.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"regexp"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpga"
 )
 
 const (
@@ -42,7 +40,6 @@ func newDevicePluginDFL(sysfsDir string, devfsDir string, mode string) (*deviceP
 		portReg:   regexp.MustCompile(dflPortRE),
 
 		getDevTree: getDevTree,
-		newPort:    fpga.NewDflPort,
 
 		annotationValue: annotationValue,
 	}, nil

--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -202,6 +202,7 @@ func newDevicePlugin(mode string, rootPath string) (*devicePlugin, error) {
 		return nil, err
 	}
 
+	dp.newPort = fpga.NewPort
 	dp.scanTicker = time.NewTicker(scanPeriod)
 	dp.scanDone = make(chan bool, 1) // buffered as we may send to it before Scan starts receiving from it
 

--- a/cmd/fpga_plugin/opae.go
+++ b/cmd/fpga_plugin/opae.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"regexp"
-
-	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpga"
 )
 
 const (
@@ -42,7 +40,6 @@ func newDevicePluginOPAE(sysfsDir string, devfsDir string, mode string) (*device
 		portReg:   regexp.MustCompile(opaePortRE),
 
 		getDevTree: getDevTree,
-		newPort:    fpga.NewIntelFpgaPort,
 
 		annotationValue: annotationValue,
 	}, nil


### PR DESCRIPTION
Used generic newPort API instead of device-specific
newDflPort and newIntelFpgaPort to initialize plugin.newPort.
