### PR TITLE
update to cert-manager v1.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-with-kind:
 	@$(PODMAN) save "docker.io/intel/intel-fpga-admissionwebhook:devel" -o $(e2e_tmp_dir)/$(WEBHOOK_IMAGE_FILE)
 	@$(KIND) create cluster --name "intel-device-plugins" --kubeconfig $(e2e_tmp_dir)/kubeconfig --image "kindest/node:v1.19.0"
 	@$(KIND) load image-archive --name "intel-device-plugins" $(e2e_tmp_dir)/$(WEBHOOK_IMAGE_FILE)
-	$(KUBECTL) --kubeconfig=$(e2e_tmp_dir)/kubeconfig apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+	$(KUBECTL) --kubeconfig=$(e2e_tmp_dir)/kubeconfig apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 	@$(GO) test -v ./test/e2e -args -kubeconfig $(e2e_tmp_dir)/kubeconfig -kubectl-path $(KUBECTL) -ginkgo.focus "Webhook" || rc=1; \
 	$(KIND) delete cluster --name "intel-device-plugins"; \
 	rm -rf $(e2e_tmp_dir); \

--- a/cmd/fpga_admissionwebhook/README.md
+++ b/cmd/fpga_admissionwebhook/README.md
@@ -53,7 +53,7 @@ The webhook depends on having [cert-manager](https://cert-manager.io/)
 installed:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 Also if your cluster operates behind a corporate proxy make sure that the API

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -169,7 +169,7 @@ As a pre-requisite you need to have [cert-manager](https://cert-manager.io)
 up and running:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 $ kubectl get pods -n cert-manager
 NAME                                      READY   STATUS    RESTARTS   AGE
 cert-manager-7747db9d88-bd2nl             1/1     Running   0          1m

--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -19,7 +19,7 @@ The operator depends on [cert-manager](https://cert-manager.io/) running in the 
 To install it run:
 
 ```
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 Make sure all the pods in the `cert-manager` namespace are up and running:

--- a/cmd/sgx_admissionwebhook/README.md
+++ b/cmd/sgx_admissionwebhook/README.md
@@ -33,7 +33,7 @@ The simplest webhook deployment depends on having [cert-manager](https://cert-ma
 installed:
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 Also if your cluster operates behind a corporate proxy make sure that the API

--- a/cmd/sgx_plugin/README.md
+++ b/cmd/sgx_plugin/README.md
@@ -127,7 +127,7 @@ $ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/
 #### Deploy cert-manager
 
 ```bash
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
 ```
 
 #### Deploy Intel Device plugin operator


### PR DESCRIPTION
Apart from updating to the latest release this PR also fixes major issue with automatic e2e testing:

FPGA webhook pod wasn't able to run due to a hard to debug mount issue:
```
 At 2021-04-13 20:13:48 +0300 EEST - event for intelfpgaplugin-webhook-7b9c7b779c-rvtq4: ​​​​​​​​kubelet <host>:
FailedMount: MountVolume.SetUp failed for volume "cert" : secret "webhook-server-cert" not found
```
