### PR TITLE
qat: update default flags and deploy without ConfigMap

### DIFF
--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -50,23 +50,12 @@ The QAT plugin can take a number of command line arguments, summarised in the fo
 | Flag | Argument | Meaning |
 |:---- |:-------- |:------- |
 | -dpdk-driver | string | DPDK Device driver for configuring the QAT device (default: `vfio-pci`) |
-| -kernel-vf-drivers | string | Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, 4xxx, C4xxx and D15xx (default: `dh895xccvf,c6xxvf,c3xxxvf`) |
+| -kernel-vf-drivers | string | Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, 4xxx, C4xxx and D15xx (default: `c6xxvf,4xxxvf`) |
 | -max-num-devices | int | maximum number of QAT devices to be provided to the QuickAssist device plugin (default: `32`) |
 | -mode | string | plugin mode which can be either `dpdk` or `kernel` (default: `dpdk`) |
 
 The plugin also accepts a number of other arguments related to logging. Please use the `-h` option to see
 the complete list of logging related options.
-
-The example [DaemonSet YAML](/deployments/qat_plugin/base/intel-qat-plugin.yaml) passes a number of these
-arguments, and takes its default values from the
-[QAT default ConfigMap](/deployments/qat_plugin/base/intel-qat-plugin-config.yaml). The following
-table summarises the defaults:
-
-| Argument | Variable | Default setting | Explanation |
-|:-------- |:-------- |:--------------- |:----------- |
-| -dpdk-driver | `$DPDK_DRIVER` | vfio-pci | A more robust and secure choice than the `igb_uio` alternative |
-| -kernel-vf-drivers | `$KERNEL_VF_DRIVERS` | c6xxvf,4xxxvf | Modify to suit your hardware setup |
-| -max-num-devices | `$MAX_NUM_DEVICES` | 32 | Modify to suit your hardware setup if necessary |
 
 For more details on the `-dpdk-driver` choice, see
 [DPDK Linux Driver Guide](http://dpdk.org/doc/guides/linux_gsg/linux_drivers.html).

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -38,7 +38,7 @@ func main() {
 	mode := flag.String("mode", "dpdk", "plugin mode which can be either dpdk (default) or kernel")
 
 	dpdkDriver := flag.String("dpdk-driver", "vfio-pci", "DPDK Device driver for configuring the QAT device")
-	kernelVfDrivers := flag.String("kernel-vf-drivers", "dh895xccvf,c6xxvf,c3xxxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, C4xxx, 4xxx, and D15xx")
+	kernelVfDrivers := flag.String("kernel-vf-drivers", "c6xxvf,4xxxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, C4xxx, 4xxx, and D15xx")
 	maxNumDevices := flag.Int("max-num-devices", 32, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
 	flag.Parse()
 

--- a/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin-config.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: intel-qat-plugin-config
-data:
-  DPDK_DRIVER: "vfio-pci"
-  KERNEL_VF_DRIVERS: "c6xxvf,4xxxvf"
-  MAX_NUM_DEVICES: "32"
-  VERBOSITY: "0"

--- a/deployments/qat_plugin/base/intel-qat-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin.yaml
@@ -18,30 +18,7 @@ spec:
         image: intel/intel-qat-plugin:devel
         securityContext:
           readOnlyRootFilesystem: true
-        env:
-        - name: DPDK_DRIVER
-          valueFrom:
-            configMapKeyRef:
-              name: intel-qat-plugin-config
-              key: DPDK_DRIVER
-        - name: KERNEL_VF_DRIVERS
-          valueFrom:
-            configMapKeyRef:
-              name: intel-qat-plugin-config
-              key: KERNEL_VF_DRIVERS
-        - name: MAX_NUM_DEVICES
-          valueFrom:
-            configMapKeyRef:
-              name: intel-qat-plugin-config
-              key: MAX_NUM_DEVICES
-        - name: VERBOSITY
-          valueFrom:
-            configMapKeyRef:
-              name: intel-qat-plugin-config
-              key: VERBOSITY
-
         imagePullPolicy: IfNotPresent
-        args: ["-dpdk-driver", "$(DPDK_DRIVER)", "-kernel-vf-drivers", "$(KERNEL_VF_DRIVERS)", "-max-num-devices", "$(MAX_NUM_DEVICES)", "-v", "$(VERBOSITY)"]
         volumeMounts:
         - name: devdir
           mountPath: /dev/vfio

--- a/deployments/qat_plugin/base/kustomization.yaml
+++ b/deployments/qat_plugin/base/kustomization.yaml
@@ -1,3 +1,2 @@
 resources:
   - intel-qat-plugin.yaml
-  - intel-qat-plugin-config.yaml

--- a/deployments/qat_plugin/overlays/debug/add-args.yaml
+++ b/deployments/qat_plugin/overlays/debug/add-args.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-qat-plugin
+spec:
+  template:
+    spec:
+      containers:
+      - name: intel-qat-plugin
+        args:
+        - "-v=4"

--- a/deployments/qat_plugin/overlays/debug/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/debug/kustomization.yaml
@@ -1,8 +1,5 @@
 nameSuffix: -debug
 bases:
 - ../../base
-configMapGenerator:
-- name: intel-qat-plugin-config
-  behavior: merge
-  literals:
-    - VERBOSITY="4"
+patches:
+  - add-args.yaml


### PR DESCRIPTION
To make QAT plugin deployment consistent with the other plugins
we update the default flags and deploy without the flag settings
provided by the ConfigMap.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>