### PR TITLE
dlb:Add memory request and limit for demo pods

### DIFF
--- a/demo/dlb-dpdk-demo-pod.yaml
+++ b/demo/dlb-dpdk-demo-pod.yaml
@@ -12,9 +12,11 @@ spec:
       limits:
         dlb.intel.com/pf: 1
         cpu: 1
+        memory: 200Mi
       requests:
         dlb.intel.com/pf: 1
         cpu: 1
+        memory: 200Mi
   - name: vf
     image: intel/dlb-dpdk-demo:devel
     imagePullPolicy: IfNotPresent
@@ -22,7 +24,8 @@ spec:
       limits:
         dlb.intel.com/vf: 1
         cpu: 1
+        memory: 200Mi
       requests:
         dlb.intel.com/vf: 1
         cpu: 1
-
+        memory: 200Mi

--- a/demo/dlb-libdlb-demo-pod.yaml
+++ b/demo/dlb-libdlb-demo-pod.yaml
@@ -12,9 +12,11 @@ spec:
       limits:
         dlb.intel.com/pf: 1
         cpu: 1
+        memory: 200Mi
       requests:
         dlb.intel.com/pf: 1
         cpu: 1
+        memory: 200Mi
   - name: vf
     image: intel/dlb-libdlb-demo:devel
     imagePullPolicy: IfNotPresent
@@ -22,6 +24,8 @@ spec:
       limits:
         dlb.intel.com/vf: 1
         cpu: 1
+        memory: 200Mi
       requests:
         dlb.intel.com/vf: 1
         cpu: 1
+        memory: 200Mi


### PR DESCRIPTION
Add memory request and limit with 200Mi so that pods can be guaranteed

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>