### PR TITLE
envtest: add more tests

### DIFF
--- a/test/envtest/dsadeviceplugin_controller_test.go
+++ b/test/envtest/dsadeviceplugin_controller_test.go
@@ -16,10 +16,13 @@ package envtest
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -34,7 +37,9 @@ var _ = Describe("DsaDevicePlugin Controller", func() {
 	Context("Basic CRUD operations", func() {
 		It("should handle DsaDevicePlugin objects correctly", func() {
 			spec := devicepluginv1.DsaDevicePluginSpec{
-				Image: "testimage",
+				Image:        "testimage",
+				InitImage:    "testinitimage",
+				NodeSelector: map[string]string{"dsa-nodeselector": "true"},
 			}
 
 			key := types.NamespacedName{
@@ -58,16 +63,80 @@ var _ = Describe("DsaDevicePlugin Controller", func() {
 				return len(fetched.Status.ControlledDaemonSet.UID) > 0
 			}, timeout, interval).Should(BeTrue())
 
-			By("updating image name successfully")
+			By("checking DaemonSet is created successfully")
+			ds := &apps.DaemonSet{}
+			_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "intel-dsa-plugin"}, ds)
+			Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(spec.Image))
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(ds.Spec.Template.Spec.InitContainers[0].Image).To(Equal(spec.InitImage))
+			Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(spec.NodeSelector))
+
+			By("updating DsaDevicePlugin successfully")
 			updatedImage := "updated-dsa-testimage"
+			updatedInitImage := "updated-dsa-testinitimage"
+			updatedProvisioningConfig := "updated-dsa-provisioningconfig"
+			updatedLogLevel := 2
+			updatedSharedDevNum := 42
+			updatedNodeSelector := map[string]string{"updated-dsa-nodeselector": "true"}
+
 			fetched.Spec.Image = updatedImage
+			fetched.Spec.InitImage = updatedInitImage
+			fetched.Spec.ProvisioningConfig = updatedProvisioningConfig
+			fetched.Spec.LogLevel = updatedLogLevel
+			fetched.Spec.SharedDevNum = updatedSharedDevNum
+			fetched.Spec.NodeSelector = updatedNodeSelector
 
 			Expect(k8sClient.Update(context.Background(), fetched)).Should(Succeed())
 			fetchedUpdated := &devicepluginv1.DsaDevicePlugin{}
-			Eventually(func() string {
+			Eventually(func() devicepluginv1.DsaDevicePluginSpec {
 				_ = k8sClient.Get(context.Background(), key, fetchedUpdated)
-				return fetchedUpdated.Spec.Image
-			}, timeout, interval).Should(Equal(updatedImage))
+				return fetchedUpdated.Spec
+			}, timeout, interval).Should(Equal(fetched.Spec))
+			time.Sleep(interval)
+
+			By("checking DaemonSet is updated successfully")
+			_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "intel-dsa-plugin"}, ds)
+
+			expectArgs := []string{
+				"-v",
+				strconv.Itoa(updatedLogLevel),
+				"-shared-dev-num",
+				strconv.Itoa(updatedSharedDevNum),
+			}
+			mode := int32(420)
+			expectedVolume := v1.Volume{
+				Name: "intel-dsa-config-volume",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{Name: updatedProvisioningConfig},
+						DefaultMode:          &mode,
+					},
+				},
+			}
+			Expect(ds.Spec.Template.Spec.Containers[0].Args).Should(ConsistOf(expectArgs))
+			Expect(ds.Spec.Template.Spec.Containers[0].Image).Should(Equal(updatedImage))
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(ds.Spec.Template.Spec.InitContainers[0].Image).To(Equal(updatedInitImage))
+			Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
+
+			Expect(ds.Spec.Template.Spec.NodeSelector).Should(Equal(updatedNodeSelector))
+
+			By("updating DsaDevicePlugin with different values successfully")
+			updatedInitImage = ""
+			updatedProvisioningConfig = ""
+			updatedNodeSelector = map[string]string{}
+			fetched.Spec.InitImage = updatedInitImage
+			fetched.Spec.ProvisioningConfig = updatedProvisioningConfig
+			fetched.Spec.NodeSelector = updatedNodeSelector
+
+			Expect(k8sClient.Update(context.Background(), fetched)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("checking DaemonSet is updated with different values successfully")
+			_ = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "intel-dsa-plugin"}, ds)
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(0))
+			Expect(ds.Spec.Template.Spec.Volumes).ShouldNot(ContainElement(expectedVolume))
+			Expect(ds.Spec.Template.Spec.NodeSelector).Should(And(HaveLen(1), HaveKeyWithValue("kubernetes.io/arch", "amd64")))
 
 			By("deleting DsaDevicePlugin successfully")
 			Eventually(func() error {


### PR DESCRIPTION
Add tests for args, initImage, nodeSelector, etc

Export getPodArgs function of controllers

Closes: #772 
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>