### PR TITLE
gpu_plugin: create resource for monitoring

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -126,7 +126,7 @@ func TestScan(t *testing.T) {
 				}
 			}
 
-			plugin := newDevicePlugin(sysfs, devfs, 1)
+			plugin := newDevicePlugin(sysfs, devfs, 1, false)
 
 			notifier := &mockNotifier{
 				scanDone: plugin.scanDone,

--- a/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
+++ b/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
@@ -60,6 +60,9 @@ spec:
               description: LogLevel sets the plugin's log level.
               minimum: 0
               type: integer
+            monitoringDev:
+              description: MonitoringDev enables the monitoring device which gives access to all GPUs.
+              type: boolean
             nodeSelector:
               additionalProperties:
                 type: string

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
@@ -31,6 +31,9 @@ type GpuDevicePluginSpec struct {
 	// InitImage is a container image with tools (e.g., GPU NFD source hook) installed on each node.
 	InitImage string `json:"initImage,omitempty"`
 
+	// MonitoringDev enables the monitoring device which gives access to all GPUs.
+	MonitoringDev bool `json:"monitoringDev,omitempty"`
+
 	// SharedDevNum is a number of containers that can share the same GPU device.
 	// +kubebuilder:validation:Minimum=1
 	SharedDevNum int `json:"sharedDevNum,omitempty"`

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -304,5 +304,9 @@ func getPodArgs(gdp *devicepluginv1.GpuDevicePlugin) []string {
 		args = append(args, "-shared-dev-num", "1")
 	}
 
+	if gdp.Spec.MonitoringDev {
+		args = append(args, "-monitoring")
+	}
+
 	return args
 }


### PR DESCRIPTION
RFC. This adds a new resource for GPU monitoring purposes. It gives access to all i915 devices in the node.

The resulting resource has an amount of one per node. Whichever POD gets access to that resource will get access to all GPUs. This is handy for creating monitoring PODs which create metrics from all GPUs, but poses certain isolation related risks unless the resource allocation is restricted to the only known allowed monitoring POD. Possible means of restricting this could be RBAC rules and perhaps namespaced extended resource quotas. The intention would be to only allow access to this resource for the GPU-monitoring POD set up by the cluster admin.

The intention is that the resource is not to be used for consuming GPU-resources, merely for metrics and monitoring purposes. We were thinking of different naming alternatives for the resource, but kept this:

"i915_monitoring"

The runners up for the resource name were "i915_all", which was simple enough but considered as giving wrong impression about intention of usage, and "i915_monitor_all" which was considered as complicated in its triple structure.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>