### PR TITLE
ci: use 1.22.1 version of k8s instead of 1.20.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 env:
   RUNC_VERSION: v1.0.2
   GO_VERSION: 1.17.2
-  K8S_VERSION: 1.20.2
+  K8S_VERSION: 1.22.1
 jobs:
 
   golangci:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     REG="cloud-native-image-registry.westus.cloudapp.azure.com/"
     RUNC_VERSION="v1.0.2"
     CRIO_VERSION="v1.20.0"
-    K8S_VERSION="1.20.2"
+    K8S_VERSION="1.22.1"
     GOLANGCI_LINT_VERSION="v1.42.0"
     GO_VERSION="1.17.2"
     GO_TAR="go${GO_VERSION}.linux-amd64.tar.gz"


### PR DESCRIPTION
ci:
- use 1.22.1 version of K8s
- update suite_test to support kubernetes 1.21+ version

In the pr [#758](https://github.com/intel/intel-device-plugins-for-kubernetes/pull/758#discussion_r753153008), k8s 1.20.2 was used to avoid the problem of timeout for waiting for process kube-apiserver to stop. Mikko figured out that there was an [update](https://github.com/kubernetes-sigs/kubebuilder/pull/2302) of [tutorial](https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html) that we followed for suite_test.go file, and that we did not fix after the update was made. So, I updated the code.