### PR TITLE
e2e: expect test workloads to finish successfully

### DIFF
--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -98,6 +98,6 @@ func describe() {
 		framework.ExpectNoError(err, "pod Create API error")
 
 		ginkgo.By("waiting the pod to finnish successfully")
-		f.PodClient().WaitForFinish(pod.ObjectMeta.Name, 60*time.Second)
+		f.PodClient().WaitForSuccess(pod.ObjectMeta.Name, 60*time.Second)
 	})
 }

--- a/test/e2e/gpu/gpu.go
+++ b/test/e2e/gpu/gpu.go
@@ -91,7 +91,7 @@ func describe() {
 		framework.ExpectNoError(err, "pod Create API error")
 
 		ginkgo.By("waiting the pod to finnish successfully")
-		f.PodClient().WaitForFinish(pod.ObjectMeta.Name, 60*time.Second)
+		f.PodClient().WaitForSuccess(pod.ObjectMeta.Name, 60*time.Second)
 
 		ginkgo.By("checking log output")
 		log, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, containerName)

--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -134,6 +134,6 @@ func describe() {
 		framework.ExpectNoError(err, "pod Create API error")
 
 		ginkgo.By("waiting the pod to finnish successfully")
-		f.PodClient().WaitForFinish(pod.ObjectMeta.Name, 60*time.Second)
+		f.PodClient().WaitForSuccess(pod.ObjectMeta.Name, 60*time.Second)
 	})
 }


### PR DESCRIPTION
WaitForFinish waits for pod to finish running, regardless of
success or failure. WaitForSuccess waits for pod to succeed
which is what we expect from our test workloads that try
to use the devices.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>