### PR TITLE
go.mod: move to Go 1.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - 'release-*'
 env:
   RUNC_VERSION: v1.0.2
-  GO_VERSION: 1.16.7
+  GO_VERSION: 1.17.2
 jobs:
 
   golangci:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     RUNC_VERSION="v1.0.2"
     CRIO_VERSION="v1.20.0"
     GOLANGCI_LINT_VERSION="v1.42.0"
-    GO_VERSION="1.16.7"
+    GO_VERSION="1.17.2"
     GO_TAR="go${GO_VERSION}.linux-amd64.tar.gz"
     GOROOT="/usr/local/go"
     GOPATH="/tmp/go"

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.16-bullseye
+ARG GOLANG_BASE=golang:1.17-bullseye
 
 FROM ${GOLANG_BASE} as builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,33 +1,96 @@
 module github.com/intel/intel-device-plugins-for-kubernetes
 
-go 1.16
+go 1.17
 
 require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-ini/ini v1.62.0
 	github.com/go-logr/logr v0.4.0
-	github.com/google/go-cmp v0.5.6 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gousb v1.1.0
-	github.com/google/uuid v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.28.0 // indirect
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
-	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
 	google.golang.org/grpc v1.38.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 	k8s.io/component-base v0.22.2
 	k8s.io/klog/v2 v2.10.0
-	k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d // indirect
 	k8s.io/kubelet v0.22.2
 	k8s.io/kubernetes v1.22.2
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/controller-runtime v0.10.0
+)
+
+require (
+	cloud.google.com/go v0.65.0 // indirect
+	github.com/Microsoft/go-winio v0.4.15 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/runc v1.0.2 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.28.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/cobra v1.1.3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.opentelemetry.io/contrib v0.20.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0 // indirect
+	go.opentelemetry.io/otel v0.20.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp v0.20.0 // indirect
+	go.opentelemetry.io/otel/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/export/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/trace v0.20.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiextensions-apiserver v0.22.1 // indirect
+	k8s.io/apiserver v0.22.2 // indirect
+	k8s.io/component-helpers v0.22.2 // indirect
+	k8s.io/kube-openapi v0.0.0-20210527164424-3c818078ee3d // indirect
+	k8s.io/kubectl v0.0.0 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
go mod tidy adds more requirements because of the changes in 1.17:

"Go versions 1.17 and higher retain more requirements in order to
support lazy module loading."

Closes: #716 

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>