### PR TITLE
GPU devices resource preferred allocation methods.

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -40,6 +40,7 @@ backend libraries can offload compute operations to GPU.
 | -enable-monitoring | - | disabled | Enable 'i915_monitoring' resource that provides access to all Intel GPU devices on the node |
 | -resource-manager | - | disabled | Enable fractional resource management, [see also dependencies](#fractional-resources) |
 | -shared-dev-num | int | 1 | Number of containers that can share the same GPU device |
+| -allocation-policy | string | none | 3 possible values: balanced, packed, none. It is meaningful when shared-dev-num > 1, balanced mode is suitable for workload balance among GPU devices, packed mode is suitable for making full use of each GPU device, none mode is the default |
 
 The plugin also accepts a number of other arguments (common to all plugins) related to logging.
 Please use the -h option to see the complete list of logging related options.

--- a/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
+++ b/deployments/operator/crd/bases/deviceplugin.intel.com_gpudeviceplugins.yaml
@@ -72,6 +72,15 @@ spec:
                 description: NodeSelector provides a simple way to constrain device
                   plugin pods to nodes with particular labels.
                 type: object
+              preferredAllocationPolicy:
+                description: PreferredAllocationPolicy sets the mode of allocating
+                  GPU devices on a node. See documentation for detailed description
+                  of the policies. Only valid when SharedDevNum > 1 is set.
+                enum:
+                - balanced
+                - packed
+                - none
+                type: string
               resourceManager:
                 description: ResourceManager handles the fractional resource management
                   for multi-GPU nodes

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
@@ -34,6 +34,11 @@ type GpuDevicePluginSpec struct {
 	// InitImage is a container image with tools (e.g., GPU NFD source hook) installed on each node.
 	InitImage string `json:"initImage,omitempty"`
 
+	// PreferredAllocationPolicy sets the mode of allocating GPU devices on a node.
+	// See documentation for detailed description of the policies. Only valid when SharedDevNum > 1 is set.
+	// +kubebuilder:validation:Enum=balanced;packed;none
+	PreferredAllocationPolicy string `json:"preferredAllocationPolicy,omitempty"`
+
 	// SharedDevNum is a number of containers that can share the same GPU device.
 	// +kubebuilder:validation:Minimum=1
 	SharedDevNum int `json:"sharedDevNum,omitempty"`

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
@@ -92,5 +92,9 @@ func (r *GpuDevicePlugin) validatePlugin() error {
 		}
 	}
 
+	if r.Spec.SharedDevNum == 1 && r.Spec.PreferredAllocationPolicy != "none" {
+		return errors.Errorf("PreferredAllocationPolicy is valid only when setting sharedDevNum > 1")
+	}
+
 	return validatePluginImage(r.Spec.Image, "intel-gpu-plugin", gpuMinVersion)
 }

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -390,7 +390,7 @@ func (c *controller) UpdateStatus(rawObj client.Object, ds *apps.DaemonSet, node
 }
 
 func getPodArgs(gdp *devicepluginv1.GpuDevicePlugin) []string {
-	args := make([]string, 0, 4)
+	args := make([]string, 0, 5)
 	args = append(args, "-v", strconv.Itoa(gdp.Spec.LogLevel))
 
 	if gdp.Spec.EnableMonitoring {
@@ -405,6 +405,12 @@ func getPodArgs(gdp *devicepluginv1.GpuDevicePlugin) []string {
 
 	if gdp.Spec.ResourceManager {
 		args = append(args, "-resource-manager")
+	}
+
+	if gdp.Spec.PreferredAllocationPolicy != "" {
+		args = append(args, "-allocation-policy", gdp.Spec.PreferredAllocationPolicy)
+	} else {
+		args = append(args, "-allocation-policy", "none")
 	}
 
 	return args


### PR DESCRIPTION
1. Implement PreferredAllocator interface.
2. Provide 3 preferred allocation policies: balancingPolicy, packingPolicy and randomizingPolicy.
3. Provide the cmdline interface: -allocation-policy balanced/packed/random, to select which preferred allocation policy to use.
4. Add the unit test and update documentation.