### PR TITLE
e2e: enable triggering e2e jobs on PRs

### DIFF
--- a/.github/workflows/e2e-fpga.yml
+++ b/.github/workflows/e2e-fpga.yml
@@ -1,16 +1,15 @@
 name: e2e-fpga
 on:
   workflow_dispatch:
-    inputs:
-      images:
-        description: 'Images to build before provisioning pull on worker'
-        required: true
-        default: 'intel-fpga-plugin:devel intel-fpga-initcontainer:devel intel-fpga-admissionwebhook:devel opae-nlb-demo:devel'
   schedule:
     - cron: '0 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
-  IMAGES: ${{ github.event.inputs.images }}
+  IMAGES: 'intel-fpga-plugin intel-fpga-initcontainer intel-fpga-admissionwebhook opae-nlb-demo'
 
 jobs:
   e2e-fpga:
@@ -26,7 +25,7 @@ jobs:
           echo "Actor: ${{ github.actor }}"
           echo "Ref: ${{ github.ref }}"
           echo "SHA: ${{ github.sha }}"
-          echo "Images: ${{ github.event.inputs.images }}"
+          echo "Images: $IMAGES"
       - name: Wait for ready state
         run: ../../../../bmetal/actions-bmetal-runstage.sh waitready
       - name: Prepare test environment

--- a/.github/workflows/e2e-qat.yml
+++ b/.github/workflows/e2e-qat.yml
@@ -1,16 +1,15 @@
 name: e2e-qat
 on:
   workflow_dispatch:
-    inputs:
-      images:
-        description: 'Images to build before provisioning pull on worker'
-        required: true
-        default: 'intel-qat-plugin:devel crypto-perf:devel'
   schedule:
     - cron: '20 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
-  IMAGES: ${{ github.event.inputs.images }}
+  IMAGES: 'intel-qat-plugin crypto-perf'
 
 jobs:
   e2e-qat:
@@ -27,7 +26,7 @@ jobs:
           echo "Actor: ${{ github.actor }}"
           echo "Ref: ${{ github.ref }}"
           echo "SHA: ${{ github.sha }}"
-          echo "Images: ${{ github.event.inputs.images }}"
+          echo "Images: $IMAGES"
       - name: Wait for ready state
         run: ../../../../bmetal/actions-bmetal-runstage.sh waitready
       - name: Prepare test environment

--- a/.github/workflows/e2e-sgx.yml
+++ b/.github/workflows/e2e-sgx.yml
@@ -1,16 +1,15 @@
 name: e2e-sgx
 on:
   workflow_dispatch:
-    inputs:
-      images:
-        description: 'Images to build before provisioning pull on worker'
-        required: true
-        default: 'intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook'
   schedule:
     - cron: '40 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
-  IMAGES: ${{ github.event.inputs.images }}
+  IMAGES: 'intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook'
 
 jobs:
   e2e-sgx:
@@ -26,7 +25,7 @@ jobs:
           echo "Actor: ${{ github.actor }}"
           echo "Ref: ${{ github.ref }}"
           echo "SHA: ${{ github.sha }}"
-          echo "Images: ${{ github.event.inputs.images }}"
+          echo "Images: $IMAGES"
       - name: Wait for ready state
         run: ../../../../bmetal/actions-bmetal-runstage.sh waitready
       - name: Prepare test environment


### PR DESCRIPTION
**NOTE:** this PR can be accepted only after setting "Require approval for all outside collaborators" option in the project configuration.