### PR TITLE
Skip PF for "i915" resource when it has VFs

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -100,6 +100,17 @@ func TestScan(t *testing.T) {
 			expectedMonitors: 1,
 		},
 		{
+			name:      "sriov-1-pf-no-vfs",
+			sysfsdirs: []string{"card0/device/drm/card0", "card0/device/drm/controlD64"},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor":       []byte("0x8086"),
+				"card0/device/sriov_numvfs": []byte("0"),
+			},
+			devfsdirs:        []string{"card0"},
+			expectedDevs:     1,
+			expectedMonitors: 1,
+		},
+		{
 			name: "two sysfs records but one dev node",
 			sysfsdirs: []string{
 				"card0/device/drm/card0",
@@ -114,16 +125,19 @@ func TestScan(t *testing.T) {
 			expectedMonitors: 1,
 		},
 		{
-			name: "two devices",
+			name: "sriov-1-pf-and-2-vfs",
 			sysfsdirs: []string{
 				"card0/device/drm/card0",
 				"card1/device/drm/card1",
+				"card2/device/drm/card2",
 			},
 			sysfsfiles: map[string][]byte{
-				"card0/device/vendor": []byte("0x8086"),
-				"card1/device/vendor": []byte("0x8086"),
+				"card0/device/vendor":       []byte("0x8086"),
+				"card0/device/sriov_numvfs": []byte("2"),
+				"card1/device/vendor":       []byte("0x8086"),
+				"card2/device/vendor":       []byte("0x8086"),
 			},
-			devfsdirs:        []string{"card0", "card1"},
+			devfsdirs:        []string{"card0", "card1", "card2"},
 			expectedDevs:     2,
 			expectedMonitors: 1,
 		},


### PR DESCRIPTION
NOTE: this has impact only for GPUs which are virtualized with SR-IOV.

Access to physical devices (PFs) is disabled for "i915" resource when they have configured virtual devices (VFs).

This is because:

* GPU resources are expected to be evenly split between VFs in such configurations

* But PF resource amount is expected to differ from VFs and typically retain only enough resources (just few MB of RAM), to be able to provide GPU metrics that are not available from VFs

* Neither the current GPU plugin, nor Kubernetes scheduling in general, has proper support for heterogeneous GPUs (= capability based scheduling)

Therefore "i915" resource needs to be limited to GPU devices with homogeneous amount of resources, which in SR-IOV configurations is expected to be the case only with VFs (when such are present).

---

Related sysfs files are described e.g. here: https://android.googlesource.com/kernel/common/+/refs/heads/android-mainline/Documentation/ABI/testing/sysfs-bus-pci

---

PS. Current HW / FW / i915 kernel module combination does not support resource amounts differing between VFs, or PF having same amount of resources as what VFs have.  But configuring them differently should be possible later on.

It would be good to have a note about the expected SR-IOV GPU configuration also in Intel plugins documentation before that, but I don't know where.

(If devices operator will get support for setting up i915 kernel module, I assume it will also have support for setting up suitable SR-IOV configuration for it.)
