### PR TITLE
sgx: change getDefaultPodCount() logic

### DIFF
--- a/cmd/sgx_plugin/sgx_plugin_test.go
+++ b/cmd/sgx_plugin/sgx_plugin_test.go
@@ -50,16 +50,15 @@ func TestPodCount(t *testing.T) {
 		expectedPodCount uint
 	}{
 		{
-			name:             "Only CPU count",
+			name:             "Default pod count",
 			envValue:         "",
-			nCPUs:            5,
-			expectedPodCount: defaultPodsPerCore * 5,
+			expectedPodCount: defaultPodCount,
 		},
 		{
 			name:             "Broken ENV",
 			envValue:         "foobar",
 			nCPUs:            5,
-			expectedPodCount: defaultPodsPerCore * 5,
+			expectedPodCount: defaultPodCount,
 		},
 		{
 			name:             "Valid ENV",


### PR DESCRIPTION
Decouple the default enclaveLimit/provisionLimit from core count. With
this change, the default limit is constant and it can be made relative
to core count by setting POD_PER_CORE multiplier via env variable.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>