### PR TITLE
gpu: add tiles annotation support

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -26,7 +26,7 @@ Intel GPU plugin facilitates Kubernetes workload offloading by providing access 
 Intel discrete (Xe) and integrated GPU HW device files.
 
 Use cases include, but are not limited to:
-- Media transcode 
+- Media transcode
 - Media analytics
 - Cloud gaming
 - High performance computing
@@ -43,7 +43,7 @@ backend libraries can offload compute operations to GPU.
 | -enable-monitoring | - | disabled | Enable 'i915_monitoring' resource that provides access to all Intel GPU devices on the node |
 | -resource-manager | - | disabled | Enable fractional resource management, [see also dependencies](#fractional-resources) |
 | -shared-dev-num | int | 1 | Number of containers that can share the same GPU device |
-| -allocation-policy | string | none | 3 possible values: balanced, packed, none. It is meaningful when shared-dev-num > 1, balanced mode is suitable for workload balance among GPU devices, packed mode is suitable for making full use of each GPU device, none mode is the default |
+| -allocation-policy | string | none | 3 possible values: balanced, packed, none. It is meaningful when shared-dev-num > 1, balanced mode is suitable for workload balance among GPU devices, packed mode is suitable for making full use of each GPU device, none mode is the default. Allocation policy does not have effect when resource manager is enabled. |
 
 The plugin also accepts a number of other arguments (common to all plugins) related to logging.
 Please use the -h option to see the complete list of logging related options.
@@ -169,6 +169,13 @@ increasing numeric timestamps in the annotation `gas-ts` and container card sele
 `gas-container-cards:card0,card1|card2,card3`. Enabling the fractional-resource support
 in the plugin without running such an annotation adding scheduler extender in the cluster
 will only slow down GPU-deployments, so do not enable this feature unnecessarily.
+
+In multi-tile systems, containers can request individual tiles to improve GPU resource usage.
+Tiles targeted for containers are specified to pod via `gas-container-tiles` annotation where the the annotation
+value describes a set of card and tile combinations. For example in a two container pod, the annotation
+could be `gas-container-tiles:card0:gt0+gt1|card1:gt1,card2:gt0`. Similarly to `gas-container-cards`, the container
+details are split via `|`. In the example above, the first container gets tiles 0 and 1 from card 0,
+and the second container gets tile 1 from card 1 and tile 0 from card 2.
 
 > **Note**: It is also possible to run the GPU device plugin using a non-root user. To do this,
 the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.

--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -197,6 +197,10 @@ func newDevicePlugin(sysfsDir, devfsDir string, options cliOptions) *devicePlugi
 
 // Implement the PreferredAllocator interface.
 func (dp *devicePlugin) GetPreferredAllocation(rqt *pluginapi.PreferredAllocationRequest) (*pluginapi.PreferredAllocationResponse, error) {
+	if dp.resMan != nil {
+		return dp.resMan.GetPreferredFractionalAllocation(rqt)
+	}
+
 	response := &pluginapi.PreferredAllocationResponse{}
 
 	for _, req := range rqt.ContainerRequests {
@@ -356,7 +360,7 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 
 func (dp *devicePlugin) Allocate(request *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	if dp.resMan != nil {
-		return dp.resMan.ReallocateWithFractionalResources(request)
+		return dp.resMan.CreateFractionalResourceResponse(request)
 	}
 
 	return nil, &dpapi.UseDefaultMethodError{}

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -48,10 +48,14 @@ func (n *mockNotifier) Notify(newDeviceTree dpapi.DeviceTree) {
 
 type mockResourceManager struct{}
 
-func (m *mockResourceManager) ReallocateWithFractionalResources(*v1beta1.AllocateRequest) (*v1beta1.AllocateResponse, error) {
+func (m *mockResourceManager) CreateFractionalResourceResponse(*v1beta1.AllocateRequest) (*v1beta1.AllocateResponse, error) {
 	return &v1beta1.AllocateResponse{}, &dpapi.UseDefaultMethodError{}
 }
 func (m *mockResourceManager) SetDevInfos(rm.DeviceInfoMap) {}
+
+func (m *mockResourceManager) GetPreferredFractionalAllocation(*v1beta1.PreferredAllocationRequest) (*v1beta1.PreferredAllocationResponse, error) {
+	return &v1beta1.PreferredAllocationResponse{}, &dpapi.UseDefaultMethodError{}
+}
 
 func createTestFiles(root string, devfsdirs, sysfsdirs []string, sysfsfiles map[string][]byte) (string, string, error) {
 	sysfs := path.Join(root, "sys")

--- a/cmd/gpu_plugin/rm/gpu_plugin_resource_manager.go
+++ b/cmd/gpu_plugin/rm/gpu_plugin_resource_manager.go
@@ -47,8 +47,6 @@ const (
 	grpcAddress    = "unix:///var/lib/kubelet/pod-resources/kubelet.sock"
 	grpcBufferSize = 4 * 1024 * 1024
 	grpcTimeout    = 5 * time.Second
-
-	retryTimeout = 1 * time.Second
 )
 
 // Errors.
@@ -63,12 +61,15 @@ func (e *zeroPendingErr) Error() string {
 }
 
 type podCandidate struct {
-	pod                 *v1.Pod
-	name                string
-	allocatedContainers int
-	allocationTargetNum int
+	pod                     *v1.Pod
+	name                    string
+	allocatedContainerCount int
+	allocationTargetNum     int
 }
 
+// DeviceInfo is a subset of deviceplugin.DeviceInfo
+// It's a lighter version of the full DeviceInfo as it is used
+// to store fractional devices.
 type DeviceInfo struct {
 	envs   map[string]string
 	nodes  []pluginapi.DeviceSpec
@@ -79,18 +80,32 @@ type getClientFunc func(string, time.Duration, int) (podresourcesv1.PodResources
 
 // ResourceManager interface for the fractional resource handling.
 type ResourceManager interface {
-	ReallocateWithFractionalResources(*pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error)
+	CreateFractionalResourceResponse(*pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error)
+	GetPreferredFractionalAllocation(*pluginapi.PreferredAllocationRequest) (*pluginapi.PreferredAllocationResponse, error)
 	SetDevInfos(DeviceInfoMap)
 }
 
+type ContainerAssignments struct {
+	deviceIds map[string]bool
+	tileEnv   string
+}
+
+type PodAssignmentDetails struct {
+	containers []ContainerAssignments
+}
+
 type resourceManager struct {
-	deviceInfos      DeviceInfoMap
-	nodeName         string
 	clientset        kubernetes.Interface
+	deviceInfos      DeviceInfoMap
 	prGetClientFunc  getClientFunc
+	assignments      map[string]PodAssignmentDetails // pod name -> assignment details
+	nodeName         string
 	skipID           string
 	fullResourceName string
+	retryTimeout     time.Duration
+	cleanupInterval  time.Duration
 	mutex            sync.RWMutex // for devTree updates during scan
+	cleanupMutex     sync.RWMutex // for assignment details during cleanup
 }
 
 // NewDeviceInfo creates a new DeviceInfo.
@@ -124,32 +139,104 @@ func NewResourceManager(skipID, fullResourceName string) (ResourceManager, error
 		skipID:           skipID,
 		fullResourceName: fullResourceName,
 		prGetClientFunc:  podresources.GetV1Client,
+		assignments:      make(map[string]PodAssignmentDetails),
+		retryTimeout:     1 * time.Second,
+		cleanupInterval:  2 * time.Minute,
 	}
 
 	klog.Info("GPU device plugin resource manager enabled")
 
+	go func() {
+		ticker := time.NewTicker(rm.cleanupInterval)
+
+		for range ticker.C {
+			klog.V(4).Info("Running cleanup")
+
+			// Gather both running and pending pods. It might happen that
+			// cleanup is triggered between GetPreferredAllocation and Allocate
+			// and it would remove the assignment data for the soon-to-be allocated pod
+			running := rm.listPodsOnNodeWithState(string(v1.PodRunning))
+			for podName, podItem := range rm.listPodsOnNodeWithState(string(v1.PodPending)) {
+				running[podName] = podItem
+			}
+
+			func() {
+				rm.cleanupMutex.Lock()
+				defer rm.cleanupMutex.Unlock()
+
+				for podName := range rm.assignments {
+					if _, found := running[podName]; !found {
+						klog.V(4).Info("Removing from assignments: ", podName)
+						delete(rm.assignments, podName)
+					}
+				}
+			}()
+
+			klog.V(4).Info("Cleanup done")
+		}
+	}()
+
 	return &rm, nil
 }
 
-// ReallocateWithFractionalResources runs the fractional resource logic.
+// Generate a unique key for Pod.
+func getPodKey(pod *v1.Pod) string {
+	return pod.Namespace + "&" + pod.Name
+}
+
+// Generate a unique key for PodResources.
+func getPodResourceKey(res *podresourcesv1.PodResources) string {
+	return res.Namespace + "&" + res.Name
+}
+
+func (rm *resourceManager) listPodsOnNodeWithState(state string) map[string]*v1.Pod {
+	pods := make(map[string]*v1.Pod)
+
+	selector, err := fields.ParseSelector("spec.nodeName=" + rm.nodeName +
+		",status.phase=" + state)
+
+	if err != nil {
+		return pods
+	}
+
+	podList, err := rm.clientset.CoreV1().Pods(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{
+		FieldSelector: selector.String(),
+	})
+
+	if err != nil {
+		return pods
+	}
+
+	for i := range podList.Items {
+		key := getPodKey(&podList.Items[i])
+		pods[key] = &podList.Items[i]
+	}
+
+	return pods
+}
+
+// CreateFractionalResourceResponse returns allocate response with the details
+// assigned in GetPreferredFractionalAllocation
 // This intentionally only logs errors and returns with the UseDefaultMethodError,
 // in case any errors are hit. This is to avoid clusters filling up with unexpected admission errors.
-func (rm *resourceManager) ReallocateWithFractionalResources(request *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
-	if !isInputOk(request, rm.skipID) {
+func (rm *resourceManager) CreateFractionalResourceResponse(request *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	if !isAllocateRequestOk(request, rm.skipID) {
 		// it is better to leave allocated gpu devices as is and return
 		return nil, &dpapi.UseDefaultMethodError{}
 	}
 
+	klog.V(4).Info("Proposed device ids: ", request.ContainerRequests[0].DevicesIDs)
+
 	podCandidate, err := rm.findAllocationPodCandidate()
-	if _, ok := err.(*retryErr); ok {
+	if errors.Is(err, &retryErr{}) {
 		klog.Warning("retrying POD resolving after sleeping")
-		time.Sleep(retryTimeout)
+		time.Sleep(rm.retryTimeout)
 
 		podCandidate, err = rm.findAllocationPodCandidate()
 	}
 
 	if err != nil {
-		if _, ok := err.(*zeroPendingErr); !ok {
+		if !errors.Is(err, &zeroPendingErr{}) {
 			klog.Error("allocation candidate not found, perhaps the GPU scheduler extender is not called, err:", err)
 		}
 		// it is better to leave allocated gpu devices as is and return
@@ -157,13 +244,170 @@ func (rm *resourceManager) ReallocateWithFractionalResources(request *pluginapi.
 	}
 
 	pod := podCandidate.pod
-	cards := containerCards(pod, podCandidate.allocatedContainers)
-	affinityMask := containerTileAffinityMask(pod, podCandidate.allocatedContainers)
 
-	return rm.createAllocateResponse(cards, affinityMask)
+	rm.cleanupMutex.Lock()
+
+	assignment, found := rm.assignments[getPodKey(pod)]
+	if !found {
+		rm.cleanupMutex.Unlock()
+		klog.Error("couldn't find allocation info from assignments:", getPodKey(pod))
+
+		return nil, &dpapi.UseDefaultMethodError{}
+	}
+
+	containerIndex := podCandidate.allocatedContainerCount
+
+	affinityMask := assignment.containers[containerIndex].tileEnv
+	getPrefDevices := assignment.containers[containerIndex].deviceIds
+
+	rm.cleanupMutex.Unlock()
+
+	devIds := request.ContainerRequests[0].DevicesIDs
+
+	// Check if all the preferred devices were also used
+	if len(devIds) != len(getPrefDevices) {
+		klog.Warningf("Allocate called with odd number of device IDs: %d vs %d", len(devIds), len(getPrefDevices))
+	}
+
+	for _, devID := range devIds {
+		if _, found := getPrefDevices[devID]; !found {
+			klog.Warningf("Not preferred device used in Allocate: %s (%v)", devID, getPrefDevices)
+		}
+	}
+
+	klog.V(4).Info("Allocate affinity mask: ", affinityMask)
+	klog.V(4).Info("Allocate device ids: ", devIds)
+
+	return rm.createAllocateResponse(devIds, affinityMask)
 }
 
-func isInputOk(rqt *pluginapi.AllocateRequest, skipID string) bool {
+func (rm *resourceManager) GetPreferredFractionalAllocation(request *pluginapi.PreferredAllocationRequest) (
+	*pluginapi.PreferredAllocationResponse, error) {
+	if !isPreferredAllocationRequestOk(request, rm.skipID) {
+		// it is better to leave allocated gpu devices as is and return
+		return &pluginapi.PreferredAllocationResponse{}, nil
+	}
+
+	klog.V(4).Info("GetPreferredAllocation request: ", request)
+
+	podCandidate, err := rm.findAllocationPodCandidate()
+	if errors.Is(err, &retryErr{}) {
+		klog.Warning("retrying POD resolving after sleeping")
+		time.Sleep(rm.retryTimeout)
+
+		podCandidate, err = rm.findAllocationPodCandidate()
+	}
+
+	if err != nil {
+		if !errors.Is(err, &zeroPendingErr{}) {
+			klog.Error("allocation candidate not found, perhaps the GPU scheduler extender is not called, err:", err)
+		}
+
+		// Return empty response as returning an error causes
+		// the pod to be labeled as UnexpectedAdmissionError
+		return &pluginapi.PreferredAllocationResponse{}, nil
+	}
+
+	pod := podCandidate.pod
+	containerIndex := podCandidate.allocatedContainerCount
+	cards := containerCards(pod, containerIndex)
+	affinityMask := containerTileAffinityMask(pod, containerIndex)
+	podKey := getPodKey(pod)
+
+	creq := request.ContainerRequests[0]
+
+	klog.V(4).Info("Get preferred fractional allocation: ",
+		podKey, creq.AllocationSize, creq.MustIncludeDeviceIDs, creq.AvailableDeviceIDs)
+
+	deviceIds := selectDeviceIDsForContainer(
+		int(creq.AllocationSize), cards, creq.AvailableDeviceIDs, creq.MustIncludeDeviceIDs)
+
+	// Map container assignment details per pod name
+
+	rm.cleanupMutex.Lock()
+
+	assignments, found := rm.assignments[podKey]
+
+	if !found {
+		assignments.containers = make([]ContainerAssignments, podCandidate.allocationTargetNum)
+	}
+
+	assignments.containers[containerIndex].tileEnv = affinityMask
+	// Store device ids so we can double check the ones in Allocate
+	assignments.containers[containerIndex].deviceIds = make(map[string]bool)
+	for _, devID := range deviceIds {
+		assignments.containers[containerIndex].deviceIds[devID] = true
+	}
+
+	rm.assignments[podKey] = assignments
+
+	rm.cleanupMutex.Unlock()
+
+	klog.V(4).Info("Selected devices for container: ", deviceIds)
+
+	response := pluginapi.PreferredAllocationResponse{
+		ContainerResponses: []*pluginapi.ContainerPreferredAllocationResponse{
+			{DeviceIDs: deviceIds},
+		},
+	}
+
+	return &response, nil
+}
+
+// selectDeviceIDsForContainer selects suitable device ids from deviceIds and mustHaveDeviceIds
+// the selection is guided by the cards list.
+func selectDeviceIDsForContainer(requestedCount int, cards, deviceIds, mustHaveDeviceIds []string) []string {
+	getBaseCard := func(deviceId string) string {
+		return strings.Split(deviceId, "-")[0]
+	}
+
+	if requestedCount < len(cards) {
+		klog.Warningf("Requested count is less than card count: %d vs %d.", requestedCount, len(cards))
+		cards = cards[0:requestedCount]
+	}
+
+	if requestedCount > len(cards) {
+		klog.Warningf("Requested count is higher than card count: %d vs %d.", requestedCount, len(cards))
+	}
+
+	// map of cardX -> device id list
+	available := map[string][]string{}
+	// Keep the last used index so we can pick the next one
+	availableIndex := map[string]int{}
+
+	// Place must have IDs first so they get used
+	for _, devID := range mustHaveDeviceIds {
+		baseCard := getBaseCard(devID)
+		available[baseCard] = append(available[baseCard], devID)
+	}
+
+	for _, devID := range deviceIds {
+		baseCard := getBaseCard(devID)
+		available[baseCard] = append(available[baseCard], devID)
+	}
+
+	selected := []string{}
+
+	for _, card := range cards {
+		indexNow := availableIndex[card]
+
+		availableDevices, found := available[card]
+		if !found {
+			klog.Warningf("card %s is not found from known devices: %v", card, available)
+			continue
+		}
+
+		if indexNow < len(availableDevices) {
+			selected = append(selected, availableDevices[indexNow])
+			indexNow++
+			availableIndex[card] = indexNow
+		}
+	}
+
+	return selected
+}
+
+func isAllocateRequestOk(rqt *pluginapi.AllocateRequest, skipID string) bool {
 	// so far kubelet calls allocate for each container separately. If that changes, we need to refine our logic.
 	if len(rqt.ContainerRequests) != 1 {
 		klog.Warning("multi-container allocation request not supported")
@@ -172,6 +416,23 @@ func isInputOk(rqt *pluginapi.AllocateRequest, skipID string) bool {
 
 	crqt := rqt.ContainerRequests[0]
 	for _, id := range crqt.DevicesIDs {
+		if id == skipID {
+			return false // intentionally not printing anything, this request is skipped
+		}
+	}
+
+	return true
+}
+
+func isPreferredAllocationRequestOk(rqt *pluginapi.PreferredAllocationRequest, skipID string) bool {
+	// so far kubelet calls allocate for each container separately. If that changes, we need to refine our logic.
+	if len(rqt.ContainerRequests) != 1 {
+		klog.Warning("multi-container allocation request not supported")
+		return false
+	}
+
+	crqt := rqt.ContainerRequests[0]
+	for _, id := range crqt.AvailableDeviceIDs {
 		if id == skipID {
 			return false // intentionally not printing anything, this request is skipped
 		}
@@ -230,6 +491,7 @@ func (rm *resourceManager) findAllocationPodCandidate() (*podCandidate, error) {
 			}
 		}
 
+		// .name here refers to a namespace+name combination
 		sort.Slice(timestampedCandidates,
 			func(i, j int) bool {
 				return pendingPods[timestampedCandidates[i].name].Annotations[gasTSAnnotation] <
@@ -249,29 +511,11 @@ func (rm *resourceManager) findAllocationPodCandidate() (*podCandidate, error) {
 
 // getNodePendingGPUPods returns a map of pod names -> pods that are pending and use the gpu.
 func (rm *resourceManager) getNodePendingGPUPods() (map[string]*v1.Pod, error) {
-	selector, err := fields.ParseSelector("spec.nodeName=" + rm.nodeName +
-		",status.phase=" + string(v1.PodPending))
+	pendingPods := rm.listPodsOnNodeWithState(string(v1.PodPending))
 
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse selector")
-	}
-
-	pendingPodList, err := rm.clientset.CoreV1().Pods(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{
-		FieldSelector: selector.String(),
-	})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to list pods")
-	}
-
-	// make a map ouf of the list, accept only GPU-using pods
-	pendingPods := make(map[string]*v1.Pod)
-
-	for i := range pendingPodList.Items {
-		pod := &pendingPodList.Items[i]
-
-		if numGPUUsingContainers(pod, rm.fullResourceName) > 0 {
-			pendingPods[pod.Name] = pod
+	for podName, pod := range pendingPods {
+		if numGPUUsingContainers(pod, rm.fullResourceName) == 0 {
+			delete(pendingPods, podName)
 		}
 	}
 
@@ -312,14 +556,16 @@ func (rm *resourceManager) findAllocationPodCandidates(pendingPods map[string]*v
 			}
 		}
 
-		if pod, pending := pendingPods[podRes.Name]; pending {
+		key := getPodResourceKey(podRes)
+
+		if pod, pending := pendingPods[key]; pending {
 			allocationTargetNum := numGPUUsingContainers(pod, rm.fullResourceName)
 			if numContainersAllocated < allocationTargetNum {
 				candidate := podCandidate{
-					pod:                 pod,
-					name:                podRes.Name,
-					allocatedContainers: numContainersAllocated,
-					allocationTargetNum: allocationTargetNum,
+					pod:                     pod,
+					name:                    key,
+					allocatedContainerCount: numContainersAllocated,
+					allocationTargetNum:     allocationTargetNum,
 				}
 				candidates = append(candidates, candidate)
 			}
@@ -335,19 +581,17 @@ func (rm *resourceManager) SetDevInfos(deviceInfos DeviceInfoMap) {
 	rm.deviceInfos = deviceInfos
 }
 
-func (rm *resourceManager) createAllocateResponse(cards []string, tileAffinityMask string) (*pluginapi.AllocateResponse, error) {
+func (rm *resourceManager) createAllocateResponse(deviceIds []string, tileAffinityMask string) (*pluginapi.AllocateResponse, error) {
 	rm.mutex.Lock()
 	defer rm.mutex.Unlock()
 
 	allocateResponse := pluginapi.AllocateResponse{}
 	cresp := pluginapi.ContainerAllocateResponse{}
 
-	for _, card := range cards {
-		newDeviceID := card + "-0"
-
-		dev, ok := rm.deviceInfos[newDeviceID]
+	for _, devID := range deviceIds {
+		dev, ok := rm.deviceInfos[devID]
 		if !ok {
-			klog.Warningf("No device info for %q, using default allocation method devices", newDeviceID)
+			klog.Warningf("No device info for %q, using default allocation method devices", devID)
 			return nil, &dpapi.UseDefaultMethodError{}
 		}
 
@@ -376,6 +620,7 @@ func (rm *resourceManager) createAllocateResponse(cards []string, tileAffinityMa
 		if cresp.Envs == nil {
 			cresp.Envs = make(map[string]string)
 		}
+
 		cresp.Envs[levelZeroAffinityMaskEnvVar] = tileAffinityMask
 	}
 
@@ -416,7 +661,7 @@ func containerCards(pod *v1.Pod, gpuUsingContainerIndex int) []string {
 		cards := strings.Split(cardList, ",")
 		if len(cards) > 0 && len(cardList) > 0 {
 			if gpuUsingContainerIndex == i {
-				klog.V(3).Infof("Cards for container nr %v in pod %v are %v", gpuUsingContainerIndex, pod.Name, cards)
+				klog.V(3).Infof("Cards for container nr %v in pod %v are %v", gpuUsingContainerIndex, getPodKey(pod), cards)
 				return cards
 			}
 			i++
@@ -429,40 +674,42 @@ func containerCards(pod *v1.Pod, gpuUsingContainerIndex int) []string {
 }
 
 func convertTileInfoToEnvMask(tileInfo string) string {
-	cardTileList := strings.Split(tileInfo, ",")
+	cards := strings.Split(tileInfo, ",")
 
-	var tileIndices []string
+	tileIndices := make([]string, len(cards))
 
-	for i, cardList := range cardTileList {
-		cards := strings.Split(cardList, ",")
+	for i, cardTileCombos := range cards {
+		cardTileSplit := strings.Split(cardTileCombos, ":")
+		if len(cardTileSplit) != 2 {
+			klog.Warningf("invalid card tile combo string (%v)", cardTileCombos)
+			return ""
+		}
 
-		for _, cardTileCombos := range cards {
-			cardTileSplit := strings.Split(cardTileCombos, ":")
-			if len(cardTileSplit) < 2 {
-				klog.Warningf("invalid card tile combo string (%v)", cardTileCombos)
+		tiles := strings.Split(cardTileSplit[1], "+")
+
+		var combos []string
+
+		for _, tile := range tiles {
+			if !strings.HasPrefix(tile, "gt") {
+				klog.Warningf("invalid tile syntax (%v)", tile)
 				return ""
 			}
 
-			tiles := strings.Split(cardTileSplit[1], "+")
+			tileNoStr := strings.TrimPrefix(tile, "gt")
+			tileNo, err := strconv.ParseInt(tileNoStr, 10, 16)
 
-			var combos []string
-
-			for _, tile := range tiles {
-				tileNoStr := strings.TrimPrefix(tile, "gt")
-				tileNo, err := strconv.ParseInt(tileNoStr, 10, 16)
-
-				if err != nil {
-					continue
-				}
-
-				levelZeroCardTileCombo :=
-					strconv.FormatInt(int64(i), 10) + "." +
-						strconv.FormatInt(int64(tileNo), 10)
-				combos = append(combos, levelZeroCardTileCombo)
+			if err != nil {
+				klog.Warningf("invalid tile syntax (%v)", tile)
+				return ""
 			}
 
-			tileIndices = append(tileIndices, strings.Join(combos, ","))
+			levelZeroCardTileCombo :=
+				strconv.FormatInt(int64(i), 10) + "." +
+					strconv.FormatInt(tileNo, 10)
+			combos = append(combos, levelZeroCardTileCombo)
 		}
+
+		tileIndices[i] = strings.Join(combos, ",")
 	}
 
 	return strings.Join(tileIndices, ",")
@@ -472,11 +719,12 @@ func convertTileInfoToEnvMask(tileInfo string) string {
 // Indices should be passed to level zero env variable to guide execution
 // gpuUsingContainerIndex 0 == first gpu-using container in the pod.
 // annotation example:
-// gas-container-tiles=card0:gt0+gt1,card1:gt0|card2:gt1+gt2||card0:gt3
+// gas-container-tiles=card0:gt0+gt1,card1:gt0|card2:gt1+gt2||card0:gt3.
 func containerTileAffinityMask(pod *v1.Pod, gpuUsingContainerIndex int) string {
 	fullAnnotation := pod.Annotations[gasTileAnnotation]
+	onlyDividers := strings.Count(fullAnnotation, "|") == len(fullAnnotation)
 
-	if fullAnnotation == "" {
+	if fullAnnotation == "" || onlyDividers {
 		return ""
 	}
 
@@ -484,6 +732,7 @@ func containerTileAffinityMask(pod *v1.Pod, gpuUsingContainerIndex int) string {
 	klog.Infof("%s:%v", fullAnnotation, tileLists)
 
 	i := 0
+
 	for _, containerTileInfo := range tileLists {
 		if len(containerTileInfo) == 0 {
 			continue
@@ -497,6 +746,7 @@ func containerTileAffinityMask(pod *v1.Pod, gpuUsingContainerIndex int) string {
 	}
 
 	klog.Warningf("couldn't find tile info for gpu using container index %v", gpuUsingContainerIndex)
+
 	return ""
 }
 


### PR DESCRIPTION
Add support to target individual gpu tiles in containers through a level zero affinity variable. Container requesting gpu.intel.com/tiles resources will be running with a level zero environment variable which will limit/target the devices the applications can use.