### PR TITLE
Images: Update license path for all plugin images

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,7 @@ Release tagged images of the components are also available on the Docker hub, ta
 All of the source code required to build intel-device-plugins-for-kubernetes
 is available under Open Source licenses. The source code files identify external Go
 modules used. Binaries are distributed as container images on
-DockerHub. Those images contain license texts under
-`/usr/local/share/package-licenses` and source code under
-`/usr/local/share/package-sources`.
+DockerHub. Those images contain license texts and source code under `/licenses`.
 
 ## Security
 

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/operator; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/operator /install_root/usr/local/bin/intel_deviceplugin_operator \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/operator" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/operator" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/dlb_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/dlb_plugin /install_root/usr/local/bin/intel_dlb_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dlb_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dlb_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/dsa_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/dsa_plugin /install_root/usr/local/bin/intel_dsa_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dsa_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dsa_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_admissionwebhook" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_admissionwebhook" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -33,9 +33,9 @@ ARG ROOT=/install_root
 RUN cd cmd/fpga_crihook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && \
     cd ../fpga_tool && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && \
     cd ../.. && \
-    install -D ${DIR}/LICENSE $ROOT/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_crihook" --save_path $ROOT/usr/local/share/go-licenses/fpga_crihook && \
-    go-licenses save "./cmd/fpga_tool" --save_path $ROOT/usr/local/share/go-licenses/fpga_tool
+    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
+    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_crihook" --save_path $ROOT/licenses/fpga_crihook && \
+    go-licenses save "./cmd/fpga_tool" --save_path $ROOT/licenses/go-licenses/fpga_tool
 
 ARG SRC_DIR=/usr/local/fpga-sw
 ARG DST_DIR=/opt/intel/fpga-sw
@@ -59,8 +59,8 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
-    && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \
-    && cp -r /usr/share/doc/musl $ROOT/usr/local/share/package-licenses/
+    && install -D LICENSE $ROOT/licenses/toybox \
+    && cp -r /usr/share/doc/musl $ROOT/licenses/
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -32,9 +32,9 @@ ARG ROOT=/install_root
 
 # Build NFD Feature Detector Hook
 RUN cd cmd/gpu_nfdhook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
-    install -D ${DIR}/LICENSE $ROOT/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE && \
+    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
     mkdir -p  $ROOT/usr/local/share/ && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_nfdhook" --save_path $ROOT/usr/local/share/go-licenses
+    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_nfdhook" --save_path $ROOT/licenses/go-licenses
 
 ARG NFD_HOOK=intel-gpu-nfdhook
 ARG SRC_DIR=/usr/local/bin/gpu-sw
@@ -51,8 +51,8 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
-    && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \
-    && cp -r /usr/share/doc/musl $ROOT/usr/local/share/package-licenses/
+    && install -D LICENSE $ROOT/licenses/toybox \
+    && cp -r /usr/share/doc/musl $ROOT/licenses/
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/sgx_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sgx_admissionwebhook \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_admissionwebhook" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_admissionwebhook" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -32,9 +32,9 @@ ARG ROOT=/install_root
 
 # Build NFD Feature Detector Hook
 RUN cd cmd/sgx_epchook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
-    install -D ${DIR}/LICENSE $ROOT/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE && \
+    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
     mkdir -p  $ROOT/usr/local/share/ && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_epchook" --save_path $ROOT/usr/local/share/go-licenses
+    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_epchook" --save_path $ROOT/licenses/go-licenses
 
 ARG NFD_HOOK=intel-sgx-epchook
 ARG SRC_DIR=/usr/local/bin/sgx-sw
@@ -51,8 +51,8 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && rm toybox.tar.gz \
     && cd toybox-$TOYBOX_VERSION \
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
-    && install -D LICENSE $ROOT/usr/local/share/package-licenses/toybox \
-    && cp -r /usr/share/doc/musl $ROOT/usr/local/share/package-licenses/
+    && install -D LICENSE $ROOT/licenses/toybox \
+    && cp -r /usr/share/doc/musl $ROOT/licenses/
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -30,8 +30,8 @@ COPY . .
 
 RUN cd cmd/sgx_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM gcr.io/distroless/static
 COPY --from=builder /install_root /


### PR DESCRIPTION
Updated license path to /install_root/licenses/ for all the plugin images except - intel-qat-plugin-kerneldrv, intel-vpu-plugin and intel-idxd-config-initcontainer images. 