### PR TITLE
add e2e-fpga workflow

### DIFF
--- a/.github/workflows/e2e-fpga.yml
+++ b/.github/workflows/e2e-fpga.yml
@@ -1,0 +1,33 @@
+name: e2e-fpga
+on:
+  workflow_dispatch:
+    inputs:
+      images:
+        description: 'Images to build before provisioning pull on worker'
+        required: true
+        default: 'intel-fpga-plugin:devel intel-fpga-initcontainer:devel intel-fpga-admissionwebhook:devel opae-nlb-demo:devel'
+
+env:
+  IMAGES: ${{ github.event.inputs.images }}
+
+jobs:
+  e2e-fpga:
+    name: e2e-fpga
+    runs-on: [self-hosted, linux, x64, fpga]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Describe test environment
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "SHA: ${{ github.sha }}"
+          echo "Images: ${{ github.event.inputs.images }}"
+      - name: Wait for ready state
+        run: ../../../../bmetal/actions-bmetal-runstage.sh waitready
+      - name: Prepare test environment
+        run: ../../../../bmetal/actions-bmetal-runstage.sh prepare
+      - name: Run tests
+        run: ../../../../bmetal/actions-bmetal-runstage.sh test

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ REG?=$(ORG)/
 TAG?=devel
 export TAG
 
+e2e-fpga:
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "FPGA Plugin"
+
 pre-pull:
 ifeq ($(TAG),devel)
 	@$(BUILDER) pull golang:1.17-bullseye

--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -82,7 +82,6 @@ func runTestCase(fmw *framework.Framework, pluginKustomizationPath, mappingsColl
 	}
 
 	ginkgo.By(fmt.Sprintf("namespace %s: deploying FPGA plugin in %s mode", fmw.Namespace.Name, pluginMode))
-	_, _ = framework.RunKubectl(fmw.Namespace.Name, "delete", "-k", tmpDir)
 	framework.RunKubectlOrDie(fmw.Namespace.Name, "apply", "-k", tmpDir)
 
 	ginkgo.By("deploying mappings")
@@ -139,6 +138,7 @@ func createPod(fmw *framework.Framework, name string, resourceName v1.ResourceNa
 					},
 				},
 			},
+			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}
 


### PR DESCRIPTION
This workflow is for testing FPGA plugin on the machine
with FPGA hardware.

The workflow can be triggered interactively from https://github.com/intel/intel-device-plugins-for-kubernetes/actions. This way maintainers can run it for any existing ref

To actually run the workflow some additional work should be done by the project admin:
- [x] add self-hosted runner to the project configuration
- [ ] Test manual workflow triggering on different branches
- [ ] Make sure the worlflow can be triggered only by project maintainers
