### PR TITLE
deployments: fix operator parameters for single-device configs

### DIFF
--- a/deployments/operator/device/dsa/dsa.yaml
+++ b/deployments/operator/device/dsa/dsa.yaml
@@ -10,5 +10,5 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --device=dsa
+        - --devices=dsa
         name: manager

--- a/deployments/operator/device/fpga/fpga.yaml
+++ b/deployments/operator/device/fpga/fpga.yaml
@@ -10,5 +10,5 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --device=fpga
+        - --devices=fpga
         name: manager

--- a/deployments/operator/device/gpu/gpu.yaml
+++ b/deployments/operator/device/gpu/gpu.yaml
@@ -10,5 +10,5 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --device=gpu
+        - --devices=gpu
         name: manager

--- a/deployments/operator/device/qat/qat.yaml
+++ b/deployments/operator/device/qat/qat.yaml
@@ -10,5 +10,5 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --device=qat
+        - --devices=qat
         name: manager

--- a/deployments/operator/device/sgx/sgx.yaml
+++ b/deployments/operator/device/sgx/sgx.yaml
@@ -10,5 +10,5 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --device=sgx
+        - --devices=sgx
         name: manager


### PR DESCRIPTION
The flag is --devices, not --device so fix the YAMLs.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>