### PR TITLE
Update example references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,14 +232,14 @@ table below.
 
 | Device Namespace | Registered Resource(s)          | Example(s)                                  |
 |:-----------------|:-----------------------------|:--------------------------------------------|
-| `dlb.intel.com`  |  `pf` or `vf`                | [dlb-libdlb-demo-pod.yaml](demo/dlb-libdlb-demo-pod.yaml) |
-| `dsa.intel.com`  | `wq-user-[shared or dedicated]` | [dsa-accel-config-demo-pod.yaml](demo/dsa-accel-config-demo-pod.yaml) |
-| `fpga.intel.com` | custom, see [mappings](cmd/fpga_admissionwebhook/README.md#mappings)| [intelfpga-job.yaml](demo/intelfpga-job.yaml) |
-| `gpu.intel.com`  | `i915`                       | [intelgpu-job.yaml](demo/intelgpu-job.yaml) |
-| `iaa.intel.com`  | `wq-user-[shared or dedicated]` | [iaa-qpl-demo-pod.yaml](demo/iaa-qpl-demo-pod.yaml) |
-| `qat.intel.com`  | `generic` or `cy`/`dc`/`sym`/`asym` | [crypto-perf-dpdk-pod-requesting-qat.yaml](deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml) |
-| `sgx.intel.com`  | `epc`                        | [intelsgx-job.yaml](deployments/sgx_enclave_apps/base/intelsgx-job.yaml) |
-| `vpu.intel.com`  | `hddl`                       | [intelvpu-job.yaml](demo/intelvpu-job.yaml) |
+| `dlb.intel.com`  |  `pf` or `vf`                | [dlb-libdlb-demo-pod.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/dlb-libdlb-demo-pod.yaml) |
+| `dsa.intel.com`  | `wq-user-[shared or dedicated]` | [dsa-accel-config-demo-pod.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/dsa-accel-config-demo-pod.yaml) |
+| `fpga.intel.com` | custom, see [mappings](cmd/fpga_admissionwebhook/README.md#mappings)| [intelfpga-job.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/intelfpga-job.yaml) |
+| `gpu.intel.com`  | `i915`                       | [intelgpu-job.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/intelgpu-job.yaml) |
+| `iaa.intel.com`  | `wq-user-[shared or dedicated]` | [iaa-qpl-demo-pod.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/iaa-qpl-demo-pod.yaml) |
+| `qat.intel.com`  | `generic` or `cy`/`dc`/`sym`/`asym` | [crypto-perf-dpdk-pod-requesting-qat.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml) |
+| `sgx.intel.com`  | `epc`                        | [intelsgx-job.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/deployments/sgx_enclave_apps/base/intelsgx-job.yaml) |
+| `vpu.intel.com`  | `hddl`                       | [intelvpu-job.yaml](https://github.com/byako/intel-device-plugins-for-kubernetes/blob/main/demo/intelvpu-job.yaml) |
 
 ## Developers
 


### PR DESCRIPTION
Make links to YAMLs full URLs instead of relative path - when github-pages are generated, these links get broken for some reason.

Fixes: #1058 

Signed-off-by: Alexey Fomenko <alexey.fomenko@intel.com>