### PR TITLE
ci: move to Go 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - 'release-*'
 env:
   RUNC_VERSION: v1.0.3
-  GO_VERSION: 1.17.4
+  GO_VERSION: 1.18
   K8S_VERSION: 1.22.1
 jobs:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     CRIO_VERSION="v1.21.4"
     K8S_VERSION="1.22.1"
     GOLANGCI_LINT_VERSION="v1.45.0"
-    GO_VERSION="1.17.4"
+    GO_VERSION="1.18"
     GO_TAR="go${GO_VERSION}.linux-amd64.tar.gz"
     GOROOT="/usr/local/go"
     GOPATH="/tmp/go"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install-tools:
 	$(GO) install sigs.k8s.io/kind@${KIND_VERSION}
 
 go-mod-tidy:
-	$(GO) mod download
+	$(GO) mod download all
 	@report=`$(GO) mod tidy -v 2>&1` ; if [ -n "$$report" ]; then echo "$$report"; exit 1; fi
 
 update-fixture:
@@ -159,7 +159,7 @@ terrascan:
 
 pre-pull:
 ifeq ($(TAG),devel)
-	@$(BUILDER) pull golang:1.17-bullseye
+	@$(BUILDER) pull golang:1.18-bullseye
 	@$(BUILDER) pull debian:unstable-slim
 	@$(BUILDER) pull clearlinux:latest
 	@$(BUILDER) pull ubuntu:20.04

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-iaa-plugin.Dockerfile
+++ b/build/docker/intel-iaa-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-qat-initcontainer.Dockerfile
+++ b/build/docker/intel-qat-initcontainer.Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -18,7 +18,7 @@
 #
 # This is used on release branches before tagging a stable version.
 # The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.17-bullseye
+ARG GOLANG_BASE=golang:1.18-bullseye
 
 # FINAL_BASE can be used to configure the base image of the final image.
 #


### PR DESCRIPTION
k8s v1.24 will move go Go 1.18. Let's do that too for our v0.24.