### PR TITLE
Dockerfilereuse

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Check Dockerfiles
+        run: make check-dockerfiles
       - name: Install build dependencies needed for VPU plugin
         run: |
           sudo apt-get update

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -186,6 +186,53 @@ $ make test
 
 and fix all new compilation issues.
 
+## How to build docker images
+
+The dockerfiles are generated on the fly from `.in` suffixed files and `.docker` include-snippets which are stitched together with
+cpp preprocessor. You need to install cpp for that, e.g. in ubuntu it is found from build-essential (sudo apt install build-essential).
+Don't edit the generated dockerfiles. Edit the inputs.
+
+The simplest way to build all the docker images, is:
+```
+$ make images
+```
+
+But it is very slow. You can drastically speed it up by first running once:
+```
+$ make vendor
+```
+
+Which brings the libraries into the builder container without downloading them again and again for each plugin.
+
+But it is still slow. You can further speed it up by first running once:
+```
+$ make licenses
+```
+
+Which pre-creates the go-licenses for all plugins, instead of re-creating them for each built plugin, every time.
+
+But it is still rather slow to build all the images, and unnecessary, if you iterate on just one. Instead, build just the one you are iterating on, example:
+
+```
+$ make intel-gpu-plugin
+```
+
+If you iterate on only one plugin and if you know what its target cmd is (see folder `cmd/`), you can opt to pre-create just its licenses, example:
+```
+$ make licenses/gpu_plugin
+```
+
+The docker image target names in the Makefile are derived from the `.Dockerfile.in` suffixed filenames under folder `build/docker/templates/`.
+
+Recap:
+```
+$ make vendor
+$ make licenses (or just make licenses/gpu_plugin)
+$ make intel-gpu-plugin
+```
+
+Repeat the last step only, unless you change library dependencies. If you pull in new sources, start again from `make vendor`.
+
 ## How to work with Intel Device Plugins operator modifications
 
 There are few useful steps when working with changes to Device Plugins CRDs and controllers:

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-deviceplugin-operator.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=operator
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_deviceplugin_operator
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/operator; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/operator /install_root/usr/local/bin/intel_deviceplugin_operator \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/operator" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-deviceplugin-operator'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_deviceplugin_operator"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-deviceplugin-operator'
 LABEL summary='Intel® device plugin operator for Kubernetes'
 LABEL description='To simplify the deployment of the device plugins, a unified device plugins operator is implemented. Currently the operator has support for the QAT, GPU, FPGA, SGX, DSA and DLB device plugins. Each device plugin has its own custom resource definition (CRD) and the corresponding controller that watches CRUD operations to those custom resources.'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_deviceplugin_operator"]

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -1,59 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-dlb-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=dlb_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_dlb_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/dlb_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/dlb_plugin /install_root/usr/local/bin/intel_dlb_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dlb_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-dlb-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_dlb_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-dlb-plugin'
 LABEL summary='Intel® DLB device plugin for Kubernetes'
 LABEL description='The DLB device plugin supports Intel Dynamic Load Balancer accelerator(DLB)'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_dlb_device_plugin"]
-

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-dsa-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=dsa_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_dsa_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/dsa_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/dsa_plugin /install_root/usr/local/bin/intel_dsa_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/dsa_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-dsa-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_dsa_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-dsa-plugin'
 LABEL summary='Intel® DSA device plugin for Kubernetes'
 LABEL description='The DSA device plugin supports acceleration using the Intel Data Streaming accelerator(DSA)'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_dsa_device_plugin"]

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-fpga-admissionwebhook.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=fpga_admissionwebhook
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_fpga_admissionwebhook
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/fpga_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/fpga_admissionwebhook /install_root/usr/local/bin/intel_fpga_admissionwebhook \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_admissionwebhook" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-fpga-admissionwebhook'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_fpga_admissionwebhook"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-fpga-admissionwebhook'
 LABEL summary='Intel® FPGA admission controller webhook for Kubernetes'
 LABEL description='The FPGA admission controller webhook is responsible for performing mapping from user-friendly function IDs to the Interface ID and Bitstream ID that are required for FPGA programming. It also implements access control by namespacing FPGA configuration information'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_fpga_admissionwebhook"]

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -1,69 +1,80 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-fpga-initcontainer.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG CRI_HOOK=intel-fpga-crihook
+ARG CMD=fpga_crihook
+ARG EP=/usr/local/fpga-sw/$CRI_HOOK
+WORKDIR ${DIR}
 COPY . .
-
-ARG ROOT=/install_root
-
-RUN cd cmd/fpga_crihook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && \
-    cd ../fpga_tool && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && \
-    cd ../.. && \
-    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_crihook" --save_path $ROOT/licenses/fpga_crihook && \
-    go-licenses save "./cmd/fpga_tool" --save_path $ROOT/licenses/go-licenses/fpga_tool
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
+ARG CMD=fpga_tool
+ARG EP=/usr/local/fpga-sw/$CMD
+WORKDIR ${DIR}
+COPY . .
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 ARG SRC_DIR=/usr/local/fpga-sw
 ARG DST_DIR=/opt/intel/fpga-sw
-ARG CRI_HOOK=intel-fpga-crihook
-
-RUN install -D /go/bin/fpga_crihook $ROOT/$SRC_DIR/$CRI_HOOK
-RUN install -D /go/bin/fpga_tool $ROOT/$SRC_DIR/
-
 RUN echo "{\n\
     \"hook\" : \"$DST_DIR/$CRI_HOOK\",\n\
     \"stage\" : [ \"prestart\" ],\n\
     \"annotation\": [ \"fpga.intel.com/region\" ]\n\
-}\n">>$ROOT/$SRC_DIR/$CRI_HOOK.json
-
+}\n">>/install_root/$SRC_DIR/$CRI_HOOK.json
 ARG TOYBOX_VERSION="0.8.6"
 ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"
+ARG ROOT=/install_root
 RUN apt update && apt -y install musl musl-tools musl-dev
 RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
     && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
@@ -73,16 +84,13 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
-
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-fpga-initcontainer'
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-fpga-initcontainer'
 LABEL summary='Intel® FPGA programming CRI hook for Kubernetes'
 LABEL description='The FPGA prestart CRI-O hook performs discovery of the requested FPGA function bitstream and programs FPGA devices based on the environment variables in the workload description'
-
 COPY --from=builder /install_root /
-
 ENTRYPOINT [ "/bin/sh", "-c", "cp -a /usr/local/fpga-sw/* /opt/intel/fpga-sw/ && ln -sf /opt/intel/fpga-sw/intel-fpga-crihook.json /etc/containers/oci/hooks.d/" ]

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-fpga-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=fpga_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_fpga_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/fpga_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/fpga_plugin /install_root/usr/local/bin/intel_fpga_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/fpga_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-fpga-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_fpga_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-fpga-plugin'
 LABEL summary='Intel® FPGA device plugin for Kubernetes'
 LABEL description='The FPGA device plugin is responsible for discovering and reporting FPGA devices to kubelet'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_fpga_device_plugin"]

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -1,60 +1,62 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-gpu-initcontainer.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
-COPY . .
-
-ARG ROOT=/install_root
-
-# Build NFD Feature Detector Hook
-RUN cd cmd/gpu_nfdhook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
-    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_nfdhook" --save_path $ROOT/licenses/go-licenses
-
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/gpu-sw/intel-gpu-nfdhook
+ARG CMD=gpu_nfdhook
 ARG NFD_HOOK=intel-gpu-nfdhook
 ARG SRC_DIR=/usr/local/bin/gpu-sw
-
-RUN install -D /go/bin/gpu_nfdhook $ROOT/$SRC_DIR/$NFD_HOOK
-
+WORKDIR ${DIR}
+COPY . .
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 ARG TOYBOX_VERSION="0.8.6"
 ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"
-
+ARG ROOT=/install_root
 RUN apt update && apt -y install musl musl-tools musl-dev
 RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
     && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
@@ -64,16 +66,13 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
-
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-gpu-initcontainer'
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-gpu-initcontainer'
 LABEL summary='Intel® GPU NFD hook for Kubernetes'
 LABEL description='The GPU fractional resources, such as GPU memory is registered as a kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of GPU device plugin operator deployment and NFD is configured to register the GPU memory extended resource reported by the hook'
-
 COPY --from=builder /install_root /
-
 ENTRYPOINT [ "/bin/sh", "-c", "cp -a /usr/local/bin/gpu-sw/intel-gpu-nfdhook /etc/kubernetes/node-feature-discovery/source.d/" ]

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-gpu-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=gpu_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_gpu_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/gpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/gpu_plugin /install_root/usr/local/bin/intel_gpu_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/gpu_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-gpu-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_gpu_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-gpu-plugin'
 LABEL summary='Intel® GPU device plugin for Kubernetes'
 LABEL description='The GPU device plugin provides access to Intel discrete (Xe) and integrated GPU HW device files'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_gpu_device_plugin"]

--- a/build/docker/intel-iaa-plugin.Dockerfile
+++ b/build/docker/intel-iaa-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2022 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-iaa-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=iaa_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_iaa_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/iaa_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/iaa_plugin /install_root/usr/local/bin/intel_iaa_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/iaa_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-iaa-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_iaa_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-iaa-plugin'
 LABEL summary='Intel® IAA device plugin for Kubernetes'
 LABEL description='The IAA device plugin supports acceleration using the Intel Analytics accelerator(IAA)'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_iaa_device_plugin"]

--- a/build/docker/intel-idxd-config-initcontainer.Dockerfile
+++ b/build/docker/intel-idxd-config-initcontainer.Dockerfile
@@ -1,67 +1,36 @@
-# Copyright 2021-2022 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
-# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
-ARG FINAL_BASE
-
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
 FROM debian:unstable-slim AS builder
-
-RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \
-        /etc/apt/sources.list.d/deb-src.list && \
-    apt update && apt install -y --no-install-recommends \
-        gcc make patch autoconf automake libtool pkg-config \
-        libjson-c-dev uuid-dev curl ca-certificates
-
+RUN echo "deb-src http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list.d/deb-src.list && apt update && apt install -y --no-install-recommends gcc make patch autoconf automake libtool pkg-config libjson-c-dev uuid-dev curl ca-certificates
 ARG ACCEL_CONFIG_VERSION="3.4.6.3"
 ARG ACCEL_CONFIG_DOWNLOAD_URL="https://github.com/intel/idxd-config/archive/accel-config-v$ACCEL_CONFIG_VERSION.tar.gz"
 ARG ACCEL_CONFIG_SHA256="a28f531dd69bdc83ca2ad23cacd079530510e98b726421c6d07e24c8426d086e"
-
-RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && \
-    echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && \
-    tar -xzf accel-config.tar.gz
-
-RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && \
-    ./git-version-gen && \
-    autoreconf -i && \
-    ./configure -q --libdir=/usr/lib64 --disable-test --disable-docs && \
-    make && \
-    make install
-
+RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && tar -xzf accel-config.tar.gz
+RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && ./git-version-gen && autoreconf -i && ./configure -q --libdir=/usr/lib64 --disable-test --disable-docs && make && make install
+###
 FROM debian:unstable-slim
-
 RUN apt update && apt install -y libjson-c5 jq
-
-COPY --from=builder /usr/lib64/libaccel-config.so.1.0.0 /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib64/libaccel-config.so.1.0.0 "/lib/x86_64-linux-gnu/"
 RUN ldconfig && mkdir -p /licenses/accel-config
-
 COPY --from=builder /usr/bin/accel-config /usr/bin/
 COPY --from=builder /accel-config.tar.gz /licenses/accel-config/
-
 ADD demo/idxd-init.sh /usr/local/bin/
 ADD demo/dsa.conf /idxd-init/
 ADD demo/iaa.conf /idxd-init/
-
 RUN mkdir /idxd-init/scratch
-
 WORKDIR /idxd-init
 ENTRYPOINT bash /usr/local/bin/idxd-init.sh

--- a/build/docker/intel-qat-initcontainer.Dockerfile
+++ b/build/docker/intel-qat-initcontainer.Dockerfile
@@ -1,37 +1,47 @@
-# Copyright 2022 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-qat-initcontainer.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 WORKDIR $DIR
 COPY . .
-
-ARG ROOT=/install_root
 ARG TOYBOX_VERSION="0.8.6"
 ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"
+ARG ROOT=/install_root
 RUN apt update && apt -y install musl musl-tools musl-dev
 RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
     && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
@@ -41,18 +51,14 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
-
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-qat-initcontainer'
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-qat-initcontainer'
 LABEL summary='Intel® QAT initcontainer for Kubernetes'
 LABEL description='Intel QAT initcontainer initializes devices'
-
 COPY --from=builder /install_root /
-
 ADD demo/qat-init.sh /usr/local/bin/
-
 ENTRYPOINT /usr/local/bin/qat-init.sh

--- a/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
+++ b/build/docker/intel-qat-plugin-kerneldrv.Dockerfile
@@ -1,63 +1,65 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-qat-plugin-kerneldrv.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
-# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
-ARG FINAL_BASE
-
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_sgx_device_plugin
+ARG CMD=qat_plugin
 WORKDIR $DIR
 COPY . .
-
 ARG QAT_DRIVER_RELEASE="qat1.7.l.4.14.0-00031"
 ARG QAT_DRIVER_SHA256="a68dfaea4308e0bb5f350b7528f1a076a0c6ba3ec577d60d99dc42c49307b76e"
-
-RUN mkdir -p /usr/src/qat \
-    && cd /usr/src/qat  \
-    && wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz \
-    && echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c - \
-    && tar xf *.tar.gz \
-    && cd /usr/src/qat/quickassist/utilities/adf_ctl \
-    && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
-    && install -D adf_ctl /install_root/usr/local/bin/adf_ctl
-RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
-RUN chmod a+x /go/bin/qat_plugin \
-    && install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN mkdir -p /usr/src/qat && cd /usr/src/qat && wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz     && echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c -     && tar xf *.tar.gz     && cd /usr/src/qat/quickassist/utilities/adf_ctl     && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat     && install -D adf_ctl /install_root/usr/local/bin/adf_ctl
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
+RUN chmod a+x /go/bin/$CMD && install -D /go/bin/$CMD /install_root/usr/local/bin/intel_qat_device_plugin
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
 FROM debian:unstable-slim
+LABEL vendor='Intel®'
+LABEL version='devel'
+LABEL release='1'
+LABEL name='intel-qat-plugin-kerneldrv'
+LABEL summary='Intel® QAT device plugin kerneldrv for Kubernetes'
 COPY --from=builder /install_root /
 ENV PATH=/usr/local/bin
 ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-qat-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=qat_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_qat_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/qat_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/qat_plugin /install_root/usr/local/bin/intel_qat_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/qat_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-qat-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-qat-plugin'
 LABEL summary='Intel® QAT device plugin for Kubernetes'
 LABEL description='The QAT plugin supports device plugin for Intel QAT adapters, and includes code showing deployment via DPDK'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-sgx-admissionwebhook.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=sgx_admissionwebhook
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_sgx_admissionwebhook
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/sgx_admissionwebhook; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/sgx_admissionwebhook /install_root/usr/local/bin/intel_sgx_admissionwebhook \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_admissionwebhook" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-sgx-admissionwebhook'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_sgx_admissionwebhook"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-sgx-admissionwebhook'
 LABEL summary='Intel® SGX admission controller webhook for Kubernetes'
 LABEL description='The SGX admission webhook is responsible for performing Pod mutations based on the sgx.intel.com/quote-provider pod annotation set by the user. The purpose of the webhook is to hide the details of setting the necessary device resources and volume mounts for using SGX remote attestation in the cluster'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_sgx_admissionwebhook"]

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -1,60 +1,62 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-sgx-initcontainer.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
-COPY . .
-
-ARG ROOT=/install_root
-
-# Build NFD Feature Detector Hook
-RUN cd cmd/sgx_epchook && GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}" && cd -\
-    install -D ${DIR}/LICENSE $ROOT/licenses/intel-device-plugins-for-kubernetes/LICENSE && \
-    GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_epchook" --save_path $ROOT/licenses/go-licenses
-
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/sgx-sw/intel-sgx-epchook
+ARG CMD=sgx_epchook
 ARG NFD_HOOK=intel-sgx-epchook
 ARG SRC_DIR=/usr/local/bin/sgx-sw
-
-RUN install -D /go/bin/sgx_epchook $ROOT/$SRC_DIR/$NFD_HOOK
-
+WORKDIR ${DIR}
+COPY . .
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 ARG TOYBOX_VERSION="0.8.6"
 ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"
-
+ARG ROOT=/install_root
 RUN apt update && apt -y install musl musl-tools musl-dev
 RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \
     && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \
@@ -64,16 +66,13 @@ RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION
     && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \
     && install -D LICENSE $ROOT/licenses/toybox \
     && cp -r /usr/share/doc/musl $ROOT/licenses/
-
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-sgx-initcontainer'
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-sgx-initcontainer'
 LABEL summary='Intel® SGX NFD hook for Kubernetes'
 LABEL description='The SGX EPC memory available on each node is registered as a Kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of SGX device plugin operator deployment and NFD is configured to register the SGX EPC memory extended resource reported by the hook'
-
 COPY --from=builder /install_root /
-
 ENTRYPOINT [ "/bin/sh", "-c", "cp -a /usr/local/bin/sgx-sw/intel-sgx-epchook /etc/kubernetes/node-feature-discovery/source.d/" ]

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -1,58 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
-ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
-# The RedHat build tool does not allow additional image build parameters.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-sgx-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+ARG CMD=sgx_plugin
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
 ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
-
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
-WORKDIR $DIR
+ARG GOLICENSES_VERSION
+ARG EP=/usr/local/bin/intel_sgx_device_plugin
+ARG CMD
+WORKDIR ${DIR}
 COPY . .
-
-RUN cd cmd/sgx_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/sgx_plugin /install_root/usr/local/bin/intel_sgx_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/sgx_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \
+    && install -D /go/bin/${CMD} /install_root${EP}
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
+###
 FROM ${FINAL_BASE}
-
-LABEL name='intel-sgx-plugin'
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_sgx_device_plugin"]
 LABEL vendor='Intel®'
 LABEL version='devel'
 LABEL release='1'
+LABEL name='intel-sgx-plugin'
 LABEL summary='Intel® SGX device plugin for Kubernetes'
 LABEL description='The SGX device plugin is responsible for discovering and reporting SGX device nodes to kubelet'
-
-COPY --from=builder /install_root /
-ENTRYPOINT ["/usr/local/bin/intel_sgx_device_plugin"]

--- a/build/docker/intel-vpu-plugin.Dockerfile
+++ b/build/docker/intel-vpu-plugin.Dockerfile
@@ -1,57 +1,64 @@
-# Copyright 2021 Intel Corporation. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# GOLANG_BASE can be used to make the build reproducible by choosing an
-# image by its hash:
-# GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
-#
-# This is used on release branches before tagging a stable version.
-# The main branch defaults to using the latest Golang base image.
+## This is a generated file, do not edit directly. Edit build/docker/templates/intel-vpu-plugin.Dockerfile.in instead.
+##
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+###
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
 ARG GOLANG_BASE=golang:1.18-bullseye
-
-# FINAL_BASE can be used to configure the base image of the final image.
-#
-# This is used in two ways:
-# 1) make <image-name> BUILDER=<docker|buildah>
-# 2) docker build ... -f <image-name>.Dockerfile
-#
-# The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
-# (see build-image.sh).
-# Declaring FINAL_BASE ARG but not setting the value to resolve build warning:
-# "[Warning] one or more build args were not consumed: [FINAL_BASE]"
-ARG FINAL_BASE
-
+###
 FROM ${GOLANG_BASE} as builder
-
 ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG BUILDFLAGS="-ldflags=-w -s"
+ARG GOLICENSES_VERSION
+ARG CMD=vpu_plugin
 WORKDIR $DIR
 COPY . .
-
 RUN echo "deb-src http://deb.debian.org/debian unstable main" | tee -a /etc/apt/sources.list
 RUN apt update && apt -y install dpkg-dev libusb-1.0-0-dev
-RUN mkdir -p /install_root/licenses/libusb \
-    && cd /install_root/licenses/libusb \
-    && apt-get --download-only source libusb-1.0-0 \
-    && cd -
-RUN cd cmd/vpu_plugin; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
-RUN install -D /go/bin/vpu_plugin /install_root/usr/local/bin/intel_vpu_device_plugin \
-    && install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
-    && GO111MODULE=on go install github.com/google/go-licenses@v1.0.0 && go-licenses save "./cmd/vpu_plugin" --save_path /install_root/licenses/go-licenses
-
+RUN mkdir -p /install_root/licenses/libusb && cd /install_root/licenses/libusb && apt-get --download-only source libusb-1.0-0 && cd -
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/vpu_plugin /install_root/usr/local/bin/intel_vpu_device_plugin
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \
+    && if [ ! -d "licenses/$CMD" ] ; then \
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \
+    --save_path /install_root/licenses/$CMD/go-licenses ; \
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi
 FROM debian:unstable-slim
+LABEL vendor='Intel®'
+LABEL version='devel'
+LABEL release='1'
+LABEL name='intel-vpu-plugin'
+LABEL summary='Intel® VPU device plugin for Kubernetes'
 RUN apt update && apt -y install libusb-1.0-0
 COPY --from=builder /install_root /
 ENTRYPOINT ["/usr/local/bin/intel_vpu_device_plugin"]

--- a/build/docker/lib/default_args.docker
+++ b/build/docker/lib/default_args.docker
@@ -1,0 +1,4 @@
+ARG DIR=/intel-device-plugins-for-kubernetes
+ARG GO111MODULE=on
+ARG BUILDFLAGS="-ldflags=-w -s"
+ARG GOLICENSES_VERSION

--- a/build/docker/lib/default_build.docker
+++ b/build/docker/lib/default_build.docker
@@ -1,0 +1,9 @@
+WORKDIR ${DIR}
+COPY . .
+
+RUN cd cmd/${CMD}; GO111MODULE=${GO111MODULE} CGO_ENABLED=0 go install "${BUILDFLAGS}"; cd - \N
+    && install -D /go/bin/${CMD} /install_root${EP}
+
+#include "default_licenses.docker"
+
+###

--- a/build/docker/lib/default_end.docker
+++ b/build/docker/lib/default_end.docker
@@ -1,0 +1,5 @@
+#define expandedString(s) string(s)
+#define string(s) #s
+
+COPY --from=builder /install_root /
+ENTRYPOINT [expandedString(_ENTRYPOINT_)]

--- a/build/docker/lib/default_header.docker
+++ b/build/docker/lib/default_header.docker
@@ -1,0 +1,3 @@
+## This is a generated file, do not edit directly. Edit INPUT_FILENAME instead.
+##
+#include "license.docker"

--- a/build/docker/lib/default_labels.docker
+++ b/build/docker/lib/default_labels.docker
@@ -1,0 +1,3 @@
+LABEL vendor='Intel®'
+LABEL version='devel'
+LABEL release='1'

--- a/build/docker/lib/default_licenses.docker
+++ b/build/docker/lib/default_licenses.docker
@@ -1,0 +1,5 @@
+RUN install -D ${DIR}/LICENSE /install_root/licenses/intel-device-plugins-for-kubernetes/LICENSE \N
+    && if [ ! -d "licenses/$CMD" ] ; then \N
+    GO111MODULE=on go run github.com/google/go-licenses@${GOLICENSES_VERSION} save "./cmd/$CMD" \N
+    --save_path /install_root/licenses/$CMD/go-licenses ; \N
+    else mkdir -p /install_root/licenses/$CMD/go-licenses/ && cd licenses/$CMD && cp -r * /install_root/licenses/$CMD/go-licenses/ ; fi

--- a/build/docker/lib/default_plugin.docker
+++ b/build/docker/lib/default_plugin.docker
@@ -1,0 +1,17 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+
+ARG EP=_ENTRYPOINT_
+ARG CMD
+
+#include "default_build.docker"
+
+FROM ${FINAL_BASE}
+
+#include "default_end.docker"
+
+#include "default_labels.docker"

--- a/build/docker/lib/final_base.docker
+++ b/build/docker/lib/final_base.docker
@@ -1,0 +1,12 @@
+## FINAL_BASE can be used to configure the base image of the final image.
+##
+## This is used in two ways:
+## 1) make <image-name> BUILDER=<docker|buildah>
+## 2) docker build ... -f <image-name>.Dockerfile
+##
+## The project default is 1) which sets FINAL_BASE=gcr.io/distroless/static
+## (see build-image.sh).
+## 2) and the default FINAL_BASE is primarily used to build Redhat Certified Openshift Operator container images that must be UBI based.
+## The RedHat build tool does not allow additional image build parameters.
+ARG FINAL_BASE=registry.access.redhat.com/ubi8-micro
+###

--- a/build/docker/lib/golang_base.docker
+++ b/build/docker/lib/golang_base.docker
@@ -1,0 +1,9 @@
+##
+## GOLANG_BASE can be used to make the build reproducible by choosing an
+## image by its hash:
+## GOLANG_BASE=golang@sha256:9d64369fd3c633df71d7465d67d43f63bb31192193e671742fa1c26ebc3a6210
+##
+## This is used on release branches before tagging a stable version.
+## The main branch defaults to using the latest Golang base image.
+ARG GOLANG_BASE=golang:1.18-bullseye
+###

--- a/build/docker/lib/license.docker
+++ b/build/docker/lib/license.docker
@@ -1,0 +1,14 @@
+## Copyright 2022 Intel Corporation. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+###

--- a/build/docker/lib/nfdhook_build.docker
+++ b/build/docker/lib/nfdhook_build.docker
@@ -1,0 +1,2 @@
+#include "default_build.docker"
+#include "toybox_build.docker"

--- a/build/docker/lib/nfdhook_end.docker
+++ b/build/docker/lib/nfdhook_end.docker
@@ -1,0 +1,6 @@
+#define xstring(s) xxstring(s)
+#define xxstring(SRC) string(cp -a SRC /etc/kubernetes/node-feature-discovery/source.d/)
+#define string(s) #s
+
+COPY --from=builder /install_root /
+ENTRYPOINT [ "/bin/sh", "-c", xstring(_ENTRYPOINT_) ]

--- a/build/docker/lib/toybox_build.docker
+++ b/build/docker/lib/toybox_build.docker
@@ -1,0 +1,15 @@
+ARG TOYBOX_VERSION="0.8.6"
+ARG TOYBOX_SHA256="e2c4f72a158581a12f4303d0d1aeec196b01f293e495e535bcdaf75eb9ae0987"
+
+ARG ROOT=/install_root
+
+RUN apt update && apt -y install musl musl-tools musl-dev
+RUN curl -SL https://github.com/landley/toybox/archive/refs/tags/$TOYBOX_VERSION.tar.gz -o toybox.tar.gz \N
+    && echo "$TOYBOX_SHA256 toybox.tar.gz" | sha256sum -c - \N
+    && tar -xzf toybox.tar.gz \N
+    && rm toybox.tar.gz \N
+    && cd toybox-$TOYBOX_VERSION \N
+    && KCONFIG_CONFIG=${DIR}/build/docker/toybox-config LDFLAGS="--static" CC=musl-gcc PREFIX=$ROOT V=2 make toybox install \N
+    && install -D LICENSE $ROOT/licenses/toybox \N
+    && cp -r /usr/share/doc/musl $ROOT/licenses/
+###

--- a/build/docker/templates/intel-deviceplugin-operator.Dockerfile.in
+++ b/build/docker/templates/intel-deviceplugin-operator.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_deviceplugin_operator
+ARG CMD=operator
+
+#include "default_plugin.docker"
+
+LABEL name='intel-deviceplugin-operator'
+LABEL summary='Intel® device plugin operator for Kubernetes'
+LABEL description='To simplify the deployment of the device plugins, a unified device plugins operator is implemented. Currently the operator has support for the QAT, GPU, FPGA, SGX, DSA and DLB device plugins. Each device plugin has its own custom resource definition (CRD) and the corresponding controller that watches CRUD operations to those custom resources.'

--- a/build/docker/templates/intel-dlb-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-dlb-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_dlb_device_plugin
+ARG CMD=dlb_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-dlb-plugin'
+LABEL summary='Intel® DLB device plugin for Kubernetes'
+LABEL description='The DLB device plugin supports Intel Dynamic Load Balancer accelerator(DLB)'

--- a/build/docker/templates/intel-dsa-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-dsa-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_dsa_device_plugin
+ARG CMD=dsa_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-dsa-plugin'
+LABEL summary='Intel® DSA device plugin for Kubernetes'
+LABEL description='The DSA device plugin supports acceleration using the Intel Data Streaming accelerator(DSA)'

--- a/build/docker/templates/intel-fpga-admissionwebhook.Dockerfile.in
+++ b/build/docker/templates/intel-fpga-admissionwebhook.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_fpga_admissionwebhook
+ARG CMD=fpga_admissionwebhook
+
+#include "default_plugin.docker"
+
+LABEL name='intel-fpga-admissionwebhook'
+LABEL summary='Intel® FPGA admission controller webhook for Kubernetes'
+LABEL description='The FPGA admission controller webhook is responsible for performing mapping from user-friendly function IDs to the Interface ID and Bitstream ID that are required for FPGA programming. It also implements access control by namespacing FPGA configuration information'

--- a/build/docker/templates/intel-fpga-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-fpga-initcontainer.Dockerfile.in
@@ -1,0 +1,39 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+ARG CRI_HOOK=intel-fpga-crihook
+
+ARG CMD=fpga_crihook
+ARG EP=/usr/local/fpga-sw/$CRI_HOOK
+#include "default_build.docker"
+
+ARG CMD=fpga_tool
+ARG EP=/usr/local/fpga-sw/$CMD
+#include "default_build.docker"
+
+ARG SRC_DIR=/usr/local/fpga-sw
+ARG DST_DIR=/opt/intel/fpga-sw
+
+RUN echo "{\n\N
+    \"hook\" : \"$DST_DIR/$CRI_HOOK\",\n\N
+    \"stage\" : [ \"prestart\" ],\n\N
+    \"annotation\": [ \"fpga.intel.com/region\" ]\n\N
+}\n">>/install_root/$SRC_DIR/$CRI_HOOK.json
+
+#include "toybox_build.docker"
+
+FROM ${FINAL_BASE}
+
+#include "default_labels.docker"
+
+LABEL name='intel-fpga-initcontainer'
+LABEL summary='Intel® FPGA programming CRI hook for Kubernetes'
+LABEL description='The FPGA prestart CRI-O hook performs discovery of the requested FPGA function bitstream and programs FPGA devices based on the environment variables in the workload description'
+
+COPY --from=builder /install_root /
+
+ENTRYPOINT [ "/bin/sh", "-c", "cp -a /usr/local/fpga-sw/* /opt/intel/fpga-sw/ && ln -sf /opt/intel/fpga-sw/intel-fpga-crihook.json /etc/containers/oci/hooks.d/" ]
+

--- a/build/docker/templates/intel-fpga-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-fpga-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_fpga_device_plugin
+ARG CMD=fpga_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-fpga-plugin'
+LABEL summary='Intel® FPGA device plugin for Kubernetes'
+LABEL description='The FPGA device plugin is responsible for discovering and reporting FPGA devices to kubelet'

--- a/build/docker/templates/intel-gpu-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-gpu-initcontainer.Dockerfile.in
@@ -1,0 +1,24 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+
+#define _ENTRYPOINT_ /usr/local/bin/gpu-sw/intel-gpu-nfdhook
+ARG EP=_ENTRYPOINT_
+ARG CMD=gpu_nfdhook
+ARG NFD_HOOK=intel-gpu-nfdhook
+ARG SRC_DIR=/usr/local/bin/gpu-sw
+
+#include "nfdhook_build.docker"
+
+FROM ${FINAL_BASE}
+
+#include "default_labels.docker"
+
+LABEL name='intel-gpu-initcontainer'
+LABEL summary='Intel® GPU NFD hook for Kubernetes'
+LABEL description='The GPU fractional resources, such as GPU memory is registered as a kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of GPU device plugin operator deployment and NFD is configured to register the GPU memory extended resource reported by the hook'
+
+#include "nfdhook_end.docker"

--- a/build/docker/templates/intel-gpu-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-gpu-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_gpu_device_plugin
+ARG CMD=gpu_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-gpu-plugin'
+LABEL summary='Intel® GPU device plugin for Kubernetes'
+LABEL description='The GPU device plugin provides access to Intel discrete (Xe) and integrated GPU HW device files'

--- a/build/docker/templates/intel-iaa-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-iaa-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_iaa_device_plugin
+ARG CMD=iaa_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-iaa-plugin'
+LABEL summary='Intel® IAA device plugin for Kubernetes'
+LABEL description='The IAA device plugin supports acceleration using the Intel Analytics accelerator(IAA)'

--- a/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
@@ -1,0 +1,41 @@
+FROM debian:unstable-slim AS builder
+
+RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \
+        /etc/apt/sources.list.d/deb-src.list && \
+    apt update && apt install -y --no-install-recommends \
+        gcc make patch autoconf automake libtool pkg-config \
+        libjson-c-dev uuid-dev curl ca-certificates
+
+ARG ACCEL_CONFIG_VERSION="3.4.6.3"
+ARG ACCEL_CONFIG_DOWNLOAD_URL="https://github.com/intel/idxd-config/archive/accel-config-v$ACCEL_CONFIG_VERSION.tar.gz"
+ARG ACCEL_CONFIG_SHA256="a28f531dd69bdc83ca2ad23cacd079530510e98b726421c6d07e24c8426d086e"
+
+RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && \
+    echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && \
+    tar -xzf accel-config.tar.gz
+
+RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && \
+    ./git-version-gen && \
+    autoreconf -i && \
+    ./configure -q --libdir=/usr/lib64 --disable-test --disable-docs && \
+    make && \
+    make install
+###
+FROM debian:unstable-slim
+
+RUN apt update && apt install -y libjson-c5 jq
+
+COPY --from=builder /usr/lib64/libaccel-config.so.1.0.0 "/lib/x86_64-linux-gnu/"
+RUN ldconfig && mkdir -p /licenses/accel-config
+
+COPY --from=builder /usr/bin/accel-config /usr/bin/
+COPY --from=builder /accel-config.tar.gz /licenses/accel-config/
+
+ADD demo/idxd-init.sh /usr/local/bin/
+ADD demo/dsa.conf /idxd-init/
+ADD demo/iaa.conf /idxd-init/
+
+RUN mkdir /idxd-init/scratch
+
+WORKDIR /idxd-init
+ENTRYPOINT bash /usr/local/bin/idxd-init.sh

--- a/build/docker/templates/intel-qat-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-qat-initcontainer.Dockerfile.in
@@ -1,0 +1,24 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+ARG DIR=/intel-device-plugins-for-kubernetes
+WORKDIR $DIR
+COPY . .
+
+#include "toybox_build.docker"
+
+FROM ${FINAL_BASE}
+
+#include "default_labels.docker"
+
+LABEL name='intel-qat-initcontainer'
+LABEL summary='Intel® QAT initcontainer for Kubernetes'
+LABEL description='Intel QAT initcontainer initializes devices'
+
+COPY --from=builder /install_root /
+
+ADD demo/qat-init.sh /usr/local/bin/
+
+ENTRYPOINT /usr/local/bin/qat-init.sh

--- a/build/docker/templates/intel-qat-plugin-kerneldrv.Dockerfile.in
+++ b/build/docker/templates/intel-qat-plugin-kerneldrv.Dockerfile.in
@@ -1,0 +1,42 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+
+#define _ENTRYPOINT_ /usr/local/bin/intel_sgx_device_plugin
+ARG EP=_ENTRYPOINT_
+ARG CMD=qat_plugin
+
+WORKDIR $DIR
+COPY . .
+
+ARG QAT_DRIVER_RELEASE="qat1.7.l.4.14.0-00031"
+ARG QAT_DRIVER_SHA256="a68dfaea4308e0bb5f350b7528f1a076a0c6ba3ec577d60d99dc42c49307b76e"
+
+RUN mkdir -p /usr/src/qat \
+    && cd /usr/src/qat  \
+    && wget https://downloadmirror.intel.com/30178/eng/$QAT_DRIVER_RELEASE.tar.gz \
+    && echo "$QAT_DRIVER_SHA256 $QAT_DRIVER_RELEASE.tar.gz" | sha256sum -c - \
+    && tar xf *.tar.gz \
+    && cd /usr/src/qat/quickassist/utilities/adf_ctl \
+    && make KERNEL_SOURCE_DIR=/usr/src/qat/quickassist/qat \
+    && install -D adf_ctl /install_root/usr/local/bin/adf_ctl
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install -tags kerneldrv; cd -
+RUN chmod a+x /go/bin/$CMD \
+    && install -D /go/bin/$CMD /install_root/usr/local/bin/intel_qat_device_plugin
+
+#include "default_licenses.docker"    
+
+
+FROM debian:unstable-slim
+
+#include "default_labels.docker"
+
+LABEL name='intel-qat-plugin-kerneldrv'
+LABEL summary='Intel® QAT device plugin kerneldrv for Kubernetes'
+
+COPY --from=builder /install_root /
+ENV PATH=/usr/local/bin
+ENTRYPOINT ["/usr/local/bin/intel_qat_device_plugin"]

--- a/build/docker/templates/intel-qat-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-qat-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_qat_device_plugin
+ARG CMD=qat_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-qat-plugin'
+LABEL summary='Intel® QAT device plugin for Kubernetes'
+LABEL description='The QAT plugin supports device plugin for Intel QAT adapters, and includes code showing deployment via DPDK'

--- a/build/docker/templates/intel-sgx-admissionwebhook.Dockerfile.in
+++ b/build/docker/templates/intel-sgx-admissionwebhook.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_sgx_admissionwebhook
+ARG CMD=sgx_admissionwebhook
+
+#include "default_plugin.docker"
+
+LABEL name='intel-sgx-admissionwebhook'
+LABEL summary='Intel® SGX admission controller webhook for Kubernetes'
+LABEL description='The SGX admission webhook is responsible for performing Pod mutations based on the sgx.intel.com/quote-provider pod annotation set by the user. The purpose of the webhook is to hide the details of setting the necessary device resources and volume mounts for using SGX remote attestation in the cluster'

--- a/build/docker/templates/intel-sgx-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-sgx-initcontainer.Dockerfile.in
@@ -1,0 +1,24 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+
+#define _ENTRYPOINT_ /usr/local/bin/sgx-sw/intel-sgx-epchook
+ARG EP=_ENTRYPOINT_
+ARG CMD=sgx_epchook
+ARG NFD_HOOK=intel-sgx-epchook
+ARG SRC_DIR=/usr/local/bin/sgx-sw
+
+#include "nfdhook_build.docker"
+
+FROM ${FINAL_BASE}
+
+#include "default_labels.docker"
+
+LABEL name='intel-sgx-initcontainer'
+LABEL summary='Intel® SGX NFD hook for Kubernetes'
+LABEL description='The SGX EPC memory available on each node is registered as a Kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of SGX device plugin operator deployment and NFD is configured to register the SGX EPC memory extended resource reported by the hook'
+
+#include "nfdhook_end.docker"

--- a/build/docker/templates/intel-sgx-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-sgx-plugin.Dockerfile.in
@@ -1,0 +1,8 @@
+#define _ENTRYPOINT_ /usr/local/bin/intel_sgx_device_plugin
+ARG CMD=sgx_plugin
+
+#include "default_plugin.docker"
+
+LABEL name='intel-sgx-plugin'
+LABEL summary='Intel® SGX device plugin for Kubernetes'
+LABEL description='The SGX device plugin is responsible for discovering and reporting SGX device nodes to kubelet'

--- a/build/docker/templates/intel-vpu-plugin.Dockerfile.in
+++ b/build/docker/templates/intel-vpu-plugin.Dockerfile.in
@@ -1,0 +1,36 @@
+#include "final_base.docker"
+#include "golang_base.docker"
+
+FROM ${GOLANG_BASE} as builder
+
+#include "default_args.docker"
+
+ARG CMD=vpu_plugin
+
+WORKDIR $DIR
+COPY . .
+
+RUN echo "deb-src http://deb.debian.org/debian unstable main" | tee -a /etc/apt/sources.list
+RUN apt update && apt -y install dpkg-dev libusb-1.0-0-dev
+RUN mkdir -p /install_root/licenses/libusb \
+    && cd /install_root/licenses/libusb \
+    && apt-get --download-only source libusb-1.0-0 \
+    && cd -
+RUN cd cmd/$CMD; GO111MODULE=${GO111MODULE} CGO_ENABLED=1 go install "${BUILDFLAGS}"; cd -
+RUN install -D /go/bin/vpu_plugin /install_root/usr/local/bin/intel_vpu_device_plugin
+
+#include "default_licenses.docker"
+
+FROM debian:unstable-slim
+
+#include "default_labels.docker"
+
+LABEL name='intel-vpu-plugin'
+LABEL summary='Intel® VPU device plugin for Kubernetes'
+
+RUN apt update && apt -y install libusb-1.0-0
+COPY --from=builder /install_root /
+ENTRYPOINT ["/usr/local/bin/intel_vpu_device_plugin"]
+
+
+


### PR DESCRIPTION
This introduces dockerfile re-usage via cpp preprocessing. Less copy-paste in our numerous dockerfiles, single file where to make changes!

Old targets work as usual, and dockerfiles are regenerated if the inputs are changed.

This was written on top of the license file build optimization.