### PR TITLE
e2e: fix SGX test flakiness

### DIFF
--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -71,8 +71,8 @@ func describe() {
 		msg = framework.RunKubectlOrDie("node-feature-discovery", "apply", "-k", filepath.Dir(nodeFeatureRulesPath))
 		framework.Logf("Create NodeFeatureRules:\n%s", msg)
 
-		if _, err = e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, "node-feature-discovery",
-			labels.Set{"app": "nfd-master"}.AsSelector(), 1 /* one replica */, 180*time.Second); err != nil {
+		if err = e2epod.WaitForPodsRunningReady(f.ClientSet, "node-feature-discovery", 2, 0,
+			100*time.Second, map[string]string{}); err != nil {
 			framework.Failf("unable to wait for NFD pods to be running and ready: %v", err)
 		}
 	})


### PR DESCRIPTION
Due to a regression in k8s.io@v1.25, WaitForPodsWithLabelRunningReady()
ignored user provided timeout and defaulted to 60s. In some cases, NFD
needs more than that to the tests fail.

Workaround the problem by moving to use WaitForPodsRunningReady() with
minPods=2 (nfd-master and at least one nfd-worker).

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>