### PR TITLE
dpapi: convert DeviceTree to an interface

### DIFF
--- a/cmd/fpga_plugin/dfl_test.go
+++ b/cmd/fpga_plugin/dfl_test.go
@@ -411,8 +411,8 @@ func TestScanFPGAsDFL(t *testing.T) {
 				t.Errorf("unexpected error: '%+v'", err)
 			} else {
 				// Validate devTree
-				if len(devTree) != len(tcase.expectedDevTreeKeys) {
-					t.Errorf("unexpected device tree size: %d, expected: %d", len(devTree), len(tcase.expectedDevTreeKeys))
+				if len(devTree.AsMap()) != len(tcase.expectedDevTreeKeys) {
+					t.Errorf("unexpected device tree size: %d, expected: %d", len(devTree.AsMap()), len(tcase.expectedDevTreeKeys))
 				}
 				err = validateDevTree(tcase.expectedDevTreeKeys, devTree)
 				if err != nil {

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -61,11 +61,11 @@ func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFil
 // validateDevTree is a helper that reduces code complexity to make golangci-lint happy.
 func validateDevTree(expectedDevTreeKeys map[string][]string, devTree dpapi.DeviceTree) error {
 	for resource, devices := range expectedDevTreeKeys {
-		if _, ok := devTree[resource]; !ok {
+		if _, ok := devTree.AsMap()[resource]; !ok {
 			return fmt.Errorf("device tree: resource %s missing", resource)
 		}
 		for _, device := range devices {
-			if _, ok := devTree[resource][device]; !ok {
+			if _, ok := devTree.AsMap()[resource][device]; !ok {
 				return fmt.Errorf("device tree resource %s: device %s missing", resource, device)
 			}
 		}

--- a/cmd/fpga_plugin/opae_test.go
+++ b/cmd/fpga_plugin/opae_test.go
@@ -401,8 +401,8 @@ func TestScanFPGAsOPAE(t *testing.T) {
 				t.Errorf("unexpected error: '%+v'", err)
 			} else {
 				// Validate devTree
-				if len(devTree) != len(tcase.expectedDevTreeKeys) {
-					t.Errorf("unexpected device tree size: %d, expected: %d", len(devTree), len(tcase.expectedDevTreeKeys))
+				if len(devTree.AsMap()) != len(tcase.expectedDevTreeKeys) {
+					t.Errorf("unexpected device tree size: %d, expected: %d", len(devTree.AsMap()), len(tcase.expectedDevTreeKeys))
 				}
 				err = validateDevTree(tcase.expectedDevTreeKeys, devTree)
 				if err != nil {

--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -82,7 +82,7 @@ func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
 			klog.Warning("Failed to scan: ", err)
 		}
 
-		found := len(devTree)
+		found := len(devTree.AsMap())
 		if found != previouslyFound {
 			klog.V(1).Info("GPU scan update: devices found: ", found)
 			previouslyFound = found
@@ -99,12 +99,13 @@ func (dp *devicePlugin) Scan(notifier dpapi.Notifier) error {
 }
 
 func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
+	devTree := dpapi.NewDeviceTree()
+
 	files, err := ioutil.ReadDir(dp.sysfsDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "Can't read sysfs folder")
+		return devTree, errors.Wrap(err, "Can't read sysfs folder")
 	}
 
-	devTree := dpapi.NewDeviceTree()
 	for _, f := range files {
 		var nodes []pluginapi.DeviceSpec
 
@@ -126,7 +127,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 
 		drmFiles, err := ioutil.ReadDir(path.Join(dp.sysfsDir, f.Name(), "device/drm"))
 		if err != nil {
-			return nil, errors.Wrap(err, "Can't read device folder")
+			return devTree, errors.Wrap(err, "Can't read device folder")
 		}
 
 		for _, drmFile := range drmFiles {

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -36,7 +36,7 @@ type mockNotifier struct {
 
 // Notify stops plugin Scan.
 func (n *mockNotifier) Notify(newDeviceTree dpapi.DeviceTree) {
-	n.devCount = len(newDeviceTree[deviceType])
+	n.devCount = len(newDeviceTree.AsMap()[deviceType])
 	n.scanDone <- true
 }
 

--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
@@ -390,8 +390,8 @@ func TestScanPrivate(t *testing.T) {
 			if !tt.expectedErr && err != nil {
 				t.Errorf("got unexpected error: %+v", err)
 			}
-			if len(tree) != tt.expectedDevNum {
-				t.Errorf("expected %d, but got %d devices", tt.expectedDevNum, len(tree))
+			if tree != nil && len(tree.AsMap()) != tt.expectedDevNum {
+				t.Errorf("expected %d, but got %d devices", tt.expectedDevNum, len(tree.AsMap()))
 			}
 
 			if err = os.RemoveAll(tmpdir); err != nil {

--- a/cmd/sgx_plugin/sgx_plugin_test.go
+++ b/cmd/sgx_plugin/sgx_plugin_test.go
@@ -37,8 +37,8 @@ type mockNotifier struct {
 
 // Notify stops plugin Scan.
 func (n *mockNotifier) Notify(newDeviceTree dpapi.DeviceTree) {
-	n.enclaveDevCount = len(newDeviceTree[deviceTypeEnclave])
-	n.provisionDevCount = len(newDeviceTree[deviceTypeProvision])
+	n.enclaveDevCount = len(newDeviceTree.AsMap()[deviceTypeEnclave])
+	n.provisionDevCount = len(newDeviceTree.AsMap()[deviceTypeProvision])
 	n.scanDone <- true
 }
 

--- a/cmd/vpu_plugin/vpu_plugin_test.go
+++ b/cmd/vpu_plugin/vpu_plugin_test.go
@@ -86,10 +86,10 @@ func TestScan(t *testing.T) {
 	if err != nil {
 		t.Error("vpu plugin test failed with testPlugin.Scan()")
 	}
-	if len(fN.tree[deviceType]) == 0 {
+	if len(fN.tree.AsMap()[deviceType]) == 0 {
 		t.Error("vpu plugin test failed with testPlugin.Scan(): tree len is 0")
 	}
-	klog.V(4).Infof("tree len is %d", len(fN.tree[deviceType]))
+	klog.V(4).Infof("tree len is %d", len(fN.tree.AsMap()[deviceType]))
 
 	//remove the hddl_service.sock and test with no hddl socket case
 	_ = f.Close()
@@ -105,7 +105,7 @@ func TestScan(t *testing.T) {
 	if err != nil {
 		t.Error("vpu plugin test failed with testPlugin.Scan() in no hddl_service.sock case.")
 	}
-	if len(fN.tree[deviceType]) != 0 {
+	if len(fN.tree.AsMap()[deviceType]) != 0 {
 		t.Error("vpu plugin test failed with testPlugin.Scan(): tree len should be 0 in no hddl_service.sock case.")
 	}
 

--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -58,19 +58,34 @@ func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginap
 }
 
 // DeviceTree contains a tree-like structure of device type -> device ID -> device info.
-type DeviceTree map[string]map[string]DeviceInfo
+type DeviceTree interface {
+	// AddDevice adds device info to DeviceTree.
+	AddDevice(devType, id string, info DeviceInfo)
+	// AsMap returns a map of maps representing the device tree.
+	// The first dimension of the map is a device type.
+	// The second dimension is a device ID.
+	// The value of the secondary maps are instances of DeviceInfo.
+	AsMap() map[string]map[string]DeviceInfo
+}
+
+// deviceTree implements DeviceTree interface.
+type deviceTree map[string]map[string]DeviceInfo
 
 // NewDeviceTree creates an instance of DeviceTree.
 func NewDeviceTree() DeviceTree {
-	return make(map[string]map[string]DeviceInfo)
+	return make(deviceTree)
 }
 
 // AddDevice adds device info to DeviceTree.
-func (tree DeviceTree) AddDevice(devType, id string, info DeviceInfo) {
+func (tree deviceTree) AddDevice(devType, id string, info DeviceInfo) {
 	if _, present := tree[devType]; !present {
 		tree[devType] = make(map[string]DeviceInfo)
 	}
 	tree[devType][id] = info
+}
+
+func (tree deviceTree) AsMap() map[string]map[string]DeviceInfo {
+	return tree
 }
 
 // Notifier receives updates from Scanner, detects changes and sends the

--- a/pkg/deviceplugin/manager_test.go
+++ b/pkg/deviceplugin/manager_test.go
@@ -31,8 +31,8 @@ func TestNotify(t *testing.T) {
 		expectedAdded   int
 		expectedUpdated int
 		expectedRemoved int
-		oldmap          map[string]map[string]DeviceInfo
-		newmap          map[string]map[string]DeviceInfo
+		oldmap          deviceTree
+		newmap          deviceTree
 	}{
 		{
 			name: "No devices found",

--- a/pkg/idxd/plugin_test.go
+++ b/pkg/idxd/plugin_test.go
@@ -237,12 +237,12 @@ func genTest(sysfs, statePattern string, tc testCase) func(t *testing.T) {
 // checkDeviceTree checks discovered device types and number of discovered devices.
 func checkDeviceTree(deviceTree dpapi.DeviceTree, expectedResult map[string]int, expectedError bool) error {
 	if !expectedError && deviceTree != nil {
-		for key := range deviceTree {
+		for key := range deviceTree.AsMap() {
 			val, ok := expectedResult[key]
 			if !ok {
 				return fmt.Errorf("unexpected device type: %s", key)
 			}
-			numberDev := len(deviceTree[key])
+			numberDev := len(deviceTree.AsMap()[key])
 			if numberDev != val {
 				return fmt.Errorf("%s: unexpected number of devices: %d, expected: %d", key, numberDev, val)
 			}


### PR DESCRIPTION
It seems people get confused about internal representation of `dpapi.DeviceTree` and tend to micro-optimize by creating pointers to its instances when in fact such micro-optimizations don't add any value, but clutter the code.

Prevent this by wrapping `dpapi.DeviceTree` in an interface with one additional method `AsMap()` returning the underlying map explicitly.