### PR TITLE
Updated Readme.md to include the Red Hat OCP availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ device plugin has its own custom resource definition (CRD) and the corresponding
 watches CRUD operations to those custom resources.
 
 The [Device plugins operator README](cmd/operator/README.md) gives the installation and usage
-details. The operator is also available via [operatorhub.io](https://operatorhub.io/operator/intel-device-plugins-operator).
+details. The operator is also available via [operatorhub.io](https://operatorhub.io/operator/intel-device-plugins-operator) and on Red Hat OpenShift Container Platform.
 
 ## Demos
 


### PR DESCRIPTION
Will add the link to operator on Red Hat catalog once the operator is published. We are also thinking of adding another readme specifically for RedHat OpenShift Platform at location - cmd/operator/README-OCP.md.

 Signed-off-by: chaitanya1731 <chaitanya.kulkarni@intel.com>