### PR TITLE
qatdeviceplugin_webhook: Extract only relevant parts for the validation

### DIFF
--- a/pkg/apis/deviceplugin/v1/qatdeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/qatdeviceplugin_webhook.go
@@ -15,8 +15,6 @@
 package v1
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -88,27 +86,5 @@ func (r *QatDevicePlugin) ValidateDelete() error {
 }
 
 func (r *QatDevicePlugin) validatePlugin() error {
-	parts := strings.SplitN(r.Spec.Image, ":", 2)
-	if len(parts) != 2 {
-		return errors.Errorf("incorrect image field %q", r.Spec.Image)
-	}
-	namespacedName := parts[0]
-	versionStr := parts[1]
-
-	parts = strings.Split(namespacedName, "/")
-	name := parts[len(parts)-1]
-	if name != "intel-qat-plugin" {
-		return errors.Errorf("incorrect image name %q. Make sure you use '<vendor>/intel-qat-plugin:<version>'", name)
-	}
-
-	ver, err := version.ParseSemantic(versionStr)
-	if err != nil {
-		return errors.Wrapf(err, "unable to parse version %q", versionStr)
-	}
-
-	if !ver.AtLeast(qatMinVersion) {
-		return errors.Errorf("version %q is too low. Should be at least %q", ver, qatMinVersion)
-	}
-
-	return nil
+	return validatePluginImage(r.Spec.Image, "intel-qat-plugin", qatMinVersion)
 }


### PR DESCRIPTION
Since we currently validate only the image name and the tag,
ignore registry, vendor and extract only relevant parts.

Closes #605
