### PR TITLE
remove monitoring arg from fractional resource overlay

### DIFF
--- a/deployments/gpu_plugin/overlays/fractional_resources/add-args.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/add-args.yaml
@@ -9,5 +9,4 @@ spec:
       - name: intel-gpu-plugin
         args:
         - "-shared-dev-num=300"
-        - "-enable-monitoring"
         - "-resource-manager"


### PR DESCRIPTION
An easter-egg slipped in the args. This removes it.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>