### PR TITLE
Add "-enable-monitoring" GPU plugin option operator support

### DIFF
--- a/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
+++ b/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
@@ -51,6 +51,10 @@ spec:
           spec:
             description: GpuDevicePluginSpec defines the desired state of GpuDevicePlugin.
             properties:
+              enableMonitoring:
+                description: EnableMonitoring enables the monitoring resource ('i915_monitoring')
+                  which gives access to all GPU devices on given node.
+                type: boolean
               image:
                 description: Image is a container image with GPU device plugin executable.
                 type: string

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
@@ -31,20 +31,20 @@ type GpuDevicePluginSpec struct {
 	// InitImage is a container image with tools (e.g., GPU NFD source hook) installed on each node.
 	InitImage string `json:"initImage,omitempty"`
 
-	// EnableMonitoring enables the monitoring resource ('i915_monitoring')
-	// which gives access to all GPU devices on given node.
-	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
-
 	// SharedDevNum is a number of containers that can share the same GPU device.
 	// +kubebuilder:validation:Minimum=1
 	SharedDevNum int `json:"sharedDevNum,omitempty"`
 
-	// ResourceManager handles the fractional resource management for multi-GPU nodes
-	ResourceManager bool `json:"resourceManager,omitempty"`
-
 	// LogLevel sets the plugin's log level.
 	// +kubebuilder:validation:Minimum=0
 	LogLevel int `json:"logLevel,omitempty"`
+
+	// ResourceManager handles the fractional resource management for multi-GPU nodes
+	ResourceManager bool `json:"resourceManager,omitempty"`
+
+	// EnableMonitoring enables the monitoring resource ('i915_monitoring')
+	// which gives access to all GPU devices on given node.
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
 
 	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
@@ -31,6 +31,10 @@ type GpuDevicePluginSpec struct {
 	// InitImage is a container image with tools (e.g., GPU NFD source hook) installed on each node.
 	InitImage string `json:"initImage,omitempty"`
 
+	// EnableMonitoring enables the monitoring resource ('i915_monitoring')
+	// which gives access to all GPU devices on given node.
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
+
 	// SharedDevNum is a number of containers that can share the same GPU device.
 	// +kubebuilder:validation:Minimum=1
 	SharedDevNum int `json:"sharedDevNum,omitempty"`

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -393,6 +393,10 @@ func getPodArgs(gdp *devicepluginv1.GpuDevicePlugin) []string {
 	args := make([]string, 0, 4)
 	args = append(args, "-v", strconv.Itoa(gdp.Spec.LogLevel))
 
+	if gdp.Spec.EnableMonitoring {
+		args = append(args, "-enable-monitoring")
+	}
+
 	if gdp.Spec.SharedDevNum > 0 {
 		args = append(args, "-shared-dev-num", strconv.Itoa(gdp.Spec.SharedDevNum))
 	} else {


### PR DESCRIPTION
Earlier added 'i915_monitoring' support is disabled by default, so this is needed to be able to use it when operator is used.

Based on Ukri's examples and tested by Ukri.
