### PR TITLE
e2e: enable triggering hw jobs on PRs

### DIFF
--- a/.github/workflows/e2e-fpga.yml
+++ b/.github/workflows/e2e-fpga.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
   IMAGES: 'intel-fpga-plugin intel-fpga-initcontainer intel-fpga-admissionwebhook opae-nlb-demo'

--- a/.github/workflows/e2e-qat.yml
+++ b/.github/workflows/e2e-qat.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '20 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
   IMAGES: 'intel-qat-plugin crypto-perf'

--- a/.github/workflows/e2e-sgx.yml
+++ b/.github/workflows/e2e-sgx.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '40 3 * * *'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 env:
   IMAGES: 'intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook'


### PR DESCRIPTION
Added event type 'pull_request' to the list of events
that trigger e2e-* workflows.

**NOTE:** this PR can be accepted only after setting "Require approval for all outside collaborators" option in the project configuration.
