### PR TITLE
images: move most plugin images to distroless/static

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
           - intel-gpu-plugin
           - intel-fpga-plugin
           - intel-qat-plugin
+          - intel-qat-plugin-kerneldrv
           - intel-vpu-plugin
           - intel-deviceplugin-operator
           - intel-sgx-admissionwebhook

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
           steps {
             dir(path: "$REPO_DIR") {
               sh "make pre-pull"
+              sh "make -e vendor"
             }
           }
         }

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -1,39 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/operator; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/operator \
-    && install -D /go/bin/operator /install_root/usr/local/bin/intel_deviceplugin_operator \
+RUN cd cmd/operator; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/operator /install_root/usr/local/bin/intel_deviceplugin_operator \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/operator /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
-RUN groupadd -g 3210 operator && useradd operator -u 3210 -g 3210
 ENTRYPOINT ["/usr/local/bin/intel_deviceplugin_operator"]

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -1,39 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/fpga_admissionwebhook \
-    && install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
+RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/fpga_admissionwebhook /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
-RUN groupadd -g 3210 fpga && useradd fpga -u 3210 -g 3210
 ENTRYPOINT ["/usr/local/bin/intel_fpga_admissionwebhook"]

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -1,38 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/fpga_plugin \
-    && install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
+RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/fpga_plugin /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
 ENTRYPOINT ["/usr/local/bin/intel_fpga_device_plugin"]

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -1,38 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/gpu_plugin \
-    && install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
+RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/gpu_plugin /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
 ENTRYPOINT ["/usr/local/bin/intel_gpu_device_plugin"]

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -1,0 +1,53 @@
+# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
+# reproducible by choosing an image by its hash and installing an OS version
+# with --version=:
+# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
+# CLEAR_LINUX_VERSION="--version=29970"
+#
+# This is used on release branches before tagging a stable version.
+# The master branch defaults to using the latest Clear Linux.
+ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+
+FROM ${CLEAR_LINUX_BASE} as builder
+
+ARG CLEAR_LINUX_VERSION=
+
+RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+RUN ldconfig
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+WORKDIR $DIR
+COPY . .
+
+ARG TAGS_KERNELDRV=kerneldrv
+
+RUN mkdir /install_root \
+    && swupd os-install \
+    ${CLEAR_LINUX_VERSION} \
+    --path /install_root \
+    --statedir /swupd-state \
+    $(test -z "${TAGS_KERNELDRV}" || echo "--bundles=libstdcpp") \
+    --no-boot-update \
+    && rm -rf /install_root/var/lib/swupd/*
+
+ARG QAT_DRIVER_RELEASE="qat1.7.l.4.11.0-00001"
+
+RUN test -z "${TAGS_KERNELDRV}" \
+    || ( swupd bundle-add wget c-basic \
+    && mkdir -p /usr/src/qat \
+    && cd /usr/src/qat  \
+    && wget https://01.org/sites/default/files/downloads/${QAT_DRIVER_RELEASE}.tar.gz \
+    && tar xf *.tar.gz \
+    && cd /usr/src/qat/quickassist/utilities/adf_ctl \
+    && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
+    && install -D adf_ctl /install_root/usr/local/bin/adf_ctl )
+RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; GO111MODULE=${GO111MODULE} go install -tags "${TAGS_KERNELDRV}"; cd -
+RUN chmod a+x /go/bin/qat_plugin \
+    && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
+    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && scripts/copy-modules-licenses.sh ./cmd/qat_plugin /install_root/usr/local/share/
+
+FROM scratch as final
+COPY --from=builder /install_root /
+ENV PATH=/usr/local/bin
+ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -1,53 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-ARG TAGS_KERNELDRV=
-
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    $(test -z "${TAGS_KERNELDRV}" || echo "--bundles=libstdcpp") \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-ARG QAT_DRIVER_RELEASE="qat1.7.l.4.11.0-00001"
-
-RUN test -z "${TAGS_KERNELDRV}" \
-    || ( swupd bundle-add wget c-basic \
-    && mkdir -p /usr/src/qat \
-    && cd /usr/src/qat  \
-    && wget https://01.org/sites/default/files/downloads/${QAT_DRIVER_RELEASE}.tar.gz \
-    && tar xf *.tar.gz \
-    && cd /usr/src/qat/quickassist/utilities/adf_ctl \
-    && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
-    && install -D adf_ctl /install_root/usr/local/bin/adf_ctl )
-RUN cd cmd/qat_plugin; echo "build tags: ${TAGS_KERNELDRV}"; GO111MODULE=${GO111MODULE} go install -tags "${TAGS_KERNELDRV}"; cd -
-RUN chmod a+x /go/bin/qat_plugin \
-    && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
+RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/qat_plugin /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
-ENV PATH=/usr/local/bin
 ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -1,39 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/sgx_admissionwebhook; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/sgx_admissionwebhook \
-    && install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sgx_admissionwebhook \
+RUN cd cmd/sgx_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sgx_admissionwebhook \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/sgx_admissionwebhook /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
-RUN groupadd -g 3210 sgx && useradd sgx -u 3210 -g 3210
 ENTRYPOINT ["/usr/local/bin/intel_sgx_admissionwebhook"]

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -1,38 +1,38 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
+# Copyright 2021 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOLANG_BASE can be used to make the build reproducible by choosing an
+# image by its hash:
+# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
 #
 # This is used on release branches before tagging a stable version.
-# The master branch defaults to using the latest Clear Linux.
-ARG CLEAR_LINUX_BASE=clearlinux/golang:latest
+# The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.15-buster
 
-FROM ${CLEAR_LINUX_BASE} as builder
+FROM ${GOLANG_BASE} as builder
 
-ARG CLEAR_LINUX_VERSION=
-
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
-RUN ldconfig
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
 WORKDIR $DIR
 COPY . .
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
-
-RUN cd cmd/sgx_plugin; GO111MODULE=${GO111MODULE} go install; cd -
-RUN chmod a+x /go/bin/sgx_plugin \
-    && install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_plugin \
+RUN cd cmd/sgx_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && scripts/copy-modules-licenses.sh ./cmd/sgx_plugin /install_root/usr/local/share/
 
-FROM scratch as final
+FROM gcr.io/distroless/static
 COPY --from=builder /install_root /
 ENTRYPOINT ["/usr/local/bin/intel_sgx_device_plugin"]

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -166,7 +166,7 @@ $ make intel-qat-plugin
 Successfully tagged intel/intel-qat-plugin:devel
 ```
 
-> **Note**: `kerneldrv` mode is excluded from the build by default. Add `EXTRA_BUILD_ARGS="--build-arg TAGS_KERNELDRV=kerneldrv"` to `make`
+> **Note**: `kerneldrv` mode is excluded from the build by default. Add `EXTRA_BUILD_ARGS="--build-arg TAGS_KERNELDRV=kerneldrv"` and run `make intel-qat-plugin-kerneldrv`
 > to get `kerneldrv` functionality added to the build.
 
 #### Deploy the DaemonSet

--- a/deployments/fpga_admissionwebhook/manager/manager.yaml
+++ b/deployments/fpga_admissionwebhook/manager/manager.yaml
@@ -21,8 +21,8 @@ spec:
         name: manager
         securityContext:
           runAsNonRoot: true
-          runAsUser: 3210
-          runAsGroup: 3210
+          runAsUser: 65532
+          runAsGroup: 65532
           readOnlyRootFilesystem: true
         resources:
           limits:

--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -35,8 +35,8 @@ spec:
             memory: 20Mi
         securityContext:
           runAsNonRoot: true
-          runAsUser: 3210
-          runAsGroup: 3210
+          runAsUser: 65532
+          runAsGroup: 65532
           readOnlyRootFilesystem: true
         env:
           - name: DEVICEPLUGIN_NAMESPACE

--- a/deployments/sgx_admissionwebhook/manager/manager.yaml
+++ b/deployments/sgx_admissionwebhook/manager/manager.yaml
@@ -21,8 +21,8 @@ spec:
         name: manager
         securityContext:
           runAsNonRoot: true
-          runAsUser: 3210
-          runAsGroup: 3210
+          runAsUser: 65532
+          runAsGroup: 65532
           readOnlyRootFilesystem: true
         resources:
           limits:

--- a/scripts/copy-modules-licenses.sh
+++ b/scripts/copy-modules-licenses.sh
@@ -47,7 +47,7 @@ for lic in $LICENSE_FILES; do
 			if [ ! -d $2/package-sources ]; then
 				mkdir $2/package-sources
 			fi
-			tar -Jvcf  $2/package-sources/$(echo $DIR | tr / _).tar.xz $DIR
+			tar -zvcf  $2/package-sources/$(echo $DIR | tr / _).tar.gz $DIR
 		fi
 	fi
 done


### PR DESCRIPTION
All but one (VPU) of the published container images can be built with
static binaries which allows us to use distroless/static as the
base image. Moreover, when combined with stripping the plugin binaries,
we can get both build time and image size savings.

This is the part 1 (out of 2) of the rework. Part 2 will finish the
change by making some adjustments to VPU plugin image and moving the
FPGA/SGX/GPU initcontainers to distroless/static too.

Partial: #516

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>
Signed-off-by: Ed Bartosh <eduard.bartosh@intel.com>