### PR TITLE
demo: crypto-perf: update test tool parameters

### DIFF
--- a/demo/crypto-perf/run-dpdk-test
+++ b/demo/crypto-perf/run-dpdk-test
@@ -10,13 +10,10 @@ fi
 
 PCI_ALLOWLIST=""
 
-for i in `echo ${!QAT*}`; do PCI_ALLOWLIST="$PCI_ALLOWLIST -w ${!i}"; done
+for i in `echo ${!QAT*}`; do PCI_ALLOWLIST="$PCI_ALLOWLIST -a ${!i}"; done
 
-# "The default mempool handler is ring based."
-MEMPOOL=$(ls /usr/lib64/librte_mempool_ring.so*|tail -1)
-PMD_QAT=$(ls /usr/lib64/librte_pmd_qat.so*|tail -1)
 LCORE=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
 
-EAL="-l ${LCORE} ${PCI_ALLOWLIST} -d ${MEMPOOL} -d ${PMD_QAT}"
+EAL="-l ${LCORE} ${PCI_ALLOWLIST}"
 
 dpdk-test-${TESTCMD}-perf ${EAL} -- ${PTEST} \


### PR DESCRIPTION
The run-dpdk-test helper script builds dpdk-test-[compress|crypto]-perf
command line parameters dynamically. Some of the parameters were changed
in the recent DPDK builds and need updating.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>