### PR TITLE
Allow usage of pre-created licenses

### DIFF
--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=dlb_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/dlb_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/dlb_plugin /install_root/usr/local/bin/intel_dlb_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_dlb_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dlb_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=dsa_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/dsa_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/dsa_plugin /install_root/usr/local/bin/intel_dsa_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_dsa_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dsa_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=fpga_admissionwebhook
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_fpga_admissionwebhook \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_admissionwebhook" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=fpga_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_fpga_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -37,20 +37,26 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=gpu_nfdhook
 WORKDIR $DIR
 COPY . .
 
 ARG ROOT=/install_root
 
 # Build NFD Feature Detector Hook
-RUN cd cmd/gpu_nfdhook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
+RUN cd cmd/$CMD && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
     install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_nfdhook" --save_path $ROOT/licenses/go-licenses
+    if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 ARG NFD_HOOK=intel-gpu-nfdhook
 ARG SRC_DIR=/usr/local/bin/gpu-sw
 
-RUN install -D /go/bin/gpu_nfdhook $ROOT/$SRC_DIR/$NFD_HOOK
+RUN install -D /go/bin/$CMD $ROOT/$SRC_DIR/$NFD_HOOK
 
 ARG TOYBOX_VERSION="0.8.6"
 ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=gpu_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_gpu_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-iaa-plugin.Dockerfile
+++ b/build/docker/intel-iaa-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=iaa_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/iaa_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/iaa_plugin /install_root/usr/local/bin/intel_iaa_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_iaa_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/iaa_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -37,6 +37,9 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=qat_plugin
 WORKDIR $DIR
 COPY . .
 
@@ -51,11 +54,14 @@ RUN mkdir -p /usr/src/qat \
     && cd /usr/src/qat/quickassist/utilities/adf_ctl \
     && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
     && install -D adf_ctl /install_root/usr/local/bin/adf_ctl
-RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
-RUN chmod a+x /go/bin/qat_plugin \
-    && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
+RUN chmod a+x /go/bin/$CMD \
+    && install -D /go/bin/$CMD /install_root/usr/local/bin/intel_qat_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM debian:unstable-slim
 COPY --from=builder /install_root /

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=qat_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_qat_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=sgx_admissionwebhook
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/sgx_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sgx_admissionwebhook \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_sgx_admissionwebhook \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_admissionwebhook" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -37,13 +37,19 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=sgx_plugin
 WORKDIR $DIR
 COPY . .
 
-RUN cd cmd/sgx_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_sgx_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM ${FINAL_BASE}
 

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -37,6 +37,9 @@ FROM ${GOLANG_BASE} as builder
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG LOCAL_LICENSES
+ARG GOLICENSES_VERSION
+ARG CMD=vpu_plugin
 WORKDIR $DIR
 COPY . .
 
@@ -46,10 +49,13 @@ RUN mkdir -p /install_root/licenses/libusb \
     && cd /install_root/licenses/libusb \
     && apt-get --download-only source libusb-1.0-0 \
     && cd -
-RUN cd cmd/vpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/vpu_plugin /install_root/usr/local/bin/intel_vpu_device_plugin \
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/$CMD /install_root/usr/local/bin/intel_vpu_device_plugin \
     && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/vpu_plugin" --save_path /install_root/licenses/go-licenses
+    && if [ -z "$LOCAL_LICENSES" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/go-licenses ; \
+    else mkdir -p /install_root/licenses/go-licenses && cp -r licenses/$CMD/* /install_root/licenses/go-licenses ; fi
 
 FROM debian:unstable-slim
 RUN apt update && apt -y install libusb-1.0-0


### PR DESCRIPTION
For discussion, as a build optimization, allow usage of pre-created
licenses. Together with usage of go mod vendor, the container build
times are significantly shorter.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>