### PR TITLE
Add "-enable-monitoring" option to GPU plugin + testing for its options

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -52,7 +52,8 @@ const (
 )
 
 type cliOptions struct {
-	sharedDevNum int
+	sharedDevNum     int
+	enableMonitoring bool
 }
 
 type devicePlugin struct {
@@ -166,8 +167,10 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 				klog.V(4).Infof("Adding %s to GPU %s", devPath, f.Name())
 				nodes = append(nodes, devSpec)
 			}
-			klog.V(4).Infof("Adding %s to GPU %s/%s", devPath, monitorType, monitorID)
-			monitor = append(monitor, devSpec)
+			if dp.options.enableMonitoring {
+				klog.V(4).Infof("Adding %s to GPU %s/%s", devPath, monitorType, monitorID)
+				monitor = append(monitor, devSpec)
+			}
 		}
 
 		if len(nodes) > 0 {
@@ -192,6 +195,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 func main() {
 	var opts cliOptions
 
+	flag.BoolVar(&opts.enableMonitoring, "enable-monitoring", false, "whether to enable 'i915_monitoring' (= all GPUs) resource")
 	flag.IntVar(&opts.sharedDevNum, "shared-dev-num", 1, "number of containers sharing the same GPU device")
 	flag.Parse()
 

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -155,7 +155,7 @@ func TestScan(t *testing.T) {
 		},
 	}
 
-	opts := cliOptions{sharedDevNum: 1}
+	opts := cliOptions{sharedDevNum: 1, enableMonitoring: true}
 
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -155,6 +155,8 @@ func TestScan(t *testing.T) {
 		},
 	}
 
+	opts := cliOptions{sharedDevNum: 1}
+
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			root, err := ioutil.TempDir("", "test_new_device_plugin")
@@ -169,7 +171,7 @@ func TestScan(t *testing.T) {
 				t.Errorf("unexpected error: %+v", err)
 			}
 
-			plugin := newDevicePlugin(sysfs, devfs, 1)
+			plugin := newDevicePlugin(sysfs, devfs, opts)
 
 			notifier := &mockNotifier{
 				scanDone: plugin.scanDone,

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -72,6 +72,7 @@ func TestScan(t *testing.T) {
 		devfsdirs        []string
 		sysfsdirs        []string
 		sysfsfiles       map[string][]byte
+		options          cliOptions
 		expectedDevs     int
 		expectedMonitors int
 	}{
@@ -95,18 +96,18 @@ func TestScan(t *testing.T) {
 			sysfsfiles: map[string][]byte{
 				"card0/device/vendor": []byte("0x8086"),
 			},
-			devfsdirs:        []string{"card0"},
-			expectedDevs:     1,
-			expectedMonitors: 1,
+			devfsdirs:    []string{"card0"},
+			expectedDevs: 1,
 		},
 		{
-			name:      "sriov-1-pf-no-vfs",
+			name:      "sriov-1-pf-no-vfs + monitoring",
 			sysfsdirs: []string{"card0/device/drm/card0", "card0/device/drm/controlD64"},
 			sysfsfiles: map[string][]byte{
 				"card0/device/vendor":       []byte("0x8086"),
 				"card0/device/sriov_numvfs": []byte("0"),
 			},
 			devfsdirs:        []string{"card0"},
+			options:          cliOptions{enableMonitoring: true},
 			expectedDevs:     1,
 			expectedMonitors: 1,
 		},
@@ -120,9 +121,8 @@ func TestScan(t *testing.T) {
 				"card0/device/vendor": []byte("0x8086"),
 				"card1/device/vendor": []byte("0x8086"),
 			},
-			devfsdirs:        []string{"card0"},
-			expectedDevs:     1,
-			expectedMonitors: 1,
+			devfsdirs:    []string{"card0"},
+			expectedDevs: 1,
 		},
 		{
 			name: "sriov-1-pf-and-2-vfs",
@@ -137,8 +137,22 @@ func TestScan(t *testing.T) {
 				"card1/device/vendor":       []byte("0x8086"),
 				"card2/device/vendor":       []byte("0x8086"),
 			},
-			devfsdirs:        []string{"card0", "card1", "card2"},
-			expectedDevs:     2,
+			devfsdirs:    []string{"card0", "card1", "card2"},
+			expectedDevs: 2,
+		},
+		{
+			name: "two devices with 13 shares + monitoring",
+			sysfsdirs: []string{
+				"card0/device/drm/card0",
+				"card1/device/drm/card1",
+			},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor": []byte("0x8086"),
+				"card1/device/vendor": []byte("0x8086"),
+			},
+			devfsdirs:        []string{"card0", "card1"},
+			options:          cliOptions{sharedDevNum: 13, enableMonitoring: true},
+			expectedDevs:     26,
 			expectedMonitors: 1,
 		},
 		{
@@ -150,14 +164,24 @@ func TestScan(t *testing.T) {
 			devfsdirs: []string{"card0"},
 		},
 		{
+			name:      "wrong vendor with 13 shares + monitoring",
+			sysfsdirs: []string{"card0/device/drm/card0"},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor": []byte("0xbeef"),
+			},
+			devfsdirs: []string{"card0"},
+			options:   cliOptions{sharedDevNum: 13, enableMonitoring: true},
+		},
+		{
 			name:      "no sysfs records",
 			sysfsdirs: []string{"non_gpu_card"},
 		},
 	}
 
-	opts := cliOptions{sharedDevNum: 1, enableMonitoring: true}
-
 	for _, tc := range tcases {
+		if tc.options.sharedDevNum == 0 {
+			tc.options.sharedDevNum = 1
+		}
 		t.Run(tc.name, func(t *testing.T) {
 			root, err := ioutil.TempDir("", "test_new_device_plugin")
 			if err != nil {
@@ -171,7 +195,7 @@ func TestScan(t *testing.T) {
 				t.Errorf("unexpected error: %+v", err)
 			}
 
-			plugin := newDevicePlugin(sysfs, devfs, opts)
+			plugin := newDevicePlugin(sysfs, devfs, tc.options)
 
 			notifier := &mockNotifier{
 				scanDone: plugin.scanDone,


### PR DESCRIPTION
Commits in this PR do following changes for the GPU plugin:

* Disable "i915_monitoring" resource by default, and add "-enable-monitoring" option so that this resource (exposing all node GPUs) can be enabled only when needed
* Move options to their own struct, so their use is more explicit (no magic values) and they can be more easily passed around
* Add testing for the new option, and also for the device sharing option that was missing testing support

---

These changes were dropped from latest versions of the PR:
* WIP/untested operator support for the new option (I will test it properly after it's clear whether rest of the changes are going to be accepted)
* Because option combinations change how GPU plugin should interpret the test environment, they and the expected resulting values are an additional testing dimension. Therefore, each test-case can have an array of them, and there's an additional loop going through these combinations

Alternatives for the last item are:
* Having the option combinations array separate from sysfs/devfs setup array.  Advantage of this is the best testing coverage (all options combos are tested with all test setups) with least amount of lines, but it requires few additional ifs to the test loop. When this was discussed in #615, people seemed to prefer slightly the approach I've taken now, but I'm fine with either of them. Example of how this could look (with additional options) is here: https://github.com/eero-t/intel-device-plugins-for-kubernetes/commit/1901af86889193c18a25abeb93e2831f9450e3f9
* Flattening the 2-dimensional test-case data to 1 dimension. This avoids the need for additional loop, but has the downside of needing larger amount of test-case duplication to provide as good coverage
