### PR TITLE
doc, Makefile: fix and update the operatorhub instruction related matters 

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -202,14 +202,14 @@ Update metadata.annotations.containerImage and metadata.annotations.createdAT fi
 deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
 to match current operator version and current date
 
+Fork the [Community Operators](https://github.com/k8s-operatorhub/community-operators) repo and clone it:
+```
+$ git clone https://github.com/<GitHub Username>/community-operators
+```
+
 Generate package manifests with:
 ```
 $ make packagemanifests OPERATOR_VERSION=0.X.Y
-```
-
-Copy the generated files to the Community Operators repo:
-```
-$ cp -r packagemanifests/* community-operators/operators/intel-device-plugins-operator/
 ```
 
 Verify the operator deployment works OK via OLM in your development cluster:
@@ -228,9 +228,11 @@ $ operator-sdk olm uninstall
 Review the package manifests by uploading the generated `packagemanifests` folder to
 https://operatorhub.io -> Contribute -> Package Your Operator.
 
-Clone the [Community Operators](https://github.com/k8s-operatorhub/community-operators) repo:
+Commit files
 ```
-$ git clone https://github.com/k8s-operatorhub/community-operators
+$ cd community-operators
+$ git add operators/intel-device-plugins-operator/0.X.Y
+$ git commit -am 'operators intel-device-plugins-operator (0.X.Y)' -S
 ```
 
 Submit a PR

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 OLM_MANIFESTS = deployments/operator/manifests
+PACKAGEMANIFESTS_DIR = community-operators/operators/intel-device-plugins-operator
 
 WEBHOOK_IMAGE_FILE = intel-fpga-admissionwebhook-devel.tgz
 
@@ -119,10 +120,10 @@ bundle:
 .PHONY: packagemanifests
 packagemanifests:
 	$(OPERATOR_SDK) generate kustomize manifests -q --input-dir $(OLM_MANIFESTS) --output-dir $(OLM_MANIFESTS) --apis-dir pkg/apis
-	$(KUSTOMIZE) build $(OLM_MANIFESTS) | sed "s|intel-deviceplugin-operator:devel|intel-deviceplugin-operator:$(OPERATOR_VERSION)|" | $(OPERATOR_SDK) generate packagemanifests -q --kustomize-dir $(OLM_MANIFESTS) --version $(OPERATOR_VERSION) --from-version $(OPERATOR_PREVIOUS_VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build $(OLM_MANIFESTS) | sed "s|intel-deviceplugin-operator:devel|intel-deviceplugin-operator:$(OPERATOR_VERSION)|" | $(OPERATOR_SDK) generate packagemanifests -q --kustomize-dir $(OLM_MANIFESTS) --version $(OPERATOR_VERSION) --from-version $(OPERATOR_PREVIOUS_VERSION) $(BUNDLE_METADATA_OPTS) --output-dir $(PACKAGEMANIFESTS_DIR)
 	# Remove unneeded resources
-	rm packagemanifests/$(OPERATOR_VERSION)/*service.yaml
-	rm packagemanifests/$(OPERATOR_VERSION)/*clusterrole.yaml
+	rm $(PACKAGEMANIFESTS_DIR)/$(OPERATOR_VERSION)/*service.yaml
+	rm $(PACKAGEMANIFESTS_DIR)/$(OPERATOR_VERSION)/*clusterrole.yaml
 
 clean:
 	@for cmd in $(cmds) ; do pwd=$(shell pwd) ; cd cmd/$$cmd ; $(GO) clean ; cd $$pwd ; done


### PR DESCRIPTION
commit 1:
Makefile: add package manifests target directory 


commit 2:
doc: fix operatorhub publishing instruction

There was a mistake in #842 that 'git clone' command didn't come up
together with the command 'cp -r'. In addition, this pr includes
the changes following [the suggestion made after #842 was merged](https://github.com/intel/intel-device-plugins-for-kubernetes/pull/842#discussion_r782058383).

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>