### PR TITLE
actions: add e2e qat workflow

### DIFF
--- a/.github/workflows/e2e-qat.yml
+++ b/.github/workflows/e2e-qat.yml
@@ -1,0 +1,35 @@
+name: e2e-qat
+on:
+  workflow_dispatch:
+    inputs:
+      images:
+        description: 'Images to build before provisioning pull on worker'
+        required: true
+        default: 'intel-qat-plugin:devel crypto-perf:devel'
+
+env:
+  IMAGES: ${{ github.event.inputs.images }}
+
+jobs:
+  e2e-qat:
+    name: e2e-qat
+    #if: contains('["bart0sh"]', github.actor)
+    runs-on: [self-hosted, linux, x64, qat]
+    concurrency: one_at_a_time_qat
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Describe test environment
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "SHA: ${{ github.sha }}"
+          echo "Images: ${{ github.event.inputs.images }}"
+      - name: Wait for ready state
+        run: ../../../../bmetal/actions-bmetal-runstage.sh waitready
+      - name: Prepare test environment
+        run: ../../../../bmetal/actions-bmetal-runstage.sh prepare
+      - name: Run tests
+        run: ../../../../bmetal/actions-bmetal-runstage.sh test

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ export TAG
 e2e-fpga:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "FPGA Plugin"
 
+e2e-qat:
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "QAT plugin in DPDK mode"
+
 pre-pull:
 ifeq ($(TAG),devel)
 	@$(BUILDER) pull golang:1.17-bullseye


### PR DESCRIPTION
This workflow is for testing QAT plugin on the machine with QAT hardware.

The workflow can be triggered interactively from https://github.com/intel/intel-device-plugins-for-kubernetes/actions. This way maintainers can run it for any existing ref