### PR TITLE
doc: use shell argument $0 instead of embedded filenames in the screencast files

### DIFF
--- a/demo/screencast-dsa-accel-config.sh
+++ b/demo/screencast-dsa-accel-config.sh
@@ -39,7 +39,7 @@ record()
 {
   clear
   out 'Record this screencast'
-  command "asciinema rec -t 'Intel DSA Device Plugin for Kubernetes.'  Intel-DSA-Device-Plugin-for-Kubernetes-Demo.cast -c 'sh ./screencast-dsa-accel-config.sh play'" 300
+  command "asciinema rec -t 'Intel DSA Device Plugin for Kubernetes.'  Intel-DSA-Device-Plugin-for-Kubernetes-Demo.cast -c 'sh $0 play'" 300
 }
 
 screen1()
@@ -104,5 +104,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast-dsa-accel-config.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi

--- a/demo/screencast-fpga-orchestrated.sh
+++ b/demo/screencast-fpga-orchestrated.sh
@@ -48,7 +48,7 @@ record()
 {
   clear
   out 'Record this screencast'
-  command "asciinema rec -t 'Intel FPGA Device Plugin for Kubernetes in orchestrated mode with $DRIVER kernel driver.'  Intel-FPGA-Device-Plugin-for-Kubernetes-orchestrated-$DRIVER-Demo.cast -c 'sh ./screencast-fpga-orchestrated.sh play'" 300
+  command "asciinema rec -t 'Intel FPGA Device Plugin for Kubernetes in orchestrated mode with $DRIVER kernel driver.'  Intel-FPGA-Device-Plugin-for-Kubernetes-orchestrated-$DRIVER-Demo.cast -c 'sh $0 play'" 300
 }
 
 screen1()
@@ -147,5 +147,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast-fpga-orchestrated.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi

--- a/demo/screencast-fpga-preprogrammed.sh
+++ b/demo/screencast-fpga-preprogrammed.sh
@@ -47,7 +47,7 @@ record()
 {
   clear
   out 'Record this screencast'
-  command "asciinema rec -t 'Intel FPGA Device Plugin for Kubernetes in preprogrammed mode with $DRIVER kernel driver.'  Intel-FPGA-Device-Plugin-for-Kubernetes-preprogrammed-$DRIVER-Demo.cast -c 'sh ./screencast-fpga-preprogrammed.sh play'" 300
+  command "asciinema rec -t 'Intel FPGA Device Plugin for Kubernetes in preprogrammed mode with $DRIVER kernel driver.'  Intel-FPGA-Device-Plugin-for-Kubernetes-preprogrammed-$DRIVER-Demo.cast -c 'sh $0 play'" 300
 }
 
 screen1()
@@ -125,5 +125,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast-fpga-preprogrammed.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi

--- a/demo/screencast-qat-dpdk.sh
+++ b/demo/screencast-qat-dpdk.sh
@@ -26,7 +26,7 @@
 {
   clear
   out 'Record this screencast'
-  command 'asciinema rec -t "Intel QAT Device Plugin for Kubernetes - Test Demo"  Intel-QAT-Device-Plugin-for-Kubernetes-Test-Demo.cast -c "sh ./qat-dp-demo.sh play"'
+  command "asciinema rec -t 'Intel QAT Device Plugin for Kubernetes - Test Demo'  Intel-QAT-Device-Plugin-for-Kubernetes-Test-Demo.cast -c 'sh $0 play'"
 }
  screen1()
 {
@@ -108,5 +108,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi

--- a/demo/screencast-qat.sh
+++ b/demo/screencast-qat.sh
@@ -41,7 +41,7 @@ record()
 {
   clear
   out 'Record this screencast'
-  command 'asciinema rec -t "Intel QAT Device Plugin for Kubernetes - Intel(R) QAT OpenSSL Engine Demo"  Intel-QAT-Device-Plugin-for-Kubernetes-OpenSSL-QAT-Engine-Demo.cast -c "sh ./screencast-qat.sh play"'
+  command "asciinema rec -t 'Intel QAT Device Plugin for Kubernetes - Intel(R) QAT OpenSSL Engine Demo'  Intel-QAT-Device-Plugin-for-Kubernetes-OpenSSL-QAT-Engine-Demo.cast -c 'sh $0 play'"
 }
 
 screen1()
@@ -180,5 +180,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi

--- a/demo/screencast-sgx.sh
+++ b/demo/screencast-sgx.sh
@@ -40,7 +40,7 @@ record()
 {
   clear
   out 'Record this screencast'
-  command 'asciinema rec -t "Intel SGX Device Plugin for Kubernetes - Intel(R) SGX DCAP ECDSA Quote Generation Demo"  Intel-SGX-Device-Plugin-for-Kubernetes-SGX-DCAP-ECDSA-Quote-Generation-Demo.cast -c "./screencast-sgx.sh play"'
+  command "asciinema rec -t 'Intel SGX Device Plugin for Kubernetes - Intel(R) SGX DCAP ECDSA Quote Generation Demo'  Intel-SGX-Device-Plugin-for-Kubernetes-SGX-DCAP-ECDSA-Quote-Generation-Demo.cast -c '$0 play'"
 }
 
 screen1()
@@ -147,5 +147,5 @@ elif [ "$1" == 'cleanup' ] ; then
 elif [ "$1" == 'record' ] ; then
   record
 else
-   echo 'Usage: screencast-sgx.sh [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]'
+   echo "Usage: $0 [--help|help|-h] | [play [<screen number>]] | [cleanup] | [record]"
 fi


### PR DESCRIPTION
This commit improves the screencast files by using the shell argument `$0` to represent the actual script filenames.

Closes: #964 