### PR TITLE
operator: fix SgxDevicePlugin webhook.Defaulter

### DIFF
--- a/pkg/apis/deviceplugin/v1/sgxdeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/sgxdeviceplugin_webhook.go
@@ -56,7 +56,7 @@ func (r *SgxDevicePlugin) Default() {
 	}
 
 	if len(r.Spec.InitImage) == 0 {
-		r.Spec.Image = "intel/intel-sgx-initcontainer:" + sgxMinVersion.String()
+		r.Spec.InitImage = "intel/intel-sgx-initcontainer:" + sgxMinVersion.String()
 	}
 }
 


### PR DESCRIPTION
The Defaulter wrongly assigned the "intel-sgx-initcontainer" to
Spec.Image instead of Spec.InitImage.

We don't see any problems because the default DaemonSet yaml
uses "intel-sgx-initcontainer".

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>