### PR TITLE
gpu_nfdhook: make memory parsing more robust

### DIFF
--- a/cmd/gpu_nfdhook/labeler.go
+++ b/cmd/gpu_nfdhook/labeler.go
@@ -131,7 +131,7 @@ func (l *labeler) getTileMemoryAmount(gpuName string) (mem, numTiles uint64) {
 			continue
 		}
 
-		n, err := strconv.ParseUint(strings.TrimSpace(string(dat)), 10, 64)
+		n, err := strconv.ParseUint(strings.TrimSpace(string(dat)), 0, 64)
 		if err != nil {
 			klog.Warning("Skipping. Can't convert addr_range: ", err)
 			continue


### PR DESCRIPTION
This add support for parsing also hex and octal amounts.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>