### PR TITLE
manually fix deps to point to latest release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/component-base v0.19.3
 	k8s.io/klog v1.0.0
-	k8s.io/kubelet v0.17.3
+	k8s.io/kubelet v0.19.3
 	k8s.io/kubernetes v1.19.3
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 	sigs.k8s.io/controller-runtime v0.7.0-alpha.6
@@ -47,7 +47,6 @@ replace (
 	k8s.io/kubelet => k8s.io/kubelet v0.19.3
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.19.3
 	k8s.io/metrics => k8s.io/metrics v0.19.3
-	k8s.io/node-api => k8s.io/node-api v0.17.3
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.3
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.19.3
 	k8s.io/sample-controller => k8s.io/sample-controller v0.19.3


### PR DESCRIPTION
For some reason the script used for automated upgrade doesn't touch two records in go.mod. Update them manually.