### PR TITLE
operator: update NFD rules for GPUs

### DIFF
--- a/deployments/nfd/node-feature-rules.yaml
+++ b/deployments/nfd/node-feature-rules.yaml
@@ -50,7 +50,7 @@ spec:
         - feature: pci.device
           matchExpressions:
             vendor: {op: In, value: ["8086"]}
-            class: {op: In, value: ["0300"]}
+            class: {op: In, value: ["0300", "0380"]}
         - feature: kernel.loadedmodule
           matchExpressions:
             drm: {op: Exists}


### PR DESCRIPTION
Intel GPUs come at least in two classes: "0300" and 0380". Desktop GPUs with
3D / display support are in "0300" category, server/compute GPUs without
those are in "0380" category.

"0380" is missing so add it.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>