### PR TITLE
api: add PreferredAllocator interface

### DIFF
--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -96,6 +96,12 @@ type PostAllocator interface {
 	PostAllocate(*pluginapi.AllocateResponse) error
 }
 
+// PreferredAllocator is an optional interface implemented by device plugins.
+type PreferredAllocator interface {
+	// GetPreferredAllocation defines the list of devices preferred for allocating next.
+	GetPreferredAllocation(*pluginapi.PreferredAllocationRequest) (*pluginapi.PreferredAllocationResponse, error)
+}
+
 // ContainerPreStarter is an optional interface implemented by device plugins.
 type ContainerPreStarter interface {
 	// PreStartContainer  defines device initialization function before container is started.

--- a/pkg/deviceplugin/manager_test.go
+++ b/pkg/deviceplugin/manager_test.go
@@ -265,7 +265,7 @@ func TestHandleUpdate(t *testing.T) {
 		mgr := Manager{
 			devicePlugin: &devicePluginStub{},
 			servers:      tt.servers,
-			createServer: func(string, func(*pluginapi.AllocateResponse) error, func(*pluginapi.PreStartContainerRequest) error) devicePluginServer {
+			createServer: func(string, postAllocateFunc, preStartContainerFunc, getPreferredAllocationFunc) devicePluginServer {
 				return &serverStub{}
 			},
 		}
@@ -279,7 +279,7 @@ func TestHandleUpdate(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	mgr := NewManager("testnamespace", &devicePluginStub{})
-	mgr.createServer = func(string, func(*pluginapi.AllocateResponse) error, func(*pluginapi.PreStartContainerRequest) error) devicePluginServer {
+	mgr.createServer = func(string, postAllocateFunc, preStartContainerFunc, getPreferredAllocationFunc) devicePluginServer {
 		return &serverStub{}
 	}
 	mgr.Run()

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -530,7 +530,7 @@ func TestGetPreferredAllocation(t *testing.T) {
 }
 
 func TestNewServer(t *testing.T) {
-	_ = newServer("test", nil, nil)
+	_ = newServer("test", nil, nil, nil)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
This adds a GetPreferredAllocator interface so that plugins can
optionally implement the API.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>