### PR TITLE
Jenkinsfile: do not push images if job was PR-triggered

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,11 +155,12 @@ pipeline {
             }
           }
         }
-      }
-      post {
-        success {
-          withDockerRegistry([ credentialsId: "e16bd38a-76cb-4900-a5cb-7f6aa3aeb22d", url: "https://${REG}" ]) {
-            sh "make push"
+        stage('push images') {
+          when { not { changeRequest() } }
+          steps {
+            withDockerRegistry([ credentialsId: "e16bd38a-76cb-4900-a5cb-7f6aa3aeb22d", url: "https://${REG}" ]) {
+              sh "make push"
+            }
           }
         }
       }


### PR DESCRIPTION
I have understood the images created in PR-triggered builds dont get any use afterwards, so the idea is to reduce stress and space consuming on registry, also saving some job time.
I moved push stmt from post block to become a stage, as I think conditional is not possible in post block.
Running push as a last stage instead of post-if-success should have same effect.