### PR TITLE
opae-nlb-demo: fix GCC 11 errors

### DIFF
--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /usr/src/opae && \
 RUN cd /usr/src/opae/opae-sdk-${OPAE_RELEASE} && \
     mkdir build && \
     cd build && \
+    CFLAGS="$CFLAGS -Wno-misleading-indentation" \
     cmake -DCMAKE_BUILD_TYPE=Release -DOPAE_BUILD_LIBOPAE_PY=OFF .. && \
     make xfpga nlb0 nlb3
 


### PR DESCRIPTION
With GCC 11, the build triggers errors:

/usr/src/opae/opae-sdk-1.5.0-2/opae-libs/include/opae/log.h:51:1: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   51 | if (p > file)                                                  \
      | ^~
...

Workaround the problem with -Wno-misleading-indentation.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>