### PR TITLE
doc: fix operatorhub publishing instruction

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -207,11 +207,16 @@ Generate package manifests with:
 $ make packagemanifests OPERATOR_VERSION=0.X.Y
 ```
 
+Copy the generated files to the Community Operators repo:
+```
+$ cp -r packagemanifests/* community-operators/operators/intel-device-plugins-operator/
+```
+
 Verify the operator deployment works OK via OLM in your development cluster:
 ```
 $ operator-sdk olm install
 $ kubectl create namespace testoperator
-$ operator-sdk run packagemanifests --namespace testoperator --version 0.X.Y
+$ operator-sdk run packagemanifests community-operators/operators/intel-device-plugins-operator/ --namespace testoperator --version 0.X.Y
 # do verification checks
 ...
 # do clean up
@@ -226,11 +231,6 @@ https://operatorhub.io -> Contribute -> Package Your Operator.
 Clone the [Community Operators](https://github.com/k8s-operatorhub/community-operators) repo:
 ```
 $ git clone https://github.com/k8s-operatorhub/community-operators
-```
-
-Copy the generated files to the Community Operators repo:
-```
-$ cp -r packagemanifests/* community-operators/operators/intel-device-plugins/
 ```
 
 Submit a PR


### PR DESCRIPTION
Current instruction does not work properly.
operator-sdk run packagemanifests should run with the manifests of the
previous version.
It will look like [this](https://github.com/hj-johannes-lee/intel-device-plugins-for-kubernetes/blob/fix-devel.md/DEVEL.md#how-to-publish-a-new-version-of-the-intel-device-plugins-operator-to-operatorhubio).

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>