### PR TITLE
qat: fix device ID validation

### DIFF
--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
@@ -303,6 +303,29 @@ func TestScanPrivate(t *testing.T) {
 			expectedDevNum: 1,
 		},
 		{
+			name:            "vfio-pci DPDKdriver with one kernel bound device (QAT device) where vfdevID is equal to qatDevId not enabbled in kernelVfDrivers",
+			dpdkDriver:      "vfio-pci",
+			kernelVfDrivers: []string{"c6xxvf"},
+			dirs: []string{
+				"sys/bus/pci/drivers/c6xx",
+				"sys/bus/pci/drivers/vfio-pci",
+				"sys/bus/pci/devices/0000:02:01.0/driver",
+				"sys/bus/pci/devices/0000:02:00.0",
+			},
+			files: map[string][]byte{
+				"sys/bus/pci/devices/0000:02:01.0/driver/unbind": []byte("some junk"),
+				"sys/bus/pci/devices/0000:02:01.0/device":        []byte("0x6f55"),
+				"sys/bus/pci/drivers/vfio-pci/new_id":            []byte("some junk"),
+			},
+			symlinks: map[string]string{
+				"sys/bus/pci/devices/0000:02:01.0/iommu_group": "sys/kernel/iommu_groups/vfiotestfile",
+				"sys/bus/pci/drivers/c6xx/0000:02:00.0":        "sys/bus/pci/devices/0000:02:00.0",
+				"sys/bus/pci/devices/0000:02:00.0/virtfn0":     "sys/bus/pci/devices/0000:02:01.0",
+			},
+			maxDevNum:      1,
+			expectedDevNum: 0,
+		},
+		{
 			name:            "vfio-pci DPDKdriver with  one kernel bound device (QAT device) where vfdevID is equal to qatDevId (37c9) but symlink is broken",
 			dpdkDriver:      "vfio-pci",
 			kernelVfDrivers: []string{"c6xxvf"},

--- a/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
@@ -4,6 +4,6 @@ metadata:
   name: intel-qat-plugin-config
 data:
   DPDK_DRIVER: "vfio-pci"
-  KERNEL_VF_DRIVERS: "dh895xccvf,c6xxvf,c3xxxvf,d15xxvf"
+  KERNEL_VF_DRIVERS: "dh895xccvf,c6xxvf,c3xxxvf"
   MAX_NUM_DEVICES: "32"
   VERBOSITY: "0"


### PR DESCRIPTION
It looks that for a long time now we have accepted a setup where a valid QAT
device ID is accepted as a QAT device resource even though the device is
not "enabled" via kernelVfDrivers parameter.

Fix device ID validation to skip valid QAT devices that are not
explicitly specified in kernelVfDrivers.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>