### PR TITLE
changes related to selinux and permissions for openshift

### DIFF
--- a/deployments/operator/rbac/role.yaml
+++ b/deployments/operator/rbac/role.yaml
@@ -245,3 +245,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  verbs:
+  - use

--- a/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
+++ b/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
@@ -17,6 +17,8 @@ spec:
       - name: intel-sgx-plugin
         image: intel/intel-sgx-plugin:devel
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         imagePullPolicy: IfNotPresent

--- a/pkg/controllers/sgx/controller.go
+++ b/pkg/controllers/sgx/controller.go
@@ -106,6 +106,9 @@ func setInitContainer(spec *v1.PodSpec, imageName string) {
 			ImagePullPolicy: "IfNotPresent",
 			Name:            "intel-sgx-initcontainer",
 			SecurityContext: &v1.SecurityContext{
+				SELinuxOptions: &v1.SELinuxOptions{
+					Type: "container_device_plugin_init_t",
+				},
 				ReadOnlyRootFilesystem: &yes,
 			},
 			VolumeMounts: []v1.VolumeMount{

--- a/pkg/controllers/sgx/controller_test.go
+++ b/pkg/controllers/sgx/controller_test.go
@@ -71,6 +71,9 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							Image:           devicePlugin.Spec.Image,
 							ImagePullPolicy: "IfNotPresent",
 							SecurityContext: &v1.SecurityContext{
+								SELinuxOptions: &v1.SELinuxOptions{
+									Type: "container_device_plugin_t",
+								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
 							},


### PR DESCRIPTION
* run the sgx container as container_device_plugin_t and init container
   as container_device_plugin_init_t. these labels are being added to
   container_selinux package upstream.
 * add rbac role for openshift

Signed-off-by: Manish Regmi <manish.regmi@intel.com>