### PR TITLE
sgx: add a sample nfd CR that can be used in openshift

### DIFF
--- a/deployments/nfd/overlays/node-feature-discovery/node-feature-discovery-openshift.yaml
+++ b/deployments/nfd/overlays/node-feature-discovery/node-feature-discovery-openshift.yaml
@@ -1,0 +1,17 @@
+# This is a sample for NodeFeatureDiscovery for Openshift
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  extraLabelNs:
+    - sgx.intel.com
+  resourceLabels:
+    - sgx.intel.com/epc
+  operand:
+    image: quay.io/openshift/origin-node-feature-discovery:4.10
+    imagePullPolicy: Always
+    servicePort: 12000
+  workerConfig:
+    configData: |

--- a/deployments/nfd/overlays/node-feature-rules/node-feature-rules-openshift.yaml
+++ b/deployments/nfd/overlays/node-feature-rules/node-feature-rules-openshift.yaml
@@ -1,0 +1,86 @@
+# this is a copy of node-feature-rules.yaml but it is tailored
+# for openshift platforms.
+apiVersion: nfd.openshift.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: intel-dp-devices
+spec:
+  rules:
+    - name: "intel.dlb"
+      labels:
+        "intel.feature.node.kubernetes.io/dlb": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            device: {op: In, value: ["2710"]}
+            class: {op: In, value: ["0b40"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dlb2: {op: Exists}
+
+    - name: "intel.dsa"
+      labels:
+        "intel.feature.node.kubernetes.io/dsa": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            device: {op: In, value: ["0b25"]}
+            class: {op: In, value: ["0880"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            idxd: {op: Exists}
+
+    - name: "intel.fpga-arria10"
+      labels:
+        "intel.feature.node.kubernetes.io/fpga-arria10": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            device: {op: In, value: ["09c4"]}
+            class: {op: In, value: ["1200"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            dfl_pci: {op: Exists}
+
+    - name: "intel.gpu"
+      labels:
+        "intel.feature.node.kubernetes.io/gpu": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            class: {op: In, value: ["0300", "0380"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            drm: {op: Exists}
+
+    - name: "intel.qat"
+      labels:
+        "intel.feature.node.kubernetes.io/qat": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            device: {op: In, value: ["37c8", "4940"]}
+            class: {op: In, value: ["0b40"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            intel_qat: {op: Exists}
+
+    - name: "intel.sgx"
+      labels:
+        "intel.feature.node.kubernetes.io/sgx": "true"
+      matchFeatures:
+        - feature: cpu.cpuid
+          matchExpressions:
+            SGX: {op: Exists}
+            SGXLC: {op: Exists}
+        - feature: cpu.sgx
+          matchExpressions:
+            enabled: {op: IsTrue}
+        - feature: kernel.config
+          matchExpressions:
+            X86_SGX: {op: Exists}


### PR DESCRIPTION
This sample nfd cr can be used to make a new nfd instance with SGX support in openshift.

Fixes: #781 