### PR TITLE
images: update license install path in all images

### DIFF
--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -33,7 +33,6 @@ ARG ROOT=/install_root
 # Build NFD Feature Detector Hook
 RUN cd cmd/gpu_nfdhook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
     install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    mkdir -p  $ROOT/usr/local/share/ && \
     GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_nfdhook" --save_path $ROOT/licenses/go-licenses
 
 ARG NFD_HOOK=intel-gpu-nfdhook

--- a/build/docker/intel-idxd-config-initcontainer.Dockerfile
+++ b/build/docker/intel-idxd-config-initcontainer.Dockerfile
@@ -40,10 +40,10 @@ FROM debian:unstable-slim
 RUN apt update && apt install -y libjson-c5 jq
 
 COPY --from=builder /usr/lib64/libaccel-config.so.1.0.0 /lib/x86_64-linux-gnu/
-RUN ldconfig && mkdir -p /usr/local/share/package-sources/
+RUN ldconfig && mkdir -p /licenses/accel-config
 
 COPY --from=builder /usr/bin/accel-config /usr/bin/
-COPY --from=builder /accel-config.tar.gz /usr/local/share/package-sources/
+COPY --from=builder /accel-config.tar.gz /licenses/accel-config/
 
 ADD demo/idxd-init.sh /idxd-init/
 ADD demo/dsa.conf /idxd-init/

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -42,8 +42,8 @@ RUN mkdir -p /usr/src/qat \
 RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
 RUN chmod a+x /go/bin/qat_plugin \
     && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM debian:unstable-slim
 COPY --from=builder /install_root /

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -33,7 +33,6 @@ ARG ROOT=/install_root
 # Build NFD Feature Detector Hook
 RUN cd cmd/sgx_epchook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
     install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    mkdir -p  $ROOT/usr/local/share/ && \
     GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_epchook" --save_path $ROOT/licenses/go-licenses
 
 ARG NFD_HOOK=intel-sgx-epchook

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -30,14 +30,14 @@ COPY . .
 
 RUN echo "deb-src http://deb.debian.org/debian unstable main" | tee -a /etc/apt/sources.list
 RUN apt update && apt -y install dpkg-dev libusb-1.0-0-dev
-RUN mkdir -p /install_root/usr/local/share/package-sources/libusb \
-    && cd /install_root/usr/local/share/package-sources/libusb \
+RUN mkdir -p /install_root/licenses/libusb \
+    && cd /install_root/licenses/libusb \
     && apt-get --download-only source libusb-1.0-0 \
     && cd -
 RUN cd cmd/vpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
 RUN install -D /go/bin/vpu_plugin /install_root/usr/local/bin/intel_vpu_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/usr/local/share/package-licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/vpu_plugin" --save_path /install_root/usr/local/share/go-licenses
+    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/vpu_plugin" --save_path /install_root/licenses/go-licenses
 
 FROM debian:unstable-slim
 RUN apt update && apt -y install libusb-1.0-0


### PR DESCRIPTION
An earlier commit updated the license install paths in our
distroless based images. This updates the remaining ones
to stay consistent.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>