### PR TITLE
Makefile: add explicit image tags to push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ $(demos):
 
 demos: $(demos)
 
-image_tags = $(patsubst %,$(REG)%,$(images) $(demos))
+image_tags = $(patsubst %,$(REG)%\:$(TAG),$(images) $(demos))
 $(image_tags):
 	@docker push $@
 


### PR DESCRIPTION
Our 'make push' started failing and it looks docker picks :latest tag
for the image it just built but fails because it does not exist:

Using default tag: latest
...

tag does not exist:
cloud-native-image-registry.westus.cloudapp.azure.com/intel-deviceplugin-operator:latest

Fix 'make push' to explicitly use the image tag set by Jenkins.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>