### PR TITLE
qat: move initcontainer script to standard path

### DIFF
--- a/build/docker/intel-qat-initcontainer.Dockerfile
+++ b/build/docker/intel-qat-initcontainer.Dockerfile
@@ -53,6 +53,6 @@ LABEL description='Intel QAT initcontainer initializes devices'
 
 COPY --from=builder /install_root /
 
-ADD demo/qat-init.sh /qat-init/
+ADD demo/qat-init.sh /usr/local/bin/
 
-ENTRYPOINT /qat-init/qat-init.sh
+ENTRYPOINT /usr/local/bin/qat-init.sh


### PR DESCRIPTION
Our images use /usr/local/bin paths so let's follow
that with qat-initcontainer too.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>