### PR TITLE
dsa: Fix the names still left as idxd-initcontainer

### DIFF
--- a/cmd/dsa_plugin/README.md
+++ b/cmd/dsa_plugin/README.md
@@ -50,7 +50,7 @@ Nothing else is needed. But if you want to deploy a customized version of the pl
 
 ### Deploy with initcontainer
 
-There's a sample [DSA initcontainer](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/build/docker/intel-idxd-initcontainer.Dockerfile) included that provisions DSA devices and workqueues (1 engine / 1 group / 1 wq (user/dedicated)), to deploy:
+There's a sample [DSA initcontainer](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/build/docker/intel-idxd-config-initcontainer.Dockerfile) included that provisions DSA devices and workqueues (1 engine / 1 group / 1 wq (user/dedicated)), to deploy:
 
 ```bash
 $ kubectl apply -k deployments/dsa_plugin/overlays/dsa_initcontainer/

--- a/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
+++ b/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
@@ -12,7 +12,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-idxd-initcontainer:devel
+        image: intel/intel-idxd-config-initcontainer:devel
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
There are a few things left un-renamed after \#771.
Rename those to idxd-config-initcontainer.

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>