### PR TITLE
openssl-qat-engine: Update QAT driver and engine versions

### DIFF
--- a/demo/openssl-qat-engine/Dockerfile
+++ b/demo/openssl-qat-engine/Dockerfile
@@ -2,17 +2,17 @@ ARG FINAL_BASE_IMAGE=clearlinux:base
 
 FROM clearlinux:base as builder
 
-ARG QAT_DRIVER_RELEASE="qat1.7.l.4.14.0-00031"
-ARG QAT_DRIVER_SHA256="a68dfaea4308e0bb5f350b7528f1a076a0c6ba3ec577d60d99dc42c49307b76e"
-ARG QAT_ENGINE_VERSION="v0.6.1"
-ARG IPSEC_MB_VERSION="v0.55"
-ARG IPP_CRYPTO_VERSION="ippcp_2020u3"
+ARG QAT_DRIVER_RELEASE="QAT.L.4.15.0-00011"
+ARG QAT_DRIVER_SHA256="036a87f8c337a3d7a8f6e44e39d9767bb88b3b7866ee00886237d454a628aa56"
+ARG QAT_ENGINE_VERSION="v0.6.9"
+ARG IPSEC_MB_VERSION="v1.0"
+ARG IPP_CRYPTO_VERSION="ippcp_2021.4"
 
 RUN swupd bundle-add --skip-diskspace-check devpkg-systemd devpkg-openssl c-basic wget git yasm && \
     git clone -b $QAT_ENGINE_VERSION https://github.com/intel/QAT_Engine && \
     git clone -b $IPP_CRYPTO_VERSION https://github.com/intel/ipp-crypto && \
     git clone -b $IPSEC_MB_VERSION https://github.com/intel/intel-ipsec-mb && \
-    wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz && \
+    wget https://downloadmirror.intel.com/649693/$QAT_DRIVER_RELEASE.tar.gz && \
     echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c - && \
     tar xf *.tar.gz
 
@@ -42,28 +42,26 @@ RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
 RUN cd /QAT_Engine && \
     ./autogen.sh && \
     ./configure \
-    --enable-ipsec_offload \
-    --enable-multibuff_offload \
-    --with-multibuff_install_dir=/usr/local \
+    --enable-qat_sw \
+    --with-qat_sw_install_dir=/usr/local \
     --with-qat_engine_id=qat-sw && \
     make && make install && \
-    mv /usr/lib64/engines-1.1/qat-sw.so /usr/lib64/engines-1.1/qat-sw.so.tmp && \
+    mv /usr/lib64/engines-1.1/qatengine.so /usr/lib64/engines-1.1/qat-sw.so.tmp && \
     make clean && \
     mv /usr/lib64/engines-1.1/qat-sw.so.tmp /usr/lib64/engines-1.1/qat-sw.so && \
     ./configure \
-    --with-qat_dir=/ \
-    --disable-ipsec_offload \
-    --disable-multibuff_offload \
-    --with-qat_install_dir=/usr/lib \
+    --with-qat_hw_dir=/ \
+    --with-qat_hw_install_dir=/usr/lib \
     --with-qat_engine_id=qat-hw && \
-    make && make install
+    make && make install && \
+    mv /usr/lib64/engines-1.1/qatengine.so /usr/lib64/engines-1.1/qat-hw.so
 
 FROM $FINAL_BASE_IMAGE
 
 COPY --from=builder /usr/lib/libqat_s.so /usr/lib/
 COPY --from=builder /usr/lib/libusdm_drv_s.so /usr/lib/
-COPY --from=builder /usr/lib64/libIPSec_MB.so.0 /usr/lib64/
-COPY --from=builder /usr/local/lib/libcrypto_mb.so /usr/lib64/
+COPY --from=builder /usr/lib64/libIPSec_MB.so.1 /usr/lib64/
+COPY --from=builder /usr/local/lib/libcrypto_mb.so.11.2 /usr/lib64/
 COPY --from=builder /usr/bin/adf_ctl /usr/bin
 COPY --from=builder /usr/lib64/engines-1.1/qat-sw.so /usr/lib64/engines-1.1/qat-sw.so
 COPY --from=builder /usr/lib64/engines-1.1/qat-hw.so /usr/lib64/engines-1.1/qat-hw.so
@@ -71,3 +69,4 @@ COPY --from=builder /LICENSE.GPL /usr/share/package-licenses/libqat/LICENSE.GPL
 COPY --from=builder /QAT_Engine/LICENSE /usr/share/package-licenses/QAT_Engine/LICENSE
 COPY --from=builder /ipp-crypto/LICENSE /usr/share/package-licenses/ipp-crypto/LICENSE
 COPY --from=builder /intel-ipsec-mb/LICENSE /usr/share/package-licenses/intel-ipsec-mb/LICENSE
+RUN ldconfig


### PR DESCRIPTION
This updates the QAT driver to the latest, QAT engine to the latest,
IPSEC MB to the latest, and IPP CRYPTO to the latest. A basic test
was done in a Kata container and openssl was able to find the qat-hw
engine. I don't have a way to test if qat-sw works as the configure
parameters have changed.

Signed-off-by: Eric Adams <eric.adams@intel.com>