### PR TITLE
operator: increase manager memory limit

### DIFF
--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
We have been getting reports about the operator getting killed
with an OOMKilled reason. This indicates we consume more memory
than what the resource limit states.

Bump up the memory limit to 50M.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>