### PR TITLE
Log GPU plugin resource count changes per type

### DIFF
--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -100,6 +100,11 @@ func (tree DeviceTree) AddDevice(devType, id string, info DeviceInfo) {
 	tree[devType][id] = info
 }
 
+// DeviceTypeCount returns number of device of given type.
+func (tree DeviceTree) DeviceTypeCount(devType string) int {
+	return len(tree[devType])
+}
+
 // Notifier receives updates from Scanner, detects changes and sends the
 // detected changes to a channel given by the creator of a Notifier object.
 type Notifier interface {


### PR DESCRIPTION
This improves #1113 further by:
* logging both GPU plugin resource type count changes separately, and
* getting rid of DeviceTree internals access

Increase in scan() method complexity required splitting the innermost loop to a separate method => changes are best reviewed from the commits themselves.

(This is WIP because there's some ongoing discussion about whether DeviceTree could provide method for this, and to indicate that it's not supposed to go in before the next release.)