### PR TITLE
operator: allow controllers to touch ownerReferences always

### DIFF
--- a/deployments/operator/rbac/role.yaml
+++ b/deployments/operator/rbac/role.yaml
@@ -66,6 +66,12 @@ rules:
 - apiGroups:
   - deviceplugin.intel.com
   resources:
+  - dlbdeviceplugins/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
   - dlbdeviceplugins/status
   verbs:
   - get
@@ -83,6 +89,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
+  - dsadeviceplugins/finalizers
+  verbs:
+  - update
 - apiGroups:
   - deviceplugin.intel.com
   resources:
@@ -106,6 +118,12 @@ rules:
 - apiGroups:
   - deviceplugin.intel.com
   resources:
+  - fpgadeviceplugins/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
   - fpgadeviceplugins/status
   verbs:
   - get
@@ -123,6 +141,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
+  - gpudeviceplugins/finalizers
+  verbs:
+  - update
 - apiGroups:
   - deviceplugin.intel.com
   resources:
@@ -146,6 +170,12 @@ rules:
 - apiGroups:
   - deviceplugin.intel.com
   resources:
+  - qatdeviceplugins/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
   - qatdeviceplugins/status
   verbs:
   - get
@@ -163,6 +193,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - deviceplugin.intel.com
+  resources:
+  - sgxdeviceplugins/finalizers
+  verbs:
+  - update
 - apiGroups:
   - deviceplugin.intel.com
   resources:

--- a/deployments/operator/webhook/manifests.yaml
+++ b/deployments/operator/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
- path: /mutate-deviceplugin-intel-com-v1-dlbdeviceplugin
+      path: /mutate-deviceplugin-intel-com-v1-dlbdeviceplugin
   failurePolicy: Fail
   name: mdlbdeviceplugin.kb.io
   rules:

--- a/pkg/controllers/dlb/controller.go
+++ b/pkg/controllers/dlb/controller.go
@@ -37,6 +37,7 @@ const ownerKey = ".metadata.controller.dlb"
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dlbdeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dlbdeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dlbdeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for DlbDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {

--- a/pkg/controllers/dsa/controller.go
+++ b/pkg/controllers/dsa/controller.go
@@ -41,6 +41,7 @@ const (
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dsadeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dsadeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dsadeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for DsaDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {

--- a/pkg/controllers/fpga/controller.go
+++ b/pkg/controllers/fpga/controller.go
@@ -39,6 +39,7 @@ const (
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=fpgadeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=fpgadeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=fpgadeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for FpgaDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -44,6 +44,7 @@ const (
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=gpudeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=gpudeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=gpudeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for GpuDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {

--- a/pkg/controllers/qat/controller.go
+++ b/pkg/controllers/qat/controller.go
@@ -39,6 +39,7 @@ const (
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=qatdeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=qatdeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=qatdeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for QatDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {

--- a/pkg/controllers/sgx/controller.go
+++ b/pkg/controllers/sgx/controller.go
@@ -41,6 +41,7 @@ const (
 
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=sgxdeviceplugins,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=sgxdeviceplugins/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=sgxdeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for SgxDevicePlugin objects.
 func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {


### PR DESCRIPTION
Clusters with OwnerReferencesPermissionEnforcement (e.g., OpenShift)
get stricter checks for metadata.ownerReferences.

This appears via errors like:
“is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to
a resource you can’t set finalizers on: ...”

The fix is to add "update" permissions to finalizers subresource
for the xDevicePlugins resources.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>