### PR TITLE
operator: update usage guidelines

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -179,7 +179,17 @@ $ make test
 
 and fix all new compilation issues.
 
-## How to publish a new version of the Intel Device Plugins operator
+## How to work with Intel Device Plugins operator modifications
+
+There are few useful steps when working with changes to Device Plugins CRDs and controllers:
+
+1. Install controller-gen: `GO111MODULE=on go get -u sigs.k8s.io/controller-tools/cmd/controller-gen@<release ver>, e.g, v0.4.1`
+2. Generate CRD and Webhook artifacts: `make generate`
+3. Test local changes using [envtest](https://book.kubebuilder.io/reference/envtest.html): `make envtest`
+4. Build a custom operator image: `make intel-deviceplugin-operator`
+5. (Un)deploy operator: `kubectl [apply|delete] -k deployments/operator/default`
+
+## How to publish a new version of the Intel Device Plugins operator to operatorhub.io
 
 Generate package manifests with:
 ```

--- a/Makefile
+++ b/Makefile
@@ -99,15 +99,6 @@ $(cmds):
 
 build: $(cmds)
 
-deploy-operator: operator generate
-	kubectl apply -k deployments/operator/default
-
-undeploy-operator:
-	kubectl delete -k deployments/operator/default
-
-run-operator: deploy-operator
-	./cmd/operator/operator
-
 .PHONY: bundle
 bundle:
 	$(OPERATOR_SDK) generate kustomize manifests -q --input-dir $(OLM_MANIFESTS) --output-dir $(OLM_MANIFESTS) --apis-dir pkg/apis
@@ -173,7 +164,7 @@ check-github-actions:
 	jq -e '$(images_json) - .jobs.image.strategy.matrix.image == []' > /dev/null || \
 	(echo "Make sure all images are listed in .github/workflows/ci.yaml"; exit 1)
 
-.PHONY: all format test lint build images $(cmds) $(images) lock-images vendor pre-pull set-version check-github-actions run-operator envtest deploy-operator undeploy-operator
+.PHONY: all format test lint build images $(cmds) $(images) lock-images vendor pre-pull set-version check-github-actions envtest
 
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build

--- a/README.md
+++ b/README.md
@@ -173,30 +173,14 @@ The [DSA device plugin](cmd/dsa_plugin/README.md) supports acceleration using th
 
 ## Device Plugins Operator
 
-Currently the operator has support for the QAT, GPU, FPGA, SGX and DSA device plugins:
-it validates container image references and extends reported statuses.
+To simplify the deployment of the device plugins, a unified device plugins operator is implemented.
 
-To run an operator instance in the container run
+Currently the operator has support for the QAT, GPU, FPGA, SGX and DSA device plugins. Each
+device plugin has its own custom resource definition (CRD) and the corresponding controller that
+watches CRUD operations to those custom resources.
 
-```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
-$ make deploy-operator
-```
-
-Then deploy your device plugin by applying its custom resource, e.g.
-`GpuDevicePlugin` with
-
-```bash
-$ kubectl apply -f ./deployments/operator/samples/deviceplugin_v1_gpudeviceplugin.yaml
-```
-
-Observe it is up and running:
-
-```bash
-$ kubectl get GpuDevicePlugin
-NAME                     DESIRED   READY   NODE SELECTOR   AGE
-gpudeviceplugin-sample   1         1                       5s
-```
+The [Device plugins operator README](cmd/operator/README.md) gives the installation and usage
+details. The operator is also available via [operatorhub.io](https://operatorhub.io/operator/intel-device-plugins-operator).
 
 ## Demos
 

--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -75,11 +75,28 @@ $ export no_proxy=$no_proxy,.svc,.svc.cluster.local
 Finally deploy the operator itself:
 
 ```
-$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/operator/default?ref=main
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/operator/default?ref=<RELEASE_VERSION>
 ```
 
 Now you can deploy the device plugins by creating corresponding custom resources.
 The samples for them are available [here](/deployments/operator/samples/).
+
+## Usage
+
+Deploy your device plugin by applying its custom resource, e.g.
+`GpuDevicePlugin` with
+
+```bash
+$ kubectl apply -f https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/operator/samples/deviceplugin_v1_gpudeviceplugin.yaml
+```
+
+Observe it is up and running:
+
+```bash
+$ kubectl get GpuDevicePlugin
+NAME                     DESIRED   READY   NODE SELECTOR   AGE
+gpudeviceplugin-sample   1         1                       5s
+```
 
 ## Known issues
 


### PR DESCRIPTION
As the operator container image is available from a registry, we should
guide users to use it rather than build and deploy it locally.

Further, drop (un)deploy-operator targets in favor of simply using
kubectl for deployment.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>