### PR TITLE
docs: Fix missing code block in operator doc 

### DIFF
--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -28,10 +28,12 @@ $ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/
 ```
 Make sure both NFD master and worker pods are running:
 
+```
 $ kubectl get pods -n node-feature-discovery
 NAME                          READY   STATUS    RESTARTS   AGE
 nfd-master-599c58dffc-9wql4   1/1     Running   0          25h
 nfd-worker-qqq4h              1/1     Running   0          25h
+```
 
 Note that labelling is not performed immediately. Give NFD 1 minute to pick up the rules and label nodes.
 


### PR DESCRIPTION
Add note about cert-manager in the section for deploying with pre-built
images since it is a requirement for the default operator deployment.
Add missing code block to section the the operator README.

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>

**Some notes/questions:**
I'm not sure if you want to use a small PR for updates to documents, so here are 2 changes that I think would improve clarity for installation/setup. I tested with Kata containers.

I am also wondering if it would make sense to put a note at the bottom of the SGX plugin README regarding `Pending` status and unavailable nodes due to `Insufficient sgx.intel.com/epc`, similar to how there is a note in the VPU plugin and a few others. I ran into this error with SGX, I think because I had initially not set up cert-manager with the pre-built image deployment.
VPU example:
https://github.com/intel/intel-device-plugins-for-kubernetes/blob/685ed6ecece7c8c365e568f6a4ad776399af5a0d/cmd/vpu_plugin/README.md?plain=1#L238-L256