### PR TITLE
Adapt GPU label support to debugfs DRM entry changes

### DIFF
--- a/cmd/gpu_nfdhook/README.md
+++ b/cmd/gpu_nfdhook/README.md
@@ -43,9 +43,11 @@ Depending on your kernel driver, running the NFD hook as root may introduce foll
 
 name | type | description|
 -----|------|------|
-|`gpu.intel.com/platform_gen`| string | GPU platform generation name, typically a number.
+|`gpu.intel.com/platform_gen`| string | GPU platform generation name, typically an integer. Deprecated.
+|`gpu.intel.com/media_version`| string | GPU platform Media pipeline generation name, typically a number.
+|`gpu.intel.com/graphics_version`| string | GPU platform graphics/compute pipeline generation name, typically a number.
 |`gpu.intel.com/platform_<PLATFORM_NAME>_.count`| number | GPU count for the named platform.
 |`gpu.intel.com/platform_<PLATFORM_NAME>_.tiles`| number | GPU tile count in the GPUs of the named platform.
 |`gpu.intel.com/platform_<PLATFORM_NAME>_.present`| string | "true" for indicating the presense of the GPU platform.
 
-For the above to work as intended, installed GPUs must be identical in their capabilities.
+For the above to work as intended, GPUs on the same node must be identical in their capabilities.

--- a/cmd/gpu_nfdhook/labeler_test.go
+++ b/cmd/gpu_nfdhook/labeler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Intel Corporation. All Rights Reserved.
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@ func getTestCases() []testcase {
 				"gpu.intel.com/platform_new.count":   "1",
 				"gpu.intel.com/platform_new.present": "true",
 				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/graphics_version":     "9",
+				"gpu.intel.com/media_version":        "9",
 				"gpu.intel.com/platform_gen":         "9",
 				"gpu.intel.com/cards":                "card0",
 			},
@@ -104,6 +106,8 @@ func getTestCases() []testcase {
 				"gpu.intel.com/platform_new.count":   "1",
 				"gpu.intel.com/platform_new.present": "true",
 				"gpu.intel.com/platform_new.tiles":   "2",
+				"gpu.intel.com/graphics_version":     "9",
+				"gpu.intel.com/media_version":        "9",
 				"gpu.intel.com/platform_gen":         "9",
 				"gpu.intel.com/cards":                "card0",
 			},
@@ -132,6 +136,8 @@ func getTestCases() []testcase {
 				"gpu.intel.com/platform_new.count":   "1",
 				"gpu.intel.com/platform_new.present": "true",
 				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/graphics_version":     "9",
+				"gpu.intel.com/media_version":        "9",
 				"gpu.intel.com/platform_gen":         "9",
 				"gpu.intel.com/cards":                "card0",
 			},
@@ -157,6 +163,8 @@ func getTestCases() []testcase {
 				"gpu.intel.com/platform_new.count":   "1",
 				"gpu.intel.com/platform_new.present": "true",
 				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/graphics_version":     "9",
+				"gpu.intel.com/media_version":        "9",
 				"gpu.intel.com/platform_gen":         "9",
 				"gpu.intel.com/cards":                "card0",
 			},
@@ -181,6 +189,60 @@ func getTestCases() []testcase {
 				"gpu.intel.com/platform_new.count":   "1",
 				"gpu.intel.com/platform_new.present": "true",
 				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/cards":                "card0",
+			},
+		},
+		{
+			sysfsdirs: []string{
+				"card0/device/drm/card0",
+			},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor": []byte("0x8086"),
+			},
+			name:           "gen version missing, but media & graphics versions present",
+			memoryOverride: 16000000000,
+			capabilityFile: map[string][]byte{
+				"0/i915_capabilities": []byte(
+					"platform: new\n" +
+						"media version: 12.5\n" +
+						"graphics version: 12.2"),
+			},
+			expectedRetval: nil,
+			expectedLabels: labelMap{
+				"gpu.intel.com/millicores":           "1000",
+				"gpu.intel.com/memory.max":           "16000000000",
+				"gpu.intel.com/platform_new.count":   "1",
+				"gpu.intel.com/platform_new.present": "true",
+				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/graphics_version":     "12.2",
+				"gpu.intel.com/media_version":        "12.5",
+				"gpu.intel.com/platform_gen":         "12",
+				"gpu.intel.com/cards":                "card0",
+			},
+		},
+		{
+			sysfsdirs: []string{
+				"card0/device/drm/card0",
+			},
+			sysfsfiles: map[string][]byte{
+				"card0/device/vendor": []byte("0x8086"),
+			},
+			name:           "only media version present",
+			memoryOverride: 16000000000,
+			capabilityFile: map[string][]byte{
+				"0/i915_capabilities": []byte(
+					"platform: new\n" +
+						"media version: 12.5"),
+			},
+			expectedRetval: nil,
+			expectedLabels: labelMap{
+				"gpu.intel.com/millicores":           "1000",
+				"gpu.intel.com/memory.max":           "16000000000",
+				"gpu.intel.com/platform_new.count":   "1",
+				"gpu.intel.com/platform_new.present": "true",
+				"gpu.intel.com/platform_new.tiles":   "1",
+				"gpu.intel.com/media_version":        "12.5",
+				"gpu.intel.com/platform_gen":         "12",
 				"gpu.intel.com/cards":                "card0",
 			},
 		},


### PR DESCRIPTION
"gen" number is in latest kernels capabilities files replaced with separate display, graphics, and media versions.

For compatibility with newer kernels, provide "gen" based on the new labels (but without decimals), and for older kernel compatibility, new labels based on "gen".

Optimize capabilities file parsing by using prefix check instead of scanf.