### PR TITLE
e2e workflows:get rid of one_at_a_time concurency

### DIFF
--- a/.github/workflows/e2e-qat.yml
+++ b/.github/workflows/e2e-qat.yml
@@ -15,7 +15,6 @@ jobs:
     name: e2e-qat
     #if: contains('["bart0sh"]', github.actor)
     runs-on: [self-hosted, linux, x64, qat]
-    concurrency: one_at_a_time_qat
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/e2e-sgx.yml
+++ b/.github/workflows/e2e-sgx.yml
@@ -14,7 +14,6 @@ jobs:
   e2e-sgx:
     name: e2e-sgx
     runs-on: [self-hosted, linux, x64, sgx]
-    concurrency: one_at_a_time_sgx
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
'concurrency: one_at_a_time_sgx' option doesn't work as expected
it causes failures of the builds when worker is busy.

Without this option job run stays in waiting state until a worker
picks it up.