### PR TITLE
Add 0380 pci class node label selector to GPU plugin

### DIFF
--- a/deployments/gpu_plugin/overlays/nfd_labeled_nodes/add-nodeselector-intel-gpu.yaml
+++ b/deployments/gpu_plugin/overlays/nfd_labeled_nodes/add-nodeselector-intel-gpu.yaml
@@ -7,3 +7,4 @@ spec:
     spec:
       nodeSelector:
         feature.node.kubernetes.io/pci-0300_8086.present: "true"
+        feature.node.kubernetes.io/pci-0380_8086.present: "true"


### PR DESCRIPTION
At the moment only 0300 PCI class (VGA compatible controller) is used for node label selector populated by NFD worker. This adds 0380 (Display controller) PCI class selector.