### PR TITLE
fpga-e2e: enable webhook tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ TAG?=devel
 export TAG
 
 e2e-fpga:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "FPGA Plugin" -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "FPGA" -delete-namespace-on-failure=false
 
 e2e-qat:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.progress -ginkgo.focus "QAT plugin in DPDK mode" -delete-namespace-on-failure=false


### PR DESCRIPTION
Enabled FPGA webhook tests by widening ginkgo.focus regexp. So far it was covering only FPGA plugin test cases.