### PR TITLE
upgrade accel-config to v3.4.6.4

### DIFF
--- a/build/docker/intel-idxd-config-initcontainer.Dockerfile
+++ b/build/docker/intel-idxd-config-initcontainer.Dockerfile
@@ -16,9 +16,9 @@
 ###
 FROM debian:unstable-slim AS builder
 RUN echo "deb-src http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list.d/deb-src.list && apt update && apt install -y --no-install-recommends gcc make patch autoconf automake libtool pkg-config libjson-c-dev uuid-dev curl ca-certificates
-ARG ACCEL_CONFIG_VERSION="3.4.6.3"
+ARG ACCEL_CONFIG_VERSION="3.4.6.4"
 ARG ACCEL_CONFIG_DOWNLOAD_URL="https://github.com/intel/idxd-config/archive/accel-config-v$ACCEL_CONFIG_VERSION.tar.gz"
-ARG ACCEL_CONFIG_SHA256="a28f531dd69bdc83ca2ad23cacd079530510e98b726421c6d07e24c8426d086e"
+ARG ACCEL_CONFIG_SHA256="5f9ee68f51913d803b9b0e51cdadaff14ea1523f6e9e4d4ab3e85de644ba6d21"
 RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && tar -xzf accel-config.tar.gz
 RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && ./git-version-gen && autoreconf -i && ./configure -q --libdir=/usr/lib64 --disable-test --disable-docs && make && make install
 ###

--- a/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
@@ -6,9 +6,9 @@ RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \
         gcc make patch autoconf automake libtool pkg-config \
         libjson-c-dev uuid-dev curl ca-certificates
 
-ARG ACCEL_CONFIG_VERSION="3.4.6.3"
+ARG ACCEL_CONFIG_VERSION="3.4.6.4"
 ARG ACCEL_CONFIG_DOWNLOAD_URL="https://github.com/intel/idxd-config/archive/accel-config-v$ACCEL_CONFIG_VERSION.tar.gz"
-ARG ACCEL_CONFIG_SHA256="a28f531dd69bdc83ca2ad23cacd079530510e98b726421c6d07e24c8426d086e"
+ARG ACCEL_CONFIG_SHA256="5f9ee68f51913d803b9b0e51cdadaff14ea1523f6e9e4d4ab3e85de644ba6d21"
 
 RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && \
     echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && \

--- a/demo/dsa-accel-config-demo/Dockerfile
+++ b/demo/dsa-accel-config-demo/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf install -y \
     wget autoconf automake libtool m4 diffutils file make dnf-utils patch \
     libuuid-devel json-c-devel
 
-ARG ACCEL_CONFIG_VERSION=v3.4.6.3
+ARG ACCEL_CONFIG_VERSION=v3.4.6.4
 
 RUN wget -O- https://github.com/intel/idxd-config/archive/accel-config-$ACCEL_CONFIG_VERSION.tar.gz | tar -zx
 


### PR DESCRIPTION
This is a preparation for IAA e2e enabling and testing if
it still works with DSA as expected.

This accel-config version has IAA test runner.