### PR TITLE
ci: fix docs generation again

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 docutils<0.18
-Markdown<3.4
 sphinx
 sphinx_rtd_theme
 recommonmark


### PR DESCRIPTION
823e87a fixed docs generation by locking Markdown version that
is compatible with sphinx-markdown-tables but did not lock
sphinx-markdown-tables itself.

Now that sphinx-markdown-tables got fixed so that it requires the
latest Markdown version, the docs generation fails again.

Fix it by dropping the Markdown version lock. This also fixes
docs generation for the release branches.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>