### PR TITLE
Use OCP privileged SCC to run SGX device plugin

### DIFF
--- a/deployments/operator/default/manager_auth_proxy_patch.yaml
+++ b/deployments/operator/default/manager_auth_proxy_patch.yaml
@@ -19,11 +19,6 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
-          readOnlyRootFilesystem: true
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"

--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -33,11 +33,6 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 65532
-          runAsGroup: 65532
-          readOnlyRootFilesystem: true
         env:
           - name: DEVICEPLUGIN_NAMESPACE
             valueFrom:

--- a/deployments/operator/rbac/role.yaml
+++ b/deployments/operator/rbac/role.yaml
@@ -226,3 +226,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  verbs:
+  - use

--- a/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
+++ b/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
@@ -17,6 +17,7 @@ spec:
       - name: intel-sgx-plugin
         image: intel/intel-sgx-plugin:devel
         securityContext:
+          privileged: true
           readOnlyRootFilesystem: true
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/pkg/controllers/sgx/controller.go
+++ b/pkg/controllers/sgx/controller.go
@@ -95,18 +95,14 @@ func addVolumeIfMissing(spec *v1.PodSpec, name, path string, hpType v1.HostPathT
 }
 
 func setInitContainer(spec *v1.PodSpec, imageName string) {
-	yes := true
 	spec.InitContainers = []v1.Container{
 		{
 			Image:           imageName,
 			ImagePullPolicy: "IfNotPresent",
 			Name:            "intel-sgx-initcontainer",
-			SecurityContext: &v1.SecurityContext{
-				ReadOnlyRootFilesystem: &yes,
-			},
 			VolumeMounts: []v1.VolumeMount{
 				{
-					MountPath: "/etc/kubernetes/node-feature-discovery/source.d/",
+					MountPath: "/etc/kubernetes/node-feature-discovery/source.d/:z",
 					Name:      "nfd-source-hooks",
 				},
 			},

--- a/pkg/controllers/sgx/controller_test.go
+++ b/pkg/controllers/sgx/controller_test.go
@@ -82,6 +82,7 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							Image:           devicePlugin.Spec.Image,
 							ImagePullPolicy: "IfNotPresent",
 							SecurityContext: &v1.SecurityContext{
+								Privileged: &yes,
 								ReadOnlyRootFilesystem: &yes,
 							},
 							VolumeMounts: []v1.VolumeMount{


### PR DESCRIPTION
the priviledged SCC needs to be used to run priviledge SGX device plugin
container on OpenShift Container Platform

for detail, please see
https://github.com/intel/intel-device-plugins-for-kubernetes/issues/762

Signed-off-by: MartinXu <martin.xu@intel.com>