### PR TITLE
Make GPU plugin intro information more generic & accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,8 @@ The below sections detail existing plugins developed using the framework.
 
 ### GPU device plugin
 
-The [GPU device plugin](cmd/gpu_plugin/README.md) supports Intel GPUs of the following hardware families:
-- Intel Xe discrete GPUs, including Xe-LP, Xe-HPG and Xe-HP SDV
-- Integrated GPUs within Intel Core processors
-- Integrated GPUs Intel Xeon processors
+The [GPU device plugin](cmd/gpu_plugin/README.md) provides access to Intel discrete (Xe)
+and integrated GPU HW device files.
 
 The demo subdirectory contains both a [GPU plugin demo video](demo/readme.md#intel-gpu-device-plugin-demo-video)
 as well as code for an OpenCL [FFT demo](demo/ubuntu-demo-opencl).

--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -20,26 +20,19 @@ Table of Contents
 
 ## Introduction
 
-The GPU device plugin for Kubernetes supports acceleration using the following Intel GPU hardware families:
+Intel GPU plugin facilitates Kubernetes workload offloading by providing access to
+Intel discrete (Xe) and integrated GPU HW device files.
 
-- Intel Xe discrete GPUs, including Xe-LP, Xe-HPG, Xe-HP SDV and XG310 
-- Integrated GPUs within Intel Core processors
-- Integrated GPUs within Intel Xeon processors
-- Intel Visual Compute Accelerator (Intel VCA)
-
-The GPU plugin facilitates offloading the processing of computation intensive workloads to GPU hardware.
-Use cases include:
-
+Use cases include, but are not limited to:
 - Media transcode 
 - Media analytics
 - Cloud gaming
 - High performance computing
 - AI training and inference
 
-For example, Intel oneAPI Video Processing Linbrary can offload video transcoding operations, and OpenCL or oneAPI Level Zero libraries can provide computation acceleration for Intel GPUs.
-
-The device plugin can also be used with [GVT-d](https://github.com/intel/gvt-linux/wiki/GVTd_Setup_Guide) device
-passthrough and acceleration.
+For example containers with Intel media driver (and components using that), can offload
+video transcoding operations, and containers with the Intel OpenCL / oneAPI Level Zero
+backend libraries can offload compute operations to GPU.
 
 ### Configuration options
 


### PR DESCRIPTION
* Information on specific HW & virtualization types on which GPU plugin is tested on, belongs to releases notes, not to README intro (where it has already became obsolete)
* HW offloading is provided by driver backends, not frontends (e.g. OneVPL is just one of the media driver frontends)
* Offloading can also be done for workloads that are not computationally intensive.  It's completely workload dependent whether that helps either with performance, power usage, both or neither