### PR TITLE
Images: Updated base image to use 'ubi8-micro' image from RedHat

### DIFF
--- a/build/docker/build-image.sh
+++ b/build/docker/build-image.sh
@@ -29,6 +29,7 @@ if [ -d $(dirname $0)/../../vendor ] ; then
     BUILD_ARGS="${BUILD_ARGS} --build-arg DIR=/go/src/github.com/intel/intel-device-plugins-for-kubernetes --build-arg GO111MODULE=off"
 fi
 
+BUILD_ARGS="${BUILD_ARGS} --build-arg FINAL_BASE=gcr.io/distroless/static"
 if [ -z "${BUILDER}" -o "${BUILDER}" = 'docker' ] ; then
     docker build --pull -t ${IMG}:${TAG} ${BUILD_ARGS} -f ${DOCKERFILE} .
 elif [ "${BUILDER}" = 'buildah' ] ; then

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/operator /install_root/usr/local/bin/intel_deviceplugin_o
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/operator" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-deviceplugin-operator' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/dlb_plugin /install_root/usr/local/bin/intel_dlb_device_p
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dlb_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-dlb-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/dsa_plugin /install_root/usr/local/bin/intel_dsa_device_p
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dsa_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-dsa-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_f
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_admissionwebhook" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-admissionwebhook' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -62,7 +74,7 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-initcontainer' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -54,7 +66,7 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-gpu-initcontainer' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_p
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-gpu-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-idxd-config-initcontainer.Dockerfile
+++ b/build/docker/intel-idxd-config-initcontainer.Dockerfile
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
+# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
+ARG FINAL_BASE
+
 FROM debian:unstable-slim AS builder
 
 RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
+# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
+ARG FINAL_BASE
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_p
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-qat-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sg
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_admissionwebhook" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-admissionwebhook' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -54,7 +66,7 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-initcontainer' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based. 
+# The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes
@@ -33,7 +45,7 @@ RUN install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_p
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
     && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_plugin" --save_path /install_root/licenses/go-licenses
 
-FROM gcr.io/distroless/static
+FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-plugin' 
 LABEL vendor='Intel®' 

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -20,6 +20,18 @@
 # The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.17-bullseye
 
+# FINAL_BASE can be used to configure the base image of the final image.
+#
+# This is used in two ways:
+# 1) make <image-name> BUILDER=<docker|buildah>
+# 2) docker build ... -f <image-name>.Dockerfile
+#
+# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+# (see build-image.sh).
+# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
+# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
+ARG FINAL_BASE
+
 FROM ${GOLANG_BASE} as builder
 
 ARG DIR=/intel-device-plugins-for-kubernetes


### PR DESCRIPTION
Updated base image to use 'ubi8-micro' image from RedHat for all plugins.

Closes: #852 