### PR TITLE
operator: align with kubebuilder v3 functionality

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -104,9 +104,9 @@ func main() {
 
 	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
 
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&devicePluginNamespace, "deviceplugin-namespace", metav1.NamespaceSystem, "The namespace where deviceplugin daemonsets are created")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Var(&devices, "devices", "Device(s) to set up.")

--- a/deployments/operator/default/manager_auth_proxy_patch.yaml
+++ b/deployments/operator/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -27,5 +27,5 @@ spec:
           allowPrivilegeEscalation: false
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/deployments/operator/device/dlb/dlb.yaml
+++ b/deployments/operator/device/dlb/dlb.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=dlb
         name: manager

--- a/deployments/operator/device/dsa/dsa.yaml
+++ b/deployments/operator/device/dsa/dsa.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=dsa
         name: manager

--- a/deployments/operator/device/fpga/fpga.yaml
+++ b/deployments/operator/device/fpga/fpga.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=fpga
         name: manager

--- a/deployments/operator/device/gpu/gpu.yaml
+++ b/deployments/operator/device/gpu/gpu.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=gpu
         name: manager

--- a/deployments/operator/device/qat/qat.yaml
+++ b/deployments/operator/device/qat/qat.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=qat
         name: manager

--- a/deployments/operator/device/sgx/sgx.yaml
+++ b/deployments/operator/device/sgx/sgx.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --devices=sgx
         name: manager


### PR DESCRIPTION
kubebuilder v3 based scaffolding has updated many things
and they are documented in [1].

Update operator's functionality to v3 level. We've done
most/some of the changes earlier (e.g., by not using
deprecated k8s APIs anymore) so the changes are minimal.

[1] https://book.kubebuilder.io/migration/v2vsv3.html

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>