### PR TITLE
switch back to debian:unstable-slim as a base

### DIFF
--- a/build/docker/intel-idxd-config-initcontainer.Dockerfile
+++ b/build/docker/intel-idxd-config-initcontainer.Dockerfile
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ###
-FROM debian:stable-slim AS builder
+FROM debian:unstable-slim AS builder
 RUN apt update && apt install -y --no-install-recommends gcc make patch autoconf automake libtool pkg-config libjson-c-dev uuid-dev curl ca-certificates
 ARG ACCEL_CONFIG_VERSION="3.4.6.4"
 ARG ACCEL_CONFIG_DOWNLOAD_URL="https://github.com/intel/idxd-config/archive/accel-config-v$ACCEL_CONFIG_VERSION.tar.gz"
@@ -22,7 +22,7 @@ ARG ACCEL_CONFIG_SHA256="5f9ee68f51913d803b9b0e51cdadaff14ea1523f6e9e4d4ab3e85de
 RUN curl -fsSL "$ACCEL_CONFIG_DOWNLOAD_URL" -o accel-config.tar.gz && echo "$ACCEL_CONFIG_SHA256 accel-config.tar.gz" | sha256sum -c - && tar -xzf accel-config.tar.gz
 RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && ./git-version-gen && autoreconf -i && ./configure -q --libdir=/usr/lib64 --disable-test --disable-docs && make && make install
 ###
-FROM debian:stable-slim
+FROM debian:unstable-slim
 RUN apt update && apt install -y libjson-c5 jq
 COPY --from=builder /usr/lib64/libaccel-config.so.1.0.0 "/lib/x86_64-linux-gnu/"
 RUN ldconfig && mkdir -p /licenses/accel-config

--- a/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-idxd-config-initcontainer.Dockerfile.in
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS builder
+FROM debian:unstable-slim AS builder
 
 RUN apt update && apt install -y --no-install-recommends \
     gcc make patch autoconf automake libtool pkg-config \
@@ -19,7 +19,7 @@ RUN cd idxd-config-accel-config-v$ACCEL_CONFIG_VERSION && \
     make && \
     make install
 ###
-FROM debian:stable-slim
+FROM debian:unstable-slim
 
 RUN apt update && apt install -y libjson-c5 jq
 

--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS builder
+FROM debian:unstable-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y curl python3-dev git gcc g++ make cmake uuid-dev libjson-c-dev libedit-dev libudev-dev
@@ -23,7 +23,7 @@ RUN cd /usr/src/opae/opae-sdk-${OPAE_RELEASE} && \
     make -j xfpga nlb0 nlb3
 
 
-FROM debian:stable-slim
+FROM debian:unstable-slim
 
 RUN apt-get update && apt-get install -y libjson-c5
 


### PR DESCRIPTION
We had to switch to debian unstable earlier due to a
mismatch in glibc versions in the debian-unstable-slim and
debian-testing-slim images and Debian package repositories.

[This issue has been fixed](https://github.com/debuerreotype/docker-debian-artifacts/issues/168), so we can switch back to debian-stable.