### PR TITLE
Add goerr113 linter check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - goconst
     - gocyclo
     - godot
+    - goerr113
     - gofmt
     - goimports
     - gomodguard

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -207,12 +206,12 @@ func getStdin(reader io.Reader) (*Stdin, error) {
 
 	// Check if device plugin annotation is set
 	if stdinJ.Annotations.ComIntelFpgaMode == "" {
-		return nil, fmt.Errorf("annotation %s is not set", annotationName)
+		return nil, errors.Errorf("annotation %s is not set", annotationName)
 	}
 
 	// Check if device plugin annotation is set
 	if stdinJ.Annotations.ComIntelFpgaMode != annotationValue {
-		return nil, fmt.Errorf("annotation %s has incorrect value '%s'", annotationName, stdinJ.Annotations.ComIntelFpgaMode)
+		return nil, errors.Errorf("annotation %s has incorrect value '%s'", annotationName, stdinJ.Annotations.ComIntelFpgaMode)
 	}
 
 	if stdinJ.Bundle == "" {
@@ -220,7 +219,7 @@ func getStdin(reader io.Reader) (*Stdin, error) {
 	}
 
 	if _, err := os.Stat(stdinJ.Bundle); err != nil {
-		return nil, fmt.Errorf("bundle directory %s: stat error: %+v", stdinJ.Bundle, err)
+		return nil, errors.Wrapf(err, "bundle directory: %s", stdinJ.Bundle)
 	}
 
 	return &stdinJ, nil

--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -190,7 +190,7 @@ func newDevicePlugin(mode string, rootPath string) (*devicePlugin, error) {
 	if _, err = os.Stat(sysfsPathOPAE); os.IsNotExist(err) {
 		sysfsPathDFL := path.Join(rootPath, sysfsDirectoryDFL)
 		if _, err = os.Stat(sysfsPathDFL); os.IsNotExist(err) {
-			return nil, fmt.Errorf("kernel driver is not loaded: neither %s nor %s sysfs entry exists", sysfsPathOPAE, sysfsPathDFL)
+			return nil, errors.Errorf("kernel driver is not loaded: neither %s nor %s sysfs entry exists", sysfsPathOPAE, sysfsPathDFL)
 		}
 		dp, err = newDevicePluginDFL(sysfsPathDFL, devfsPath, mode)
 	} else {

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -61,11 +60,11 @@ func createTestDirs(devfs, sysfs string, devfsDirs, sysfsDirs []string, sysfsFil
 func validateDevTree(expectedDevTreeKeys map[string][]string, devTree dpapi.DeviceTree) error {
 	for resource, devices := range expectedDevTreeKeys {
 		if _, ok := devTree[resource]; !ok {
-			return fmt.Errorf("device tree: resource %s missing", resource)
+			return errors.Errorf("device tree: resource %s missing", resource)
 		}
 		for _, device := range devices {
 			if _, ok := devTree[resource][device]; !ok {
-				return fmt.Errorf("device tree resource %s: device %s missing", resource, device)
+				return errors.Errorf("device tree resource %s: device %s missing", resource, device)
 			}
 		}
 	}

--- a/cmd/fpga_plugin/mode.go
+++ b/cmd/fpga_plugin/mode.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -15,7 +15,7 @@ func getModeOverrideFromCluster(nodeName, kubeConfig, master, mode string) (stri
 	var err error
 
 	if len(nodeName) == 0 {
-		return mode, fmt.Errorf("node name is not set")
+		return mode, errors.New("node name is not set")
 	}
 
 	if len(kubeConfig) == 0 {

--- a/cmd/fpga_tool/fpga_tool.go
+++ b/cmd/fpga_tool/fpga_tool.go
@@ -140,7 +140,7 @@ func installBitstream(fname string, dryRun, force, quiet bool) (err error) {
 	dst, err := os.OpenFile(installPath, flags, 0644)
 	if err != nil {
 		if os.IsExist(err) {
-			return fmt.Errorf("destination file %q already exist. Use --force to overwrite it", installPath)
+			return errors.Wrapf(err, "destination file %q already exist. Use --force to overwrite it", installPath)
 		}
 		return errors.Wrap(err, "can't create destination file")
 	}

--- a/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
@@ -34,6 +34,8 @@ import (
 	fakeexec "k8s.io/utils/exec/testing"
 )
 
+var errFake = errors.New("fake error")
+
 const (
 	adfCtlOutput = `Checking status of all devices.
 There is 3 QAT acceleration device(s) in the system:
@@ -92,7 +94,7 @@ func TestGetOnlineDevices(t *testing.T) {
 		},
 		{
 			name:        "adf_ctl fails to run",
-			adfCtlError: errors.New("fake error"),
+			adfCtlError: errFake,
 			expectedErr: true,
 		},
 	}

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -35,6 +35,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	errFake = errors.New("Fake error")
+)
+
 const (
 	devicePluginPath = "/tmp/"
 	kubeletSocket    = devicePluginPath + "kubelet-test.sock"
@@ -338,7 +342,7 @@ func TestAllocate(t *testing.T) {
 				},
 			},
 			postAllocate: func(resp *pluginapi.AllocateResponse) error {
-				return fmt.Errorf("Fake error for %s", "dev1")
+				return fmt.Errorf("%w for %q", errFake, "dev1")
 			},
 			expectedErr: true,
 		},
@@ -380,7 +384,7 @@ func (s *listAndWatchServerStub) Send(resp *pluginapi.ListAndWatchResponse) erro
 	s.sendCounter = s.sendCounter + 1
 	if s.generateErr == s.sendCounter {
 		klog.V(4).Info("listAndWatchServerStub::Send returns error")
-		return fmt.Errorf("Fake error")
+		return errFake
 	}
 
 	klog.V(4).Info("listAndWatchServerStub::Send", resp.Devices)

--- a/pkg/fpgacontroller/fpgacontroller_test.go
+++ b/pkg/fpgacontroller/fpgacontroller_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	logger = ctrl.Log.WithName("test")
-	scheme = runtime.NewScheme()
+	errClient = errors.New("client error")
+	logger    = ctrl.Log.WithName("test")
+	scheme    = runtime.NewScheme()
 )
 
 func init() {
@@ -51,7 +52,7 @@ func TestAcceleratorFunctionReconcile(t *testing.T) {
 		},
 		{
 			name:        "client error",
-			getError:    errors.New("client error"),
+			getError:    errClient,
 			expectedErr: true,
 		},
 		{
@@ -102,7 +103,7 @@ func TestFpgaRegionReconcile(t *testing.T) {
 		},
 		{
 			name:        "client error",
-			getError:    errors.New("client error"),
+			getError:    errClient,
 			expectedErr: true,
 		},
 		{

--- a/pkg/idxd/plugin_test.go
+++ b/pkg/idxd/plugin_test.go
@@ -15,6 +15,7 @@
 package idxd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -23,6 +24,10 @@ import (
 
 	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/deviceplugin"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+var (
+	errUnitTest = errors.New("unit test error")
 )
 
 const (
@@ -239,16 +244,16 @@ func checkDeviceTree(deviceTree dpapi.DeviceTree, expectedResult map[string]int,
 		for key := range deviceTree {
 			val, ok := expectedResult[key]
 			if !ok {
-				return fmt.Errorf("unexpected device type: %s", key)
+				return fmt.Errorf("%w: unexpected device type: %s", errUnitTest, key)
 			}
 			numberDev := len(deviceTree[key])
 			if numberDev != val {
-				return fmt.Errorf("%s: unexpected number of devices: %d, expected: %d", key, numberDev, val)
+				return fmt.Errorf("%w: %s: unexpected number of devices: %d, expected: %d", errUnitTest, key, numberDev, val)
 			}
 			delete(expectedResult, key)
 		}
 		if len(expectedResult) > 0 {
-			return fmt.Errorf("missing expected result(s): %+v", expectedResult)
+			return fmt.Errorf("%w: missing expected result(s): %+v", errUnitTest, expectedResult)
 		}
 	}
 	return nil

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -79,7 +79,7 @@ func WaitForPodFailure(f *framework.Framework, name string, timeout time.Duratio
 			case v1.PodFailed:
 				return true, nil
 			case v1.PodSucceeded:
-				return true, fmt.Errorf("pod %q successed with reason: %q, message: %q", name, pod.Status.Reason, pod.Status.Message)
+				return true, errors.Errorf("pod %q successed with reason: %q, message: %q", name, pod.Status.Reason, pod.Status.Message)
 			default:
 				return false, nil
 			}


### PR DESCRIPTION
Add goerr113 lintercheck
Fix the usage of fmt.Errorf() by wrapping errors
Fix the usage of errors.New()

Closes: #641 