### PR TITLE
drop deprecated grpc.WithInsecure()

### DIFF
--- a/cmd/gpu_plugin/rm/gpu_plugin_resource_manager_test.go
+++ b/cmd/gpu_plugin/rm/gpu_plugin_resource_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,8 +86,7 @@ func (w *mockPodResources) GetAllocatableResources(ctx context.Context,
 }
 
 func newMockResourceManager(pods []v1.Pod) ResourceManager {
-	//nolint: staticcheck
-	client, err := grpc.Dial("", grpc.WithInsecure())
+	client, err := grpc.Dial("", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		os.Exit(1)
 	}

--- a/pkg/deviceplugin/server.go
+++ b/pkg/deviceplugin/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -328,8 +329,8 @@ func watchFile(file string) error {
 func (srv *server) registerWithKubelet(kubeletSocket, pluginEndPoint, resourceName string) error {
 	ctx := context.Background()
 
-	//nolint: staticcheck
-	conn, err := grpc.DialContext(ctx, kubeletSocket, grpc.WithInsecure(),
+	conn, err := grpc.DialContext(ctx, kubeletSocket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}))

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"k8s.io/klog/v2"
@@ -179,8 +180,8 @@ func TestSetupAndServe(t *testing.T) {
 
 	ctx := context.Background()
 
-	//nolint: staticcheck
-	conn, err := grpc.DialContext(ctx, pluginSocket, grpc.WithInsecure(),
+	conn, err := grpc.DialContext(ctx, pluginSocket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}))
@@ -230,8 +231,8 @@ func TestSetupAndServe(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}
 
-	//nolint: staticcheck
-	conn, err = grpc.DialContext(ctx, pluginSocket, grpc.WithInsecure(),
+	conn, err = grpc.DialContext(ctx, pluginSocket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}))


### PR DESCRIPTION
Closes: #814

grpc-go v1.43.0 deprecated grpc.WithInsecure() in favor of
insecure.NewCredentials(). Move to use the recommended approach
and drop the linter annotations.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>