### PR TITLE
Change imagePullPolicy to Always

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Table of Contents
 * [Developers](#developers)
 * [Running e2e Tests](#running-e2e-tests)
 * [Supported Kubernetes versions](#supported-kubernetes-versions)
+* [Pre-built plugin images](#pre-built-plugin-images)
 * [Related code](#related-code)
 
 ## Prerequisites
@@ -265,6 +266,14 @@ matching Kubernetes versions are listed below:
 
 [Go environment]: https://golang.org/doc/install
 [Kubernetes cluster]: https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
+
+## Pre-built plugin images
+
+Pre-built images of the plugins are available on the Docker hub. These images are automatically built and uploaded to the hub from the latest master branch of this repository.
+
+Release tagged images of the components are also available on the Docker hub, tagged with their release version numbers in the format x.y.z, corresponding to the branches and releases in this repository.
+
+**Note:** the default deployment files and operators are configured with [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) ```IfNotPresent``` and can be changed with ```scripts/set-image-pull-policy.sh```.
 
 ## License
 

--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -16,6 +16,7 @@ spec:
       initContainers:
       - name: intel-gpu-initcontainer
         image: intel/intel-gpu-initcontainer:devel
+        imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:

--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       containers:
       - image: intel/intel-deviceplugin-operator:devel
+        imagePullPolicy: IfNotPresent
         name: manager
         resources:
           limits:

--- a/scripts/set-image-pull-policy.sh
+++ b/scripts/set-image-pull-policy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019-2020 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Invoke this script with a imagePullPolicy as parameter
+# and it will update all hard-coded imagePullPolicy
+# in the deployments, demos and controller code
+#
+# Adapted from https://github.com/intel/pmem-csi/
+
+if [[ $# != 1 ]] || [[ "$1" == "?" ]] || [[ "$1" == "--help" ]] ||
+   [[ ! $1 =~ IfNotPresent|Always ]]; then
+    echo "Usage: $0 <IfNotPresent|Always>" >&2
+    exit 1
+fi
+
+IMAGE_PULL_POLICY=$1
+
+echo IMAGE_PULL_POLICY=$IMAGE_PULL_POLICY
+
+sed -i -e "s;\(imagePullPolicy\:\ \).*;\1$IMAGE_PULL_POLICY;" $(git grep -l 'imagePullPolicy' deployments/*.yaml demo/*.yaml)
+
+sed -i -e "s;\(ImagePullPolicy\:\ \).*;\1\"$IMAGE_PULL_POLICY\",;" $(git grep -l 'ImagePullPolicy' pkg/controllers/*/*.go)


### PR DESCRIPTION
These patches change imagePullPolicy to Always in base deployments
and demos as discussed in #400.

In case a specific imagePullPolicy is required, it can be provided
through the relevant kustomization.yaml.

Closes #400.
