### PR TITLE
webhooks: use common constant for plugin min version

### DIFF
--- a/pkg/apis/deviceplugin/v1/dsadeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/dsadeviceplugin_webhook.go
@@ -33,7 +33,7 @@ var (
 	// dsadevicepluginlog is for logging in this package.
 	dsadevicepluginlog = logf.Log.WithName("dsadeviceplugin-resource")
 
-	dsaMinVersion = version.MustParseSemantic("0.18.0")
+	dsaMinVersion = version.MustParseSemantic(imageMinVersion)
 )
 
 // SetupWebhookWithManager sets up a webhook for DsaDevicePlugin custom resources.
@@ -52,7 +52,7 @@ func (r *DsaDevicePlugin) Default() {
 	dsadevicepluginlog.Info("default", "name", r.Name)
 
 	if len(r.Spec.Image) == 0 {
-		r.Spec.Image = "intel/intel-dsa-plugin:0.18.0"
+		r.Spec.Image = "intel/intel-dsa-plugin:" + dsaMinVersion.String()
 	}
 }
 

--- a/pkg/apis/deviceplugin/v1/fpgadeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/fpgadeviceplugin_webhook.go
@@ -33,7 +33,7 @@ var (
 	// fpgadevicepluginlog is for logging in this package.
 	fpgadevicepluginlog = logf.Log.WithName("fpgadeviceplugin-resource")
 
-	fpgaMinVersion = version.MustParseSemantic("0.19.0")
+	fpgaMinVersion = version.MustParseSemantic(imageMinVersion)
 )
 
 // SetupWebhookWithManager sets up a webhook for FpgaDevicePlugin custom resources.
@@ -52,11 +52,11 @@ func (r *FpgaDevicePlugin) Default() {
 	fpgadevicepluginlog.Info("default", "name", r.Name)
 
 	if len(r.Spec.Image) == 0 {
-		r.Spec.Image = "intel/intel-fpga-plugin:0.19.0"
+		r.Spec.Image = "intel/intel-fpga-plugin:" + fpgaMinVersion.String()
 	}
 
 	if len(r.Spec.InitImage) == 0 {
-		r.Spec.InitImage = "intel/intel-fpga-initcontainer:0.19.0"
+		r.Spec.InitImage = "intel/intel-fpga-initcontainer:" + fpgaMinVersion.String()
 	}
 }
 

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
@@ -33,7 +33,7 @@ var (
 	// gpudevicepluginlog is for logging in this package.
 	gpudevicepluginlog = logf.Log.WithName("gpudeviceplugin-resource")
 
-	gpuMinVersion = version.MustParseSemantic("0.18.0")
+	gpuMinVersion = version.MustParseSemantic(imageMinVersion)
 )
 
 // SetupWebhookWithManager sets up a webhook for GpuDevicePlugin custom resources.
@@ -52,7 +52,7 @@ func (r *GpuDevicePlugin) Default() {
 	gpudevicepluginlog.Info("default", "name", r.Name)
 
 	if len(r.Spec.Image) == 0 {
-		r.Spec.Image = "intel/intel-gpu-plugin:0.18.0"
+		r.Spec.Image = "intel/intel-gpu-plugin:" + gpuMinVersion.String()
 	}
 }
 

--- a/pkg/apis/deviceplugin/v1/qatdeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/qatdeviceplugin_webhook.go
@@ -33,7 +33,7 @@ var (
 	// qatdevicepluginlog is for logging in this package.
 	qatdevicepluginlog = logf.Log.WithName("qatdeviceplugin-resource")
 
-	qatMinVersion = version.MustParseSemantic("0.18.0")
+	qatMinVersion = version.MustParseSemantic(imageMinVersion)
 )
 
 // SetupWebhookWithManager sets up a webhook for QatDevicePlugin custom resources.
@@ -52,7 +52,7 @@ func (r *QatDevicePlugin) Default() {
 	qatdevicepluginlog.Info("default", "name", r.Name)
 
 	if len(r.Spec.Image) == 0 {
-		r.Spec.Image = "intel/intel-qat-plugin:0.18.0"
+		r.Spec.Image = "intel/intel-qat-plugin:" + qatMinVersion.String()
 	}
 }
 

--- a/pkg/apis/deviceplugin/v1/sgxdeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/sgxdeviceplugin_webhook.go
@@ -33,7 +33,7 @@ var (
 	// sgxdevicepluginlog is for logging in this package.
 	sgxdevicepluginlog = logf.Log.WithName("sgxdeviceplugin-resource")
 
-	sgxMinVersion = version.MustParseSemantic("0.19.0")
+	sgxMinVersion = version.MustParseSemantic(imageMinVersion)
 )
 
 // SetupWebhookWithManager sets up a webhook for SgxDevicePlugin custom resources.
@@ -52,11 +52,11 @@ func (r *SgxDevicePlugin) Default() {
 	sgxdevicepluginlog.Info("default", "name", r.Name)
 
 	if len(r.Spec.Image) == 0 {
-		r.Spec.Image = "intel/intel-sgx-plugin:0.19.0"
+		r.Spec.Image = "intel/intel-sgx-plugin:" + sgxMinVersion.String()
 	}
 
 	if len(r.Spec.InitImage) == 0 {
-		r.Spec.Image = "intel/intel-sgx-initcontainer:0.19.0"
+		r.Spec.Image = "intel/intel-sgx-initcontainer:" + sgxMinVersion.String()
 	}
 }
 

--- a/pkg/apis/deviceplugin/v1/webhook_common.go
+++ b/pkg/apis/deviceplugin/v1/webhook_common.go
@@ -22,6 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
+// common constants for webhooks.
+const imageMinVersion string = "0.21.0"
+
 // common functions for webhooks
 
 func validatePluginImage(image, expectedImageName string, expectedMinVersion *version.Version) error {


### PR DESCRIPTION
Move CRD validating webhooks' image min version checks to use
common constant across all the plugins.

After the change, we carry the same min version for all devices
and this version becomes easier to maintain when we make new
releases.

Each CRD webhook still carries its own xyzMinVersion if we decide
to go back to CRD specific versions later.

Closes: #627 