### PR TITLE
documentation: remove deprecated toc section in README

### DIFF
--- a/cmd/dsa_plugin/README.md
+++ b/cmd/dsa_plugin/README.md
@@ -6,7 +6,6 @@ Table of Contents
 * [Installation](#installation)
     * [Deploy with pre-built container image](#deploy-with-pre-built-container-image)
     * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Build the plugin image](#build-the-plugin-image)
         * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -9,7 +9,6 @@ Table of Contents
     * [Pre-built images](#pre-built-images)
     * [Dependencies](#dependencies)
     * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Verify plugin registration](#verify-plugin-registration)
         * [Building the plugin image](#building-the-plugin-image)

--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -7,7 +7,6 @@ Table of Contents
 * [Installation](#installation)
     * [Deploy with pre-built container image](#deploy-with-pre-built-container-image)
     * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Build the plugin image](#build-the-plugin-image)
         * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -8,7 +8,6 @@ Table of Contents
     * [Prerequisites](#prerequisites)
     * [Pre-built image](#pre-built-image)
     * [Getting the source code:](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Build the plugin image](#build-the-plugin-image)
         * [Deploy the DaemonSet](#deploy-the-daemonset)

--- a/cmd/sgx_plugin/README.md
+++ b/cmd/sgx_plugin/README.md
@@ -8,7 +8,6 @@ Contents
         * [Backwards compatiblity note](#backwards-compatibility-note)
     * [Deploying with Pre-built images](#deploying-with-pre-built-images)
     * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Build the plugin image](#build-the-plugin-image)
         * [Deploy the DaemonSet](#deploy-the-daemonset)

--- a/cmd/vpu_plugin/README.md
+++ b/cmd/vpu_plugin/README.md
@@ -5,7 +5,6 @@ Table of Contents
 * [Introduction](#introduction)
 * [Installation](#installation)
     * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
     * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
         * [Build the plugin image](#build-the-plugin-image)
         * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)


### PR DESCRIPTION
The 'Verify node kubelet config' content was removed in 6b208f8.

Signed-off-by: Li Ning <ning.a.li@transwarp.io>