### PR TITLE
Add checksum checks for toybox and qat driver

### DIFF
--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -50,9 +50,13 @@ RUN echo "{\n\
     \"annotation\": [ \"fpga.intel.com/region\" ]\n\
 }\n">>$ROOT/$SRC_DIR/$CRI_HOOK.json
 
-ARG TOYBOX_VERSION="0.8.4"
+ARG TOYBOX_VERSION="0.8.5"
+ARG TOYBOX_SHA256="27cc073222f3b726ee10d96c4f32ac2c4c936b07ea195227736755971e6d90c9"
 RUN apt update && apt -y install musl musl-tools musl-dev
-RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz | tar xz \
+RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
+    && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
+    && tar -xzf toybox.tar.gz \
+    && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -41,9 +41,14 @@ ARG SRC_DIR=/usr/local/bin/gpu-sw
 
 RUN install -D /go/bin/gpu_nfdhook $ROOT/$SRC_DIR/$NFD_HOOK
 
-ARG TOYBOX_VERSION="0.8.4"
+ARG TOYBOX_VERSION="0.8.5"
+ARG TOYBOX_SHA256="27cc073222f3b726ee10d96c4f32ac2c4c936b07ea195227736755971e6d90c9"
+
 RUN apt update && apt -y install musl musl-tools musl-dev
-RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz | tar xz \
+RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
+    && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
+    && tar -xzf toybox.tar.gz \
+    && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -29,10 +29,12 @@ WORKDIR $DIR
 COPY . .
 
 ARG QAT_DRIVER_RELEASE="qat1.7.l.4.14.0-00031"
+ARG QAT_DRIVER_SHA256="a68dfaea4308e0bb5f350b7528f1a076a0c6ba3ec577d60d99dc42c49307b76e"
 
 RUN mkdir -p /usr/src/qat \
     && cd /usr/src/qat  \
-    && wget https://downloadmirror.intel.com/30178/eng/${QAT_DRIVER_RELEASE}.tar.gz \
+    && wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz \
+    && echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c - \
     && tar xf *.tar.gz \
     && cd /usr/src/qat/quickassist/utilities/adf_ctl \
     && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -41,9 +41,14 @@ ARG SRC_DIR=/usr/local/bin/sgx-sw
 
 RUN install -D /go/bin/sgx_epchook $ROOT/$SRC_DIR/$NFD_HOOK
 
-ARG TOYBOX_VERSION="0.8.4"
+ARG TOYBOX_VERSION="0.8.5"
+ARG TOYBOX_SHA256="27cc073222f3b726ee10d96c4f32ac2c4c936b07ea195227736755971e6d90c9"
+
 RUN apt update && apt -y install musl musl-tools musl-dev
-RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz | tar xz \
+RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
+    && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
+    && tar -xzf toybox.tar.gz \
+    && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \

--- a/build/docker/toybox-config
+++ b/build/docker/toybox-config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # ToyBox version: KCONFIG_VERSION
-# Sat May 15 08:23:52 2021
+# Tue Sep 14 22:53:41 2021
 #
 CONFIG_TOYBOX_CONTAINER=y
 CONFIG_TOYBOX_FIFREEZE=y
@@ -92,6 +92,7 @@ CONFIG_LS=y
 # CONFIG_TAR is not set
 # CONFIG_TEE is not set
 # CONFIG_TEST is not set
+# CONFIG_TEST_GLUE is not set
 # CONFIG_TIME is not set
 # CONFIG_TOUCH is not set
 # CONFIG_TRUE is not set
@@ -115,6 +116,7 @@ CONFIG_LS=y
 # CONFIG_BC is not set
 # CONFIG_BOOTCHARTD is not set
 # CONFIG_BRCTL is not set
+# CONFIG_CHSH is not set
 # CONFIG_CROND is not set
 # CONFIG_CRONTAB is not set
 # CONFIG_DD is not set
@@ -154,18 +156,20 @@ CONFIG_LS=y
 # CONFIG_MORE is not set
 # CONFIG_OPENVT is not set
 # CONFIG_DEALLOCVT is not set
-# CONFIG_READELF is not set
 # CONFIG_ROUTE is not set
 CONFIG_SH=y
 # CONFIG_CD is not set
 # CONFIG_EXIT is not set
+# CONFIG_SET is not set
 # CONFIG_UNSET is not set
 # CONFIG_EVAL is not set
 # CONFIG_EXEC is not set
 # CONFIG_EXPORT is not set
 # CONFIG_JOBS is not set
+# CONFIG_LOCAL is not set
 # CONFIG_SHIFT is not set
 # CONFIG_SOURCE is not set
+# CONFIG_WAIT is not set
 # CONFIG_STTY is not set
 # CONFIG_SULOGIN is not set
 # CONFIG_SYSLOGD is not set
@@ -187,7 +191,9 @@ CONFIG_SH=y
 #
 # CONFIG_ACPI is not set
 # CONFIG_ASCII is not set
+# CONFIG_UNICODE is not set
 # CONFIG_BASE64 is not set
+# CONFIG_BASE32 is not set
 # CONFIG_BLKDISCARD is not set
 # CONFIG_BLKID is not set
 # CONFIG_FSTYPE is not set
@@ -247,7 +253,9 @@ CONFIG_SH=y
 # CONFIG_PMAP is not set
 # CONFIG_PRINTENV is not set
 # CONFIG_PWDX is not set
+# CONFIG_PWGEN is not set
 # CONFIG_READAHEAD is not set
+# CONFIG_READELF is not set
 # CONFIG_READLINK is not set
 # CONFIG_REALPATH is not set
 # CONFIG_REBOOT is not set
@@ -365,7 +373,6 @@ CONFIG_TOYBOX_LSM_NONE=y
 # CONFIG_TOYBOX_FLOAT is not set
 # CONFIG_TOYBOX_HELP is not set
 # CONFIG_TOYBOX_HELP_DASHDASH is not set
-# CONFIG_TOYBOX_I18N is not set
 # CONFIG_TOYBOX_FREE is not set
 # CONFIG_TOYBOX_NORECURSE is not set
 # CONFIG_TOYBOX_DEBUG is not set

--- a/demo/openssl-qat-engine/Dockerfile
+++ b/demo/openssl-qat-engine/Dockerfile
@@ -3,6 +3,7 @@ ARG FINAL_BASE_IMAGE=clearlinux:base
 FROM clearlinux:base as builder
 
 ARG QAT_DRIVER_RELEASE="qat1.7.l.4.14.0-00031"
+ARG QAT_DRIVER_SHA256="a68dfaea4308e0bb5f350b7528f1a076a0c6ba3ec577d60d99dc42c49307b76e"
 ARG QAT_ENGINE_VERSION="v0.6.1"
 ARG IPSEC_MB_VERSION="v0.55"
 ARG IPP_CRYPTO_VERSION="ippcp_2020u3"
@@ -12,6 +13,7 @@ RUN swupd bundle-add --skip-diskspace-check devpkg-systemd devpkg-openssl c-basi
     git clone -b $IPP_CRYPTO_VERSION https://github.com/intel/ipp-crypto && \
     git clone -b $IPSEC_MB_VERSION https://github.com/intel/intel-ipsec-mb && \
     wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz && \
+    echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c - && \
     tar xf *.tar.gz
 
 RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \


### PR DESCRIPTION
Add checksum checks for toybox and qat driver
Use toybox version 0.8.5 instead of 0.8.4
Update toybox-config

Closes: #643
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>