### PR TITLE
doc: allow building container images at anywhere under the demo folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,21 @@ $(images):
 
 images: $(images)
 
-demos = $(shell basename -a demo/*/)
+demo-images = $(patsubst demo/%/Dockerfile,%,$(shell find demo -name "Dockerfile"))
 
-$(demos):
-	@cd demo/ && ./build-image.sh $(REG)$@ $(BUILDER)
+define add-demo-build-target =
+target := $(notdir $(1))
+demos  := $(demos) $$(target)
+
+ifneq ("$(dir $(1))","./")
+$$(target): $(1)
+endif
+
+$(1):
+	@cd demo/ && ./build-image.sh $(REG)$$(notdir $$@) $(BUILDER) $$(dir $$@)
+endef
+
+$(foreach s,$(demo-images),$(eval $(call add-demo-build-target,$s)))
 
 demos: $(demos)
 

--- a/demo/build-image.sh
+++ b/demo/build-image.sh
@@ -2,7 +2,7 @@
 
 IMG=$1
 BUILDER=$2
-DIR=$(basename $IMG)
+DIR=$3$(basename $IMG)
 
 if [ -z "$DIR" ]; then
     (>&2 echo "Usage: $0 <image directory>")
@@ -14,13 +14,12 @@ if [ ! -d "$DIR" ]; then
     exit 1
 fi
 
-CWD=`dirname $0`
 TAG=${TAG:-devel}
 
 if [ -z "$BUILDER" -o "$BUILDER" = 'docker' ] ; then
-    docker build --pull -t ${IMG}:${TAG} "$CWD/$DIR/"
+    docker build --pull -t ${IMG}:${TAG} "$DIR/"
 elif [ "$BUILDER" = 'buildah' ] ; then
-    buildah bud  --pull-always -t ${IMG}:${TAG} "$CWD/$DIR/"
+    buildah bud  --pull-always -t ${IMG}:${TAG} "$DIR/"
 else
     (>&2 echo "Unknown builder $BUILDER")
     exit 1


### PR DESCRIPTION
The current [logic](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/v0.23.0/Makefile#L158-L161) of building demo images requires the docker build materials are in the 1st level folder in the `demo` directory. This commit relaxes the limitation so that we can properly organize the demo images by plugin types [Phase 0].

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>
Closes: #954 