### PR TITLE
Replace obsolete patches syntax

### DIFF
--- a/deployments/dsa_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/dsa_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patches:
+patchesStrategicMerge:
   - add-namespace-kube-system.yaml

--- a/deployments/dsa_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/dsa_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patchesStrategicMerge:
-  - add-namespace-kube-system.yaml
+patches:
+  - path: add-namespace-kube-system.yaml

--- a/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - resource-cluster-role-binding.yaml
   - resource-cluster-role.yaml
   - resource-reader-sa.yaml
-patches:
+patchesStrategicMerge:
   - add-serviceaccount.yaml
   - add-podresource-mount.yaml
   - add-args.yaml

--- a/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - resource-cluster-role-binding.yaml
   - resource-cluster-role.yaml
   - resource-reader-sa.yaml
-patchesStrategicMerge:
-  - add-serviceaccount.yaml
-  - add-podresource-mount.yaml
-  - add-args.yaml
+patches:
+  - path: add-serviceaccount.yaml
+  - path: add-podresource-mount.yaml
+  - path: add-args.yaml

--- a/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patches:
+patchesStrategicMerge:
   - add-namespace-kube-system.yaml

--- a/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patchesStrategicMerge:
-  - add-namespace-kube-system.yaml
+patches:
+  - path: add-namespace-kube-system.yaml

--- a/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patchesStrategicMerge:
-  - add-nodeselector-intel-gpu.yaml
+patches:
+  - path: add-nodeselector-intel-gpu.yaml

--- a/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/nfd_labeled_nodes/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patches:
+patchesStrategicMerge:
   - add-nodeselector-intel-gpu.yaml

--- a/deployments/qat_plugin/overlays/debug/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/debug/kustomization.yaml
@@ -1,5 +1,5 @@
 nameSuffix: -debug
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
   - add-args.yaml

--- a/deployments/qat_plugin/overlays/debug/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/debug/kustomization.yaml
@@ -1,5 +1,5 @@
 nameSuffix: -debug
 bases:
 - ../../base
-patchesStrategicMerge:
-  - add-args.yaml
+patches:
+  - path: add-args.yaml

--- a/deployments/qat_plugin/overlays/e2e/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/e2e/kustomization.yaml
@@ -5,5 +5,5 @@ commonAnnotations:
 resources:
 - ../sriov_numvfs
 
-patches:
+patchesStrategicMerge:
   - add-args.yaml

--- a/deployments/qat_plugin/overlays/e2e/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/e2e/kustomization.yaml
@@ -5,5 +5,5 @@ commonAnnotations:
 resources:
 - ../sriov_numvfs
 
-patchesStrategicMerge:
-  - add-args.yaml
+patches:
+  - path: add-args.yaml

--- a/deployments/sgx_plugin/overlays/epc-hook-initcontainer/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-hook-initcontainer/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - ../../base
-patchesStrategicMerge:
-  - add-epc-nfd-initcontainer.yaml
+patches:
+  - path: add-epc-nfd-initcontainer.yaml

--- a/deployments/sgx_plugin/overlays/epc-hook-initcontainer/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-hook-initcontainer/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - ../../base
-patches:
+patchesStrategicMerge:
   - add-epc-nfd-initcontainer.yaml

--- a/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
@@ -3,5 +3,5 @@ bases:
   - ../../../nfd/overlays/sgx
   - ../../../nfd/overlays/node-feature-rules
   - ../../../sgx_admissionwebhook/overlays/default-with-certmanager
-patches:
+patchesStrategicMerge:
   - add-epc-nfd-initcontainer.yaml

--- a/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
@@ -3,5 +3,5 @@ bases:
   - ../../../nfd/overlays/sgx
   - ../../../nfd/overlays/node-feature-rules
   - ../../../sgx_admissionwebhook/overlays/default-with-certmanager
-patchesStrategicMerge:
-  - add-epc-nfd-initcontainer.yaml
+patches:
+  - path: add-epc-nfd-initcontainer.yaml

--- a/deployments/sgx_plugin/overlays/epc-register/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-register/kustomization.yaml
@@ -4,5 +4,5 @@ namespace: kube-system
 resources:
   - service-account.yaml
   - init-daemonset.yaml
-patches:
+patchesStrategicMerge:
   - add-node-selector.yaml

--- a/deployments/sgx_plugin/overlays/epc-register/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-register/kustomization.yaml
@@ -4,5 +4,5 @@ namespace: kube-system
 resources:
   - service-account.yaml
   - init-daemonset.yaml
-patchesStrategicMerge:
-  - add-node-selector.yaml
+patches:
+  - path: add-node-selector.yaml

--- a/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patches:
+patchesStrategicMerge:
   - add-namespace-kube-system.yaml

--- a/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
+++ b/deployments/vpu_plugin/overlays/namespace_kube-system/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
   - ../../base
-patchesStrategicMerge:
-  - add-namespace-kube-system.yaml
+patches:
+  - path: add-namespace-kube-system.yaml

--- a/deployments/vpu_plugin/overlays/xlink/kustomization.yaml
+++ b/deployments/vpu_plugin/overlays/xlink/kustomization.yaml
@@ -1,6 +1,6 @@
 bases:
 - ../../base/
-patches:
+patchesStrategicMerge:
 - add_command_args.yaml
 patchesJson6902:
 - target:


### PR DESCRIPTION
This was made obsolete in v1.0.9
https://github.com/kubernetes-sigs/kustomize/blob/v1.0.9/pkg/types/kustomization.go#L129

And stopped working in v3.0.3
https://github.com/kubernetes-sigs/kustomize/issues/1373