### PR TITLE
Use nfd release instead of master

### DIFF
--- a/deployments/sgx_nfd/kustomization.yaml
+++ b/deployments/sgx_nfd/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=master"
+- "https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.9.0"
 
 configMapGenerator:
 - name: nfd-worker-conf


### PR DESCRIPTION
Master branch of the NFD project is [broken](https://github.com/kubernetes-sigs/node-feature-discovery/pull/708). It broke SGX plugin deployment.
Changed reference to the release tag.