### PR TITLE
dlb: update links for dlb demos

### DIFF
--- a/demo/dlb-dpdk-demo/Dockerfile
+++ b/demo/dlb-dpdk-demo/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install ninja
 ARG DLB_TARBALL="dlblinuxsrcrelease7.4.020211006.txz"
 ARG DLB_TARBALL_SHA256="715c34314d77dce9fe0cd61d5c0f269016971e8d9aa680bc0e4a32d4284aae09"
 
-RUN wget https://01.org/sites/default/files/downloads/$DLB_TARBALL \
+RUN wget https://downloadmirror.intel.com/690271/$DLB_TARBALL \
     && echo "$DLB_TARBALL_SHA256 $DLB_TARBALL" | sha256sum -c - \
     && tar -Jxf $DLB_TARBALL --no-same-owner && rm $DLB_TARBALL
 

--- a/demo/dlb-libdlb-demo/Dockerfile
+++ b/demo/dlb-libdlb-demo/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y wget xz-utils make gcc
 ARG DLB_DRIVER_RELEASE="dlblinuxsrcrelease7.4.020211006"
 ARG DLB_DRIVER_SHA256="715c34314d77dce9fe0cd61d5c0f269016971e8d9aa680bc0e4a32d4284aae09"
 
-RUN wget https://01.org/sites/default/files/downloads//$DLB_DRIVER_RELEASE.txz \
+RUN wget https://downloadmirror.intel.com/690271/$DLB_DRIVER_RELEASE.txz \
     && echo "$DLB_DRIVER_SHA256 $DLB_DRIVER_RELEASE.txz" | sha256sum -c - \
     && tar -xvf *.txz --no-same-owner
 


### PR DESCRIPTION
download dlb tarball from downloadmirror.intel.com, not from 01.org that would be down soon