### PR TITLE
Add exported setter function for topology in DeviceInfo struct

### DIFF
--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -66,6 +66,11 @@ func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginap
 	return deviceInfo
 }
 
+// SetTopology sets the topology information in DeviceInfo struct
+func (d *DeviceInfo) SetTopology(topologyInfo *pluginapi.TopologyInfo) {
+	d.topology = topologyInfo
+}
+
 // DeviceTree contains a tree-like structure of device type -> device ID -> device info.
 type DeviceTree map[string]map[string]DeviceInfo
 


### PR DESCRIPTION
Allows custom handling of the topologyInfo for devices rejected by FindSysFsDevice()