### PR TITLE
demo: fix SGX screencast

### DIFF
--- a/demo/screencast-sgx.sh
+++ b/demo/screencast-sgx.sh
@@ -93,8 +93,8 @@ screen5()
 {
   clear
   out "4. Verify node resources"
-  command "kubectl get nodes -o json | jq .items[].status.allocatable | grep -i sgx"
-  command "kubectl get nodes -o json | jq .items[].metadata.labels | grep SGX"
+  command "kubectl get nodes -o json | jq .items[].status.allocatable | grep sgx"
+  command "kubectl get nodes -o json | jq .items[].metadata.labels | grep sgx"
   out "Both node labels and resources for SGX are in place"
 }
 


### PR DESCRIPTION
With the recent move to NFD custom source config for SGX features,
we no longer get SGX* cpuid labels but custom-intel.sgx so the grep
fails. Move to lowercase only checks.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>