### PR TITLE
Makefile: fix the target for python3 venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,5 +215,5 @@ clean-html:
 _work/venv/.stamp: docs/requirements.txt
 	rm -rf ${@D}
 	python3 -m venv ${@D}
-	. ${@D}/bin/activate && pip install -r $<
+	. ${@D}/bin/activate && pip install wheel && pip install -r $<
 	touch $@


### PR DESCRIPTION
Fixes #881
Add wheel installing process before installing reuiqrements

I do not know why, but putting 'wheel' in requirements.txt does
not work for fixing the error in #881. So, alternatively, install
wheel first and then continue the following installing command.

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>