### PR TITLE
Make it possible to select supported devices in the operator

### DIFF
--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -98,6 +98,20 @@ NAME                     DESIRED   READY   NODE SELECTOR   AGE
 gpudeviceplugin-sample   1         1                       5s
 ```
 
+In order to limit the deployment to a specific device type,
+use one of kustomizations under deployments/operator/device.
+
+For example, to limit the deployment to FPGA, use:
+
+```bash
+$ kubectl apply -k deployments/operator/device/fpga
+```
+
+Operator also supports deployments with multiple selected device types.
+In this case, create a new kustomization with the necessary resources
+that passes the desired device types to the operator using `--device`
+command line argument multiple times.
+
 ## Known issues
 
 When the operator is run with leader election enabled, that is with the option
@@ -106,3 +120,7 @@ number of pods. Otherwise a heart beat used by the leader election code may trig
 a timeout and crash. We are going to use different clients for the controller and
 leader election code to alleviate the issue. See more details in
 https://github.com/intel/intel-device-plugins-for-kubernetes/issues/476.
+
+In case the deployment is limited to specific device type(s),
+the CRDs for other device types are still created, but no controllers
+for them are registered.

--- a/deployments/operator/device/dsa/dsa.yaml
+++ b/deployments/operator/device/dsa/dsa.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inteldeviceplugins-controller-manager
+  namespace: inteldeviceplugins-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --device=dsa
+        name: manager

--- a/deployments/operator/device/dsa/kustomization.yaml
+++ b/deployments/operator/device/dsa/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+ - ../../default
+
+patchesStrategicMerge:
+ - dsa.yaml

--- a/deployments/operator/device/fpga/fpga.yaml
+++ b/deployments/operator/device/fpga/fpga.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inteldeviceplugins-controller-manager
+  namespace: inteldeviceplugins-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --device=fpga
+        name: manager

--- a/deployments/operator/device/fpga/kustomization.yaml
+++ b/deployments/operator/device/fpga/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+ - ../../default
+
+patchesStrategicMerge:
+ - fpga.yaml

--- a/deployments/operator/device/gpu/gpu.yaml
+++ b/deployments/operator/device/gpu/gpu.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inteldeviceplugins-controller-manager
+  namespace: inteldeviceplugins-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --device=gpu
+        name: manager

--- a/deployments/operator/device/gpu/kustomization.yaml
+++ b/deployments/operator/device/gpu/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+ - ../../default
+
+patchesStrategicMerge:
+ - gpu.yaml

--- a/deployments/operator/device/qat/kustomization.yaml
+++ b/deployments/operator/device/qat/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+ - ../../default
+
+patchesStrategicMerge:
+ - qat.yaml

--- a/deployments/operator/device/qat/qat.yaml
+++ b/deployments/operator/device/qat/qat.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inteldeviceplugins-controller-manager
+  namespace: inteldeviceplugins-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --device=qat
+        name: manager

--- a/deployments/operator/device/sgx/kustomization.yaml
+++ b/deployments/operator/device/sgx/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+ - ../../default
+
+patchesStrategicMerge:
+ - sgx.yaml

--- a/deployments/operator/device/sgx/sgx.yaml
+++ b/deployments/operator/device/sgx/sgx.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inteldeviceplugins-controller-manager
+  namespace: inteldeviceplugins-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        - --device=sgx
+        name: manager


### PR DESCRIPTION
In order to support per device deployment in the operator:
- Add customization overlays for FPGA, DSA, SGX, GPU, QAT under deployments/operator/device/
- Add --device cmdline to operator main.go which defines the controllers/webhooks to set up