### PR TITLE
fpga: update NFD labelling rules

### DIFF
--- a/deployments/nfd/overlays/node-feature-rules/node-feature-rules.yaml
+++ b/deployments/nfd/overlays/node-feature-rules/node-feature-rules.yaml
@@ -39,9 +39,15 @@ spec:
             vendor: {op: In, value: ["8086"]}
             device: {op: In, value: ["09c4"]}
             class: {op: In, value: ["1200"]}
-        - feature: kernel.loadedmodule
-          matchExpressions:
-            dfl_pci: {op: Exists}
+      matchAny:
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                dfl_pci: {op: Exists}
+        - matchFeatures:
+            - feature: kernel.loadedmodule
+              matchExpressions:
+                intel_fpga_pci: {op: Exists}
 
     - name: "intel.gpu"
       labels:


### PR DESCRIPTION
Added OPAE kernel module as an alternative to DFL
to the Arria10 labeling rules.

Fixes: #1069