### PR TITLE
operator-csv: Added minKubeVersion to clusterServiceVersion.yaml. Picked '1.21.0' as it is mentioned in the "supported versions" matrix in README.md

### DIFF
--- a/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
+++ b/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
@@ -116,6 +116,7 @@ spec:
   - email: mikko.ylinen@intel.com
     name: Mikko Ylinen
   maturity: alpha
+  minKubeVersion: 1.21.0
   provider:
     name: Intel® Corporation
     url: https://intel.com


### PR DESCRIPTION
When validated bundle against operatorframework suite, it show the warning to mention the minKubeVersion (minimum kubernetes cluster version supported). Please see below - 

[ckulkar1@jfz1r09h07 intel-device-plugins-for-kubernetes]$ operator-sdk bundle validate ./bundle --select-optional suite=operatorframework
WARN[0000] Warning: Value : (intel-device-plugins-operator.v0.23.0) csv.Spec.minKubeVersion is not informed. It is recommended you provide this information. Otherwise, it would mean that your operator project can be distributed and installed in any cluster version available, which is not necessarily the case for all projects.
INFO[0000] All validation tests have completed successfully

Signed-off-by: chaitanya1731 <chaitanya.kulkarni@intel.com>