### PR TITLE
Provide workaround for the media issue and document it

### DIFF
--- a/cmd/gpu_plugin/render-device.sh
+++ b/cmd/gpu_plugin/render-device.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+#
+# Copyright 2021 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Some GPU workloads are unable to find the (Intel) GPU provisioned for
+# them by Kubernetes. This script checks and tells which device to use.
+#
+# For example (all?) media applications using VA-API or QSV media APIs [1],
+# fail when /dev/dri/renderD128 is not present, or happens to be of
+# a type not supported by the media driver.
+#
+# Happily (all?) media applications have an option to specify a suitable
+# render device name, which can be used with this script.
+#
+# [1] Compute, 3D, and OneVPL APIs do not suffer from this issue.
+#
+#
+# Running the script requires only few tools, which should be present in
+# all distro base images.  The required tools, and the packages they
+# reside in Debian based distros, are:
+# - dash: 'sh' (minimal bourne shell)
+# - coreutils: 'seq', 'cat', 'echo'
+# - sed: 'sed'
+#
+# But they are also provided by 'busybox' and 'toybox' tool sets.
+
+
+usage ()
+{
+	name=${0##*/}
+	echo "Provides (Intel GPU) render device name application can use, either"
+	echo "on standard output, or added to given command line. If device index"
+	echo "N is given, provides name of Nth available (Intel GPU) render device."
+	echo
+	echo "Usage:"
+	echo "  $name <device index>"
+	echo "  $name [device index] <media program> [other options] <GPU selection option>"
+	echo
+	echo "Examples:"
+	echo "  \$ vainfo --display drm --device \$($name 1)"
+	echo "  \$ $name vainfo --display drm --device"
+	echo "  Running: vainfo --display drm --device /dev/dri/renderD140"
+	echo
+	echo "ERROR: $1!"
+	exit 1
+}
+
+if [ $# -eq 0 ]; then
+	usage "no arguments given"
+fi
+
+# determine required GPU index
+NaN=$(echo "$1" | sed 's/[0-9]\+//')
+if [ "$NaN" = "" ] && [ "$1" != "" ]; then
+	required=$1
+	if [ "$required" -lt 1 ] || [ "$required" -gt 127 ]; then
+		usage "GPU index $required not in range 1-127"
+	fi
+	shift
+else
+	required=1
+fi
+visible=0
+
+vendor=""
+intel="0x8086"
+# find host index "i" for Nth visible Intel GPU device
+for i in $(seq 128 255); do
+	if [ -w "/dev/dri/renderD$i" ]; then
+		vendor=$(cat "/sys/class/drm/renderD$i/device/vendor")
+		if [ "$vendor" = "$intel" ]; then
+			visible=$((visible+1))
+			if [ $visible -eq $required ]; then
+				break
+			fi
+		fi
+	fi
+done
+
+if [ $visible -ne $required ]; then
+	usage "$visible Intel GPU(s) found, not $required as requested"
+fi
+device="/dev/dri/renderD$i"
+
+if [ $# -eq 0 ]; then
+	echo "$device"
+	exit 0
+fi
+
+if [ $# -lt 2 ]; then
+	usage "media program and/or GPU selection option missing"
+fi
+
+# run given media workload with GPU device name appended to end
+echo "Running: $* $device"
+exec "$@" "$device"


### PR DESCRIPTION
Easier alternative (for container maintainers) would be GPU device plugin providing `RENDER_DEVICE<X>` environment variables for all the requested GPUs, but Ukri was not interested in adding temporary [1] media specific workaround to the GPU plugin code, that still requires adding shell to the container, or modifying application code to directly use such env var.  Hence this workaround.

[1] (OneAPI) VPL API includes (feature based) device discovery support, but for now almost none of the media applications support VPL, so that does help yet.

QSV is deprecated in favor of VPL, so it is never going to get device discovery functionality, and there has been not much indication in last 3 years that libva would be getting such support either: https://github.com/intel/libva/issues/221
