### PR TITLE
dlb:Fix the problem that klog is not printed

### DIFF
--- a/cmd/dlb_plugin/dlb_plugin.go
+++ b/cmd/dlb_plugin/dlb_plugin.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -106,6 +107,7 @@ func (dp *DevicePlugin) scan() dpapi.DeviceTree {
 }
 
 func main() {
+	flag.Parse()
 	klog.V(1).Infof("DLB device plugin started")
 
 	plugin := NewDevicePlugin(dlbDeviceFilePathRE, sysfsDir)


### PR DESCRIPTION
Add flag parsing to get command line parameters so that parameters about klog can be not ignored