### PR TITLE
change golang base to Debian bullseye

### DIFF
--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-buster
+ARG GOLANG_BASE=golang:1.16-bullseye
 
 FROM ${GOLANG_BASE} as builder
 


### PR DESCRIPTION
Changed base from Debian buster to Debian bullseye as suggested [here](https://github.com/intel/intel-device-plugins-for-kubernetes/pull/717#issuecomment-927610286) as bullseye(stable) is closer to our target distro (Debian-unstable) than buster (oldstable) among availalble golang bases.