### PR TITLE
fpga: move GetAPIVersion call out of NewPort and NewFME

### DIFF
--- a/pkg/fpga/dfl_linux.go
+++ b/pkg/fpga/dfl_linux.go
@@ -56,10 +56,6 @@ func (f *DflFME) Close() error {
 // NewDflFME Opens device.
 func NewDflFME(dev string) (FME, error) {
 	fme := &DflFME{DevPath: dev}
-	// check that kernel API is compatible
-	if _, err := fme.GetAPIVersion(); err != nil {
-		return nil, errors.Wrap(err, "kernel API mismatch")
-	}
 	if err := checkVendorAndClass(fme); err != nil {
 		return nil, err
 	}
@@ -96,10 +92,6 @@ func (f *DflPort) Close() error {
 // NewDflPort Opens device.
 func NewDflPort(dev string) (Port, error) {
 	port := &DflPort{DevPath: dev}
-	// check that kernel API is compatible
-	if _, err := port.GetAPIVersion(); err != nil {
-		return nil, errors.Wrap(err, "kernel API mismatch")
-	}
 	if err := checkVendorAndClass(port); err != nil {
 		return nil, err
 	}

--- a/pkg/fpga/intel_fpga_linux.go
+++ b/pkg/fpga/intel_fpga_linux.go
@@ -53,10 +53,6 @@ func (f *IntelFpgaFME) Close() error {
 // NewIntelFpgaFME Opens device.
 func NewIntelFpgaFME(dev string) (FME, error) {
 	fme := &IntelFpgaFME{DevPath: dev}
-	// check that kernel API is compatible
-	if _, err := fme.GetAPIVersion(); err != nil {
-		return nil, errors.Wrap(err, "kernel API mismatch")
-	}
 	if err := checkVendorAndClass(fme); err != nil {
 		return nil, err
 	}
@@ -90,11 +86,6 @@ func (f *IntelFpgaPort) Close() error {
 // NewIntelFpgaPort Opens device.
 func NewIntelFpgaPort(dev string) (Port, error) {
 	port := &IntelFpgaPort{DevPath: dev}
-	// check that kernel API is compatible
-	if _, err := port.GetAPIVersion(); err != nil {
-		port.Close()
-		return nil, errors.Wrap(err, "kernel API mismatch")
-	}
 	if err := checkVendorAndClass(port); err != nil {
 		port.Close()
 		return nil, err


### PR DESCRIPTION
This call is implemented by calling ioctl, which raises
"open /dev/intel-fpga-port.X: operation not permitted" when
called inside unprivileged container.

This breaks FPGA plugin.

Calling this API from fpga_tool is still OK, so
moving calls there should fix the issue.