### PR TITLE
Move to v1 in RBAC API

### DIFF
--- a/deployments/operator/rbac/auth_proxy_client_clusterrole.yaml
+++ b/deployments/operator/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
In order to get rid of deprecation warnings when deploying the operator,
move away from v1beta1 in RBAC API.

Closes: #489 