### PR TITLE
e2e/sgx: increase epc registration check timeout

### DIFF
--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -90,7 +90,7 @@ func describe() {
 		}
 
 		ginkgo.By("checking the resource is allocatable")
-		if err = utils.WaitForNodesWithResource(f.ClientSet, "sgx.intel.com/epc", 30*time.Second); err != nil {
+		if err = utils.WaitForNodesWithResource(f.ClientSet, "sgx.intel.com/epc", 150*time.Second); err != nil {
 			framework.Failf("unable to wait for nodes to have positive allocatable epc resource: %v", err)
 		}
 		if err = utils.WaitForNodesWithResource(f.ClientSet, "sgx.intel.com/enclave", 30*time.Second); err != nil {


### PR DESCRIPTION
The NFD worker sleep timout is 60s by default so there are changes
we'll miss getting the sgx.intel.com/epc extended resource registered
before the timeout.

Increase the timeout so that at least two NFD worker labeling rounds
are included.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>