### PR TITLE
Remove nolint annot.

### DIFF
--- a/cmd/gpu_nfdhook/labeler_test.go
+++ b/cmd/gpu_nfdhook/labeler_test.go
@@ -33,7 +33,6 @@ type testcase struct {
 	memoryReserved uint64
 }
 
-//nolint:funlen
 func getTestCases() []testcase {
 	return []testcase{
 		{


### PR DESCRIPTION
Remove the annotation nolint:funlen since funlen is not used anymore.
It was found from pr [#709](https://github.com/intel/intel-device-plugins-for-kubernetes/pull/709#issuecomment-922978330).

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>