### PR TITLE
ci: add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ on:
 env:
   GO_VERSION: 1.18.3
   K8S_VERSION: 1.24.2
+permissions:
+  contents: read
+
 jobs:
 
   docs:
@@ -37,6 +40,9 @@ jobs:
         mv _build/html/* $HOME/output/
 
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-dlb.yml
+++ b/.github/workflows/e2e-dlb.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-dlb-plugin dlb-libdlb-demo'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-dlb:
     name: e2e-dlb

--- a/.github/workflows/e2e-dsa.yml
+++ b/.github/workflows/e2e-dsa.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-dsa-plugin intel-idxd-config-initcontainer accel-config-demo'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-dsa:
     name: e2e-dsa

--- a/.github/workflows/e2e-fpga.yml
+++ b/.github/workflows/e2e-fpga.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-fpga-plugin intel-fpga-initcontainer intel-fpga-admissionwebhook opae-nlb-demo'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-fpga:
     name: e2e-fpga

--- a/.github/workflows/e2e-gpu.yml
+++ b/.github/workflows/e2e-gpu.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-gpu-plugin intel-gpu-initcontainer'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-gpu:
     name: e2e-gpu

--- a/.github/workflows/e2e-iaa.yml
+++ b/.github/workflows/e2e-iaa.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-iaa-plugin intel-idxd-config-initcontainer accel-config-demo'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-iaa:
     name: e2e-iaa

--- a/.github/workflows/e2e-qat.yml
+++ b/.github/workflows/e2e-qat.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-qat-plugin intel-qat-initcontainer crypto-perf'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-qat:
     name: e2e-qat

--- a/.github/workflows/e2e-sgx.yml
+++ b/.github/workflows/e2e-sgx.yml
@@ -11,6 +11,9 @@ on:
 env:
   IMAGES: 'intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-sgx:
     name: e2e-sgx

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,14 @@ on:
         - release-0.23
         - release-0.24
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue. Merging this PR will also help improve the Scorecard score for this project.  

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

### Before this change
`GITHUB_TOKEN` has `write` permissions for multiple scopes which are not needed. 
e.g. https://github.com/intel/intel-device-plugins-for-kubernetes/runs/7536935045?check_suite_focus=true#step:1:19

### After this change
`GITHUB_TOKEN` will have minimum permissions needed. 

