### PR TITLE
Add "prefix" option to GPU plugin for scalability testing

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -367,8 +367,12 @@ func (dp *devicePlugin) Allocate(request *pluginapi.AllocateRequest) (*pluginapi
 }
 
 func main() {
-	var opts cliOptions
+	var (
+		prefix string
+		opts   cliOptions
+	)
 
+	flag.StringVar(&prefix, "prefix", "", "Prefix for devfs & sysfs paths")
 	flag.BoolVar(&opts.enableMonitoring, "enable-monitoring", false, "whether to enable 'i915_monitoring' (= all GPUs) resource")
 	flag.BoolVar(&opts.resourceManagement, "resource-manager", false, "fractional GPU resource management")
 	flag.IntVar(&opts.sharedDevNum, "shared-dev-num", 1, "number of containers sharing the same GPU device")
@@ -393,7 +397,7 @@ func main() {
 
 	klog.V(1).Infof("GPU device plugin started with %s preferred allocation policy", opts.preferredAllocationPolicy)
 
-	plugin := newDevicePlugin(sysfsDrmDirectory, devfsDriDirectory, opts)
+	plugin := newDevicePlugin(prefix+sysfsDrmDirectory, prefix+devfsDriDirectory, opts)
 	manager := dpapi.NewManager(namespace, plugin)
 	manager.Run()
 }


### PR DESCRIPTION
GPU plugin code assumes container paths to match host paths, and container runtime prevents creating fake files under real paths.  When non-standard paths are used, devices can be faked for scalability testing.

The whole picture and review comments are in the RFC PR #1104, from which this is split off.