### PR TITLE
lint: output all found issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ run:
   tests: true
   build-tags:
     - kerneldrv
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 linters:
   disable-all: true


### PR DESCRIPTION
golangci-lint outputs max 50 issues by default. This can lead to false estimation of the fixing effort for enabling new checks
Disabling default threashold should fix this