### PR TITLE
documentation: remove kubelet configuration check

### DIFF
--- a/cmd/dsa_plugin/README.md
+++ b/cmd/dsa_plugin/README.md
@@ -54,17 +54,6 @@ $ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the dsa plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 To deploy the dsa plugin as a daemonset, you first need to build a container image for the

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -163,17 +163,6 @@ $ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the FPGA plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 As a pre-requisite you need to have [cert-manager](https://cert-manager.io)

--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -78,17 +78,6 @@ $ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the gpu plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 To deploy the gpu plugin as a daemonset, you first need to build a container image for the

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -147,17 +147,6 @@ $ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 To deploy the plugin as a DaemonSet, you first need to build a container image for the plugin and

--- a/cmd/sgx_plugin/README.md
+++ b/cmd/sgx_plugin/README.md
@@ -152,17 +152,6 @@ $ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 To deploy the plugin as a DaemonSet, you first need to build a container image for the plugin and

--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -54,17 +54,6 @@ $ mkdir -p $(go env GOPATH)/src/github.com/intel
 $ git clone https://github.com/intel/intel-device-plugins-for-kubernetes $(go env GOPATH)/src/github.com/intel/intel-device-plugins-for-kubernetes
 ```
 
-### Verify node kubelet config
-
-Every node that will be running the vpu plugin must have the
-[kubelet device-plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
-configured. For each node, check that the kubelet device plugin socket exists:
-
-```bash
-$ ls /var/lib/kubelet/device-plugins/kubelet.sock
-/var/lib/kubelet/device-plugins/kubelet.sock
-```
-
 ### Deploying as a DaemonSet
 
 To deploy the vpu plugin as a daemonset, you first need to build a container image for the


### PR DESCRIPTION
Removed device plugin socket check from the documentation as
device plugin support is enabled by default in Kubelet.
