### PR TITLE
doc: modify SGX device plugin deployments url from 'main' to '<RELEASE_VERSION>'

### DIFF
--- a/cmd/sgx_plugin/README.md
+++ b/cmd/sgx_plugin/README.md
@@ -106,7 +106,7 @@ $ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/
 #### Deploy SGX device plugin with the operator
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/intel/intel-device-plugins-for-kubernetes/main/deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/intel/intel-device-plugins-for-kubernetes/<RELEASE_VERSION>/deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml
 ```
 
 ### Getting the source code


### PR DESCRIPTION
I found the SGX device plugin deployments url always points to `main` branch, it will cause errors if users try to deploy previous version of SGX device plugin using this url.