### PR TITLE
fix links by removing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,19 +227,25 @@ spec:
           <device namespace>/<resource>: X
 ```
 
-The summary of resources available via plugins in this repository is given in the
-table below.
+The summary of resources available via plugins in this repository is given in the list below.
 
-| Device Namespace | Registered Resource(s)          | Example(s)                                  |
-|:-----------------|:-----------------------------|:--------------------------------------------|
-| `dlb.intel.com`  |  `pf` or `vf`                | [dlb-libdlb-demo-pod.yaml](demo/dlb-libdlb-demo-pod.yaml) |
-| `dsa.intel.com`  | `wq-user-[shared or dedicated]` | [dsa-accel-config-demo-pod.yaml](demo/dsa-accel-config-demo-pod.yaml) |
-| `fpga.intel.com` | custom, see [mappings](cmd/fpga_admissionwebhook/README.md#mappings)| [intelfpga-job.yaml](demo/intelfpga-job.yaml) |
-| `gpu.intel.com`  | `i915`                       | [intelgpu-job.yaml](demo/intelgpu-job.yaml) |
-| `iaa.intel.com`  | `wq-user-[shared or dedicated]` | [iaa-qpl-demo-pod.yaml](demo/iaa-qpl-demo-pod.yaml) |
-| `qat.intel.com`  | `generic` or `cy`/`dc`/`sym`/`asym` | [crypto-perf-dpdk-pod-requesting-qat.yaml](deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml) |
-| `sgx.intel.com`  | `epc`                        | [intelsgx-job.yaml](deployments/sgx_enclave_apps/base/intelsgx-job.yaml) |
-| `vpu.intel.com`  | `hddl`                       | [intelvpu-job.yaml](demo/intelvpu-job.yaml) |
+**Device Namespace : Registered Resource(s)**
+ * `dlb.intel.com`  : `pf` or `vf`
+   * [dlb-libdlb-demo-pod.yaml](demo/dlb-libdlb-demo-pod.yaml)
+ * `dsa.intel.com`  : `wq-user-[shared or dedicated]`
+   * [dsa-accel-config-demo-pod.yaml](demo/dsa-accel-config-demo-pod.yaml)
+ * `fpga.intel.com` : custom, see [mappings](cmd/fpga_admissionwebhook/README.md#mappings)
+   * [intelfpga-job.yaml](demo/intelfpga-job.yaml)
+ * `gpu.intel.com`  : `i915`
+   * [intelgpu-job.yaml](demo/intelgpu-job.yaml)
+ * `iaa.intel.com`  : `wq-user-[shared or dedicated]`
+   * [iaa-qpl-demo-pod.yaml](demo/iaa-qpl-demo-pod.yaml)
+ * `qat.intel.com`  : `generic` or `cy`/`dc`/`sym`/`asym`
+   * [crypto-perf-dpdk-pod-requesting-qat.yaml](deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml)
+ * `sgx.intel.com`  : `epc`
+   * [intelsgx-job.yaml](deployments/sgx_enclave_apps/base/intelsgx-job.yaml)
+ * `vpu.intel.com`  : `hddl`
+   * [intelvpu-job.yaml](demo/intelvpu-job.yaml)
 
 ## Developers
 


### PR DESCRIPTION
As a workaround for broken links, this removes the Workload Authors
section table and replaces it with a list.

fixes #1058

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>