### PR TITLE
docs: rework development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Table of Contents
 * [Demos](#demos)
 * [Workload Authors](#workload-authors)
 * [Developers](#developers)
-* [Running e2e Tests](#running-e2e-tests)
 * [Supported Kubernetes versions](#supported-kubernetes-versions)
 * [Pre-built plugin images](#pre-built-plugin-images)
 * [License](#license)
@@ -38,7 +37,7 @@ Table of Contents
 
 Prerequisites for building and running these device plugins include:
 
-- Appropriate hardware
+- Appropriate hardware and drivers
 - A fully configured [Kubernetes cluster]
 - A working [Go environment], of at least version v1.16.
 
@@ -249,64 +248,8 @@ The summary of resources available via plugins in this repository is given in th
 
 ## Developers
 
-For information on how to develop a new plugin using the framework, see the
-[Developers Guide](DEVEL.md) and the code in the
-[device plugins pkg directory](pkg/deviceplugin).
-
-## Running E2E Tests
-
-Currently the E2E tests require having a Kubernetes cluster already configured
-on the nodes with the hardware required by the device plugins. Also all the
-container images with the executables under test must be available in the
-cluster. If these two conditions are satisfied, run the tests with:
-
-```bash
-$ go test -v ./test/e2e/...
-```
-
-In case you want to run only certain tests, e.g., QAT ones, run:
-
-```bash
-$ go test -v ./test/e2e/... -args -ginkgo.focus "QAT"
-```
-
-If you need to specify paths to your custom `kubeconfig` containing
-embedded authentication info then add the `-kubeconfig` argument:
-
-```bash
-$ go test -v ./test/e2e/... -args -kubeconfig /path/to/kubeconfig
-```
-
-The full list of available options can be obtained with:
-
-```bash
-$ go test ./test/e2e/... -args -help
-```
-
-It is possible to run the tests which don't depend on hardware
-without a pre-configured Kubernetes cluster. Just make sure you have
-[Kind](https://kind.sigs.k8s.io/) installed on your host and run:
-
-```
-$ make test-with-kind
-```
-
-## Running Controller Tests with a Local Control Plane
-
-The controller-runtime library provides a package for integration testing by
-starting a local control plane. The package is called
-[envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest). The
-operator uses this package for its integration testing.
-Please have a look at `envtest`'s documentation to set up it properly. But basically
-you just need to have `etcd` and `kube-apiserver` binaries available on your
-host. By default they are expected to be located at `/usr/local/kubebuilder/bin`.
-But you can have it stored anywhere by setting the `KUBEBUILDER_ASSETS`
-environment variable. If you have the binaries copied to
-`${HOME}/work/kubebuilder-assets`, run the tests:
-
-```bash
-$ KUBEBUILDER_ASSETS=${HOME}/work/kubebuilder-assets make envtest
-```
+For information on how to develop a new plugin using the framework or work on development task in
+this repository, see the [Developers Guide](DEVEL.md).
 
 ## Supported Kubernetes Versions
 

--- a/cmd/dlb_plugin/README.md
+++ b/cmd/dlb_plugin/README.md
@@ -4,16 +4,9 @@ Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
-    * [Deploy with pre-built container image](#deploy-with-pre-built-container-image)
-    * [Getting the source code](#getting-the-source-code)
-    * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
-        * [Build the plugin image](#build-the-plugin-image)
-        * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)
-    * [Deploy by hand](#deploy-by-hand)
-        * [Build the plugin](#build-the-plugin)
-        * [Run the plugin as administrator](#run-the-plugin-as-administrator)
-    * [Verify plugin registration](#verify-plugin-registration)
-    * [Testing the plugin](#testing-the-plugin)
+    * [Pre-built Images](#pre-built-images)
+    * [Verify Plugin Registration](#verify-plugin-registration)
+* [Testing and Demos](#testing-and-demos)
 
 ## Introduction
 
@@ -138,7 +131,7 @@ The following sections detail how to obtain, build, deploy and test the DLB devi
 
 Examples are provided showing how to deploy the plugin either using a DaemonSet or by hand on a per-node basis.
 
-### Deploy with pre-built container image
+### Pre-built Images
 
 [Pre-built images](https://hub.docker.com/r/intel/intel-dlb-plugin)
 of this component are available on the Docker hub. These images are automatically built and uploaded
@@ -149,74 +142,15 @@ release version numbers in the format `x.y.z`, corresponding to the branches and
 repository. Thus the easiest way to deploy the plugin in your cluster is to run this command
 
 ```bash
-$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/dlb_plugin?ref=<REF>
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/dlb_plugin?ref=<RELEASE_VERSION>
 daemonset.apps/intel-dlb-plugin created
 ```
 
-Where `<REF>` needs to be substituted with the desired git ref, e.g. `main`.
+Where `<RELEASE_VERSION>` needs to be substituted with the desired [release tag](https://github.com/intel/intel-device-plugins-for-kubernetes/tags) or `main` to get `devel` images.
 
-Nothing else is needed. But if you want to deploy a customized version of the plugin read further.
+Nothing else is needed. See [the development guide](../../DEVEL.md) for details if you want to deploy a customized version of the plugin.
 
-### Getting the source code
-
-```bash
-$ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
-```
-
-### Deploying as a DaemonSet
-
-To deploy the dlb plugin as a daemonset, you first need to build a container image for the
-plugin and ensure that is visible to your nodes.
-
-#### Build the plugin image
-
-The following will use `docker` to build a local container image called
-`intel/intel-dlb-plugin` with the tag `devel`.
-
-The image build tool can be changed from the default `docker` by setting the `BUILDER` argument
-to the [`Makefile`](Makefile).
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make intel-dlb-plugin
-...
-Successfully tagged intel/intel-dlb-plugin:devel
-```
-
-#### Deploy plugin DaemonSet
-
-You can then use the [example DaemonSet YAML](/deployments/dlb_plugin/base/intel-dlb-plugin.yaml)
-file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
-
-```bash
-$ kubectl apply -k deployments/dlb_plugin
-daemonset.apps/intel-dlb-plugin created
-```
-
-### Deploy by hand
-
-For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
-In this case, you do not need to build the complete container image, and can build just the plugin.
-
-#### Build the plugin
-
-First we build the plugin:
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make dlb_plugin
-```
-
-#### Run the plugin as administrator
-
-Now we can run the plugin directly on the node:
-
-```bash
-$ sudo -E ${INTEL_DEVICE_PLUGINS_SRC}/cmd/dlb_plugin/dlb_plugin
-```
-
-### Verify plugin registration
+### Verify Plugin Registration
 
 You can verify the plugin has been registered with the expected nodes by searching for the relevant
 resource allocation status on the nodes:
@@ -228,7 +162,7 @@ master
   dlb.intel.com/vf: 4
 ```
 
-### Testing the plugin
+## Testing and Demos
 
 We can test the plugin is working by deploying the provided example test images (dlb-libdlb-demo and dlb-dpdk-demo).
 

--- a/cmd/dsa_plugin/README.md
+++ b/cmd/dsa_plugin/README.md
@@ -4,16 +4,9 @@ Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
-    * [Deploy with pre-built container image](#deploy-with-pre-built-container-image)
-    * [Getting the source code](#getting-the-source-code)
-    * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
-        * [Build the plugin image](#build-the-plugin-image)
-        * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)
-    * [Deploy by hand](#deploy-by-hand)
-        * [Build the plugin](#build-the-plugin)
-        * [Run the plugin as administrator](#run-the-plugin-as-administrator)
-    * [Verify plugin registration](#verify-plugin-registration)
-    * [Testing the plugin](#testing-the-plugin)
+    * [Pre-built Images](#pre-built-images)
+    * [Verify Plugin Registration](#verify-plugin-registration)
+* [Testing and Demos](#testing-and-demos)
 
 ## Introduction
 
@@ -25,11 +18,9 @@ The DSA plugin and operator optionally support provisioning of DSA devices and w
 
 ## Installation
 
-The following sections detail how to obtain, build, deploy and test the DSA device plugin.
+The following sections detail how to use the DSA device plugin.
 
-Examples are provided showing how to deploy the plugin either using a DaemonSet or by hand on a per-node basis.
-
-### Deploy with pre-built container image
+### Pre-built Images
 
 [Pre-built images](https://hub.docker.com/r/intel/intel-dsa-plugin)
 of this component are available on the Docker hub. These images are automatically built and uploaded
@@ -40,25 +31,23 @@ release version numbers in the format `x.y.z`, corresponding to the branches and
 repository. Thus the easiest way to deploy the plugin in your cluster is to run this command
 
 ```bash
-$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/dsa_plugin?ref=<REF>
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/dsa_plugin?ref=<RELEASE_VERSION>
 daemonset.apps/intel-dsa-plugin created
 ```
 
-Where `<REF>` needs to be substituted with the desired git ref, e.g. `main`.
+Where `<RELEASE_VERSION>` needs to be substituted with the desired [release tag](https://github.com/intel/intel-device-plugins-for-kubernetes/tags) or `main` to get `devel` images.
 
-Nothing else is needed. But if you want to deploy a customized version of the plugin read further.
+Nothing else is needed. See [the development guide](../../DEVEL.md) for details if you want to deploy a customized version of the plugin.
 
-### Deploy with initcontainer
+#### Automatic Provisioning
 
-There's a sample [DSA initcontainer](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/build/docker/intel-idxd-config-initcontainer.Dockerfile) included that provisions DSA devices and workqueues (1 engine / 1 group / 1 wq (user/dedicated)), to deploy:
+There's a sample [idxd initcontainer](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/build/docker/intel-idxd-config-initcontainer.Dockerfile) included that provisions DSA devices and workqueues (1 engine / 1 group / 1 wq (user/dedicated)), to deploy:
 
 ```bash
 $ kubectl apply -k deployments/dsa_plugin/overlays/dsa_initcontainer/
 ```
 
 The provisioning [script](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/demo/idxd-init.sh) and [template](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/demo/dsa.conf) are available for customization.
-
-### Deploy with initcontainer and provisioning config in the ConfigMap
 
 The provisioning config can be optionally stored in the ProvisioningConfig configMap which is then passed to initcontainer through the volume mount.
 
@@ -70,68 +59,7 @@ To create a custom provisioning config:
 $ kubectl create configmap --namespace=inteldeviceplugins-system intel-dsa-config --from-file=demo/dsa.conf
 ```
 
-### Getting the source code
-
-```bash
-$ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
-```
-
-### Deploying as a DaemonSet
-
-To deploy the dsa plugin as a daemonset, you first need to build a container image for the
-plugin and ensure that is visible to your nodes.
-
-#### Build the plugin image
-
-The following will use `docker` to build a local container image called
-`intel/intel-dsa-plugin` with the tag `devel`.
-
-The image build tool can be changed from the default `docker` by setting the `BUILDER` argument
-to the [`Makefile`](Makefile).
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make intel-dsa-plugin
-...
-Successfully tagged intel/intel-dsa-plugin:devel
-```
-
-#### Deploy plugin DaemonSet
-
-You can then use the [example DaemonSet YAML](/deployments/dsa_plugin/base/intel-dsa-plugin.yaml)
-file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
-
-```bash
-$ kubectl apply -k deployments/dsa_plugin
-daemonset.apps/intel-dsa-plugin created
-```
-
-### Deploy by hand
-
-For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
-In this case, you do not need to build the complete container image, and can build just the plugin.
-
-#### Build the plugin
-
-First we build the plugin:
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make dsa_plugin
-```
-
-#### Run the plugin as administrator
-
-Now we can run the plugin directly on the node:
-
-```bash
-$ sudo -E ${INTEL_DEVICE_PLUGINS_SRC}/cmd/dsa_plugin/dsa_plugin
-device-plugin registered
-```
-
-### Verify plugin registration
-
+### Verify Plugin Registration
 You can verify the plugin has been registered with the expected nodes by searching for the relevant
 resource allocation status on the nodes:
 
@@ -145,7 +73,7 @@ node1
  dsa.intel.com/wq-user-shared: 20
 ```
 
-### Testing the plugin
+## Testing and Demos
 
 We can test the plugin is working by deploying the provided example accel-config test image.
 

--- a/cmd/fpga_crihook/README.md
+++ b/cmd/fpga_crihook/README.md
@@ -4,9 +4,6 @@ Table of Contents
 
 * [Introduction](#introduction)
 * [Dependencies](#dependencies)
-* [Building](#building)
-    * [Getting the source code](#getting-the-source-code)
-    * [Building the image](#building-the-image)
 * [Configuring CRI-O](#configuring-cri-o)
 
 ## Introduction
@@ -40,26 +37,7 @@ install the following:
 All components have the same basic dependencies as the
 [generic plugin framework dependencies](../../README.md#about)
 
-## Building
-
-The following sections detail how to obtain, build and deploy the CRI-O
-prestart hook.
-
-### Getting the source code
-
-```bash
-$ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
-```
-
-### Building the image
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make intel-fpga-initcontainer
-...
-Successfully tagged intel/intel-fpga-initcontainer:devel
-```
+See [the development guide](../../DEVEL.md) for details if you want to deploy a customized version of the CRI hook.
 
 ## Configuring CRI-O
 

--- a/cmd/fpga_plugin/README.md
+++ b/cmd/fpga_plugin/README.md
@@ -3,19 +3,12 @@
 Table of Contents
 
 * [Introduction](#introduction)
-* [Component overview](#component-overview)
-* [FPGA modes](#fpga-modes)
+    * [Component overview](#component-overview)
+* [Modes and Configuration Options](#modes-and-configuration-options)
 * [Installation](#installation)
-    * [Pre-built images](#pre-built-images)
-    * [Dependencies](#dependencies)
-    * [Getting the source code](#getting-the-source-code)
-    * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
-        * [Verify plugin registration](#verify-plugin-registration)
-        * [Building the plugin image](#building-the-plugin-image)
-    * [Deploy by hand](#deploy-by-hand)
-        * [Build FPGA device plugin](#build-fpga-device-plugin)
-        * [Run FPGA device plugin in af mode](#run-fpga-device-plugin-in-af-mode)
-        * [Run FPGA device plugin in region mode](#run-fpga-device-plugin-in-region-mode)
+    * [Prerequisites](#prerequisites)
+    * [Pre-built Images](#pre-built-images)
+    * [Verify Plugin Registration](#verify-plugin-registration)
 
 ## Introduction
 
@@ -37,7 +30,7 @@ The components together implement the following features:
 - orchestration of FPGA programming
 - access control for FPGA hardware
 
-## Component overview
+### Component overview
 
 The following components are part of this repository, and work together to support Intel FPGAs under
 Kubernetes:
@@ -70,7 +63,7 @@ Kubernetes:
 The repository also contains an [FPGA helper tool](../fpga_tool/README.md) that may be useful during
 development, initial deployment and debugging.
 
-## FPGA modes
+### Modes and Configuration options
 
 The FPGA plugin set can run in one of two modes:
 
@@ -97,33 +90,9 @@ af mode:
 
 ## Installation
 
-The below sections cover how to obtain, build and install this component.
+The below sections cover how to use this component.
 
-Components can generally be installed either using DaemonSets or running them
-'by hand' on each node.
-
-### Pre-built images
-
-Pre-built images of the components are available on the [Docker hub](https://hub.docker.com/u/intel).
-These images are automatically built and uploaded to the hub from the latest `main` branch of
-this repository.
-
-Release tagged images of the components are also available on the Docker hub, tagged with their
-release version numbers (of the form `x.y.z`, matching the branch/tag release number in this repo).
-
-The deployment YAML files supplied with these components in this repository use the images with the
-`devel` tag by default. If you do not build your own local images, then your Kubernetes cluster may
-pull down the `devel` images from the Docker hub by default.
-
-To use the release tagged versions of the images, edit the YAML deployment files appropriately.
-
-The following images are available on the Docker hub:
-
-- [The FPGA plugin](https://hub.docker.com/r/intel/intel-fpga-plugin)
-- [The FPGA admisson webhook](https://hub.docker.com/r/intel/intel-fpga-admissionwebhook)
-- [The FPGA CRI-O prestart hook (in the `initcontainer` image)](https://hub.docker.com/r/intel/intel-fpga-initcontainer)
-
-### Dependencies
+### Prerequisites
 
 All components have the same basic dependencies as the
 [generic plugin framework dependencies](../../README.md#about)
@@ -153,18 +122,6 @@ which is present and thus to use:
 Install this component (FPGA device plugin) first, and then follow the links
 and instructions to install the other components.
 
-### Getting the source code
-
-To obtain the YAML files used for deployment, or to obtain the source tree if you intend to
-do a hand-deployment or build your own image, you will require access to the source code:
-
-```bash
-$ export INTEL_DEVICE_PLUGINS_SRC=/path/to/intel-device-plugins-for-kubernetes
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes ${INTEL_DEVICE_PLUGINS_SRC}
-```
-
-### Deploying as a DaemonSet
-
 The FPGA webhook deployment depends on having [cert-manager](https://cert-manager.io/)
 installed. See its installation instructions [here](https://cert-manager.io/docs/installation/kubectl/).
 
@@ -177,9 +134,24 @@ cert-manager-webhook-64dc9fff44-29cfc     1/1     Running   0          1m
 
 ```
 
+### Pre-built Images
+
+Pre-built images of the components are available on the [Docker hub](https://hub.docker.com/u/intel).
+These images are automatically built and uploaded to the hub from the latest `main` branch of
+this repository.
+
+Release tagged images of the components are also available on the Docker hub, tagged with their
+release version numbers (of the form `x.y.z`, matching the branch/tag release number in this repo).
+
+The following images are available on the Docker hub:
+
+- [The FPGA plugin](https://hub.docker.com/r/intel/intel-fpga-plugin)
+- [The FPGA admisson webhook](https://hub.docker.com/r/intel/intel-fpga-admissionwebhook)
+- [The FPGA CRI-O prestart hook (in the `initcontainer` image)](https://hub.docker.com/r/intel/intel-fpga-initcontainer)
+
 Depending on the FPGA mode, run either
 ```bash
-$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/fpga_plugin/overlays/af
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/fpga_plugin/overlays/af?ref=<RELEASE_VERSION>
 namespace/intelfpgaplugin-system created
 customresourcedefinition.apiextensions.k8s.io/acceleratorfunctions.fpga.intel.com created
 customresourcedefinition.apiextensions.k8s.io/fpgaregions.fpga.intel.com created
@@ -196,7 +168,7 @@ issuer.cert-manager.io/intelfpgaplugin-selfsigned-issuer created
 ```
 or
 ```bash
-$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/fpga_plugin/overlays/region
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/fpga_plugin/overlays/region?ref=<RELEASE_VERSION>
 namespace/intelfpgaplugin-system created
 customresourcedefinition.apiextensions.k8s.io/acceleratorfunctions.fpga.intel.com created
 customresourcedefinition.apiextensions.k8s.io/fpgaregions.fpga.intel.com created
@@ -211,6 +183,9 @@ daemonset.apps/intelfpgaplugin-fpgadeviceplugin created
 certificate.cert-manager.io/intelfpgaplugin-serving-cert created
 issuer.cert-manager.io/intelfpgaplugin-selfsigned-issuer created
 ```
+
+Where `<RELEASE_VERSION>` needs to be substituted with the desired [release tag](https://github.com/intel/intel-device-plugins-for-kubernetes/tags) or `main` to get `devel` images.
+
 The command should result in two pods running:
 ```bash
 $ kubectl get pods -n intelfpgaplugin-system
@@ -218,12 +193,6 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 intelfpgaplugin-fpgadeviceplugin-skcw5     1/1     Running   0          57s
 intelfpgaplugin-webhook-7d6bcb8b57-k52b9   1/1     Running   0          57s
 ```
-
-If you intend to deploy your own image, you will need to reference the
-[image build section](#build-the-plugin-image) first.
-
-If you do not want to deploy the `devel` or release tagged image, you will need to create your
-own kustomization overlay referencing your required image.
 
 If you need the FPGA plugin on some nodes to operate in a different mode then add this
 annotation to the nodes:
@@ -241,7 +210,7 @@ And restart the pods on the nodes.
 > also deploys the [FPGA CRI-O hook](../fpga_crihook/README.md) `initcontainer` image, but it will be
 > benign (un-used) when running the FPGA plugin in `af` mode.
 
-#### Verify plugin registration
+#### Verify Plugin Registration
 
 Verify the FPGA plugin has been deployed on the nodes. The below shows the output
 you can expect in `region` mode, but similar output should be expected for `af`
@@ -253,76 +222,7 @@ fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
 fpga.intel.com/region-ce48969398f05f33946d560708be108a:  1
 ```
 
-#### Building the plugin image
-
-If you need to build your own image from sources, and are not using the images
-available on the Docker Hub, follow the below details.
-
 > **Note:** The FPGA plugin [DaemonSet YAML](/deployments/fpga_plugin/fpga_plugin.yaml)
 > also deploys the [FPGA CRI-O hook](../fpga_crihook/README.md) `initcontainer` image as well. You may
 > also wish to build that image locally before deploying the FPGA plugin to avoid deploying
 > the Docker hub default image.
-
-The following will use `docker` to build a local container image called
-`intel/intel-fpga-plugin` with the tag `devel`.
-The image build tool can be changed from the default docker by setting the `BUILDER` argument
-to the [Makefile](/Makefile).
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make intel-fpga-plugin
-...
-Successfully tagged intel/intel-fpga-plugin:devel
-```
-
-This image launches `fpga_plugin` in `af` mode by default.
-
-To use your own container image, create you own kustomization overlay patching
-[`deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml`](/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml)
-file.
-
-### Deploy by hand
-
-For development purposes, it is sometimes convenient to deploy the plugin 'by hand'
-on a node. In this case, you do not need to build the complete container image,
-and can build just the plugin.
-
-> **Note:** The FPGA plugin has a number of other associated items that may also need
-> to be configured or installed. It is recommended you reference the actions of the
-> DaemonSet YAML deployment for more details.
-
-#### Build FPGA device plugin
-
-When deploying by hand, you only need to build the plugin itself, and not the whole
-container image:
-
-```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make fpga_plugin
-```
-
-#### Run FPGA device plugin in af mode
-
-```bash
-$ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
-$ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E ${INTEL_DEVICE_PLUGINS_SRC}/cmd/fpga_plugin/fpga_plugin -mode af -kubeconfig $KUBE_CONF
-FPGA device plugin started in af mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-af-f7df405cbd7acf7222f144b0b93acd18.sock
-device-plugin registered
-```
-
-> **Note**: It is also possible to run the FPGA device plugin using a non-root user. To do this,
-the nodes' DAC rules must be configured to device plugin socket creation and kubelet registration.
-Furthermore, the deployments `securityContext` must be configured with appropriate `runAsUser/runAsGroup`.
-
-#### Run FPGA device plugin in region mode
-
-```bash
-$ export KUBE_CONF=/var/run/kubernetes/admin.kubeconfig # path to kubeconfig with admin's credentials
-$ export NODE_NAME="<node name>" # if the node's name was overridden and differs from hostname
-$ sudo -E ${INTEL_DEVICE_PLUGINS_SRC}/cmd/fpga_plugin/fpga_plugin -mode region -kubeconfig $KUBE_CONF
-FPGA device plugin started in region mode
-device-plugin start server at: /var/lib/kubelet/device-plugins/fpga.intel.com-region-ce48969398f05f33946d560708be108a.sock
-device-plugin registered
-```

--- a/cmd/iaa_plugin/README.md
+++ b/cmd/iaa_plugin/README.md
@@ -4,17 +4,9 @@ Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
-    * [Deploy with pre-built container image](#deploy-with-pre-built-container-image)
-    * [Getting the source code](#getting-the-source-code)
-    * [Verify node kubelet config](#verify-node-kubelet-config)
-    * [Deploying as a DaemonSet](#deploying-as-a-daemonset)
-        * [Build the plugin image](#build-the-plugin-image)
-        * [Deploy plugin DaemonSet](#deploy-plugin-daemonset)
-    * [Deploy by hand](#deploy-by-hand)
-        * [Build the plugin](#build-the-plugin)
-        * [Run the plugin as administrator](#run-the-plugin-as-administrator)
+    * [Pre-built images](#pre-built-images)
     * [Verify plugin registration](#verify-plugin-registration)
-    * [Testing the plugin](#testing-the-plugin)
+* [Testing and Demos](#testing-and-demos)
 
 ## Introduction
 
@@ -26,42 +18,28 @@ The IAA plugin and operator optionally support provisioning of IAA devices and w
 
 ## Installation
 
-The following sections detail how to obtain, build, deploy and test the IAA device plugin.
+The following sections detail how to use the IAA device plugin.
 
-### Getting the source code
+### Pre-built Images
 
-```bash
-$ git clone https://github.com/intel/intel-device-plugins-for-kubernetes
-```
+[Pre-built images](https://hub.docker.com/r/intel/intel-iaa-plugin)
+of this component are available on the Docker hub. These images are automatically built and uploaded
+to the hub from the latest main branch of this repository.
 
-### Deploying as a DaemonSet
-
-To deploy the IAA plugin as a daemonset, you first need to build a container image for the
-plugin and ensure that is visible to your nodes.
-
-#### Build the plugin image
-
-The following will use `docker` to build a local container image called
-`intel/intel-iaa-plugin` with the tag `devel`.
+Release tagged images of the components are also available on the Docker hub, tagged with their
+release version numbers in the format `x.y.z`, corresponding to the branches and releases in this
+repository. Thus the easiest way to deploy the plugin in your cluster is to run this command
 
 ```bash
-$ cd ${INTEL_DEVICE_PLUGINS_SRC}
-$ make intel-iaa-plugin
-...
-Successfully tagged intel/intel-iaa-plugin:devel
-```
-
-#### Deploy plugin DaemonSet
-
-You can then use the [example DaemonSet YAML](/deployments/iaa_plugin/base/intel-iaa-plugin.yaml)
-file provided to deploy the plugin. The default kustomization that deploys the YAML as is:
-
-```bash
-$ kubectl apply -k deployments/iaa_plugin
+$ kubectl apply -k https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/iaa_plugin?ref=<RELEASE_VERSION>
 daemonset.apps/intel-iaa-plugin created
 ```
 
-### Deploy with initcontainer
+Where `<RELEASE_VERSION>` needs to be substituted with the desired [release tag](https://github.com/intel/intel-device-plugins-for-kubernetes/tags) or `main` to get `devel` images.
+
+Nothing else is needed. See [the development guide](../../DEVEL.md) for details if you want to deploy a customized version of the plugin.
+
+#### Automatic Provisioning
 
 There's a sample [idxd initcontainer](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/build/docker/intel-idxd-initcontainer.Dockerfile) included that provisions IAA devices and workqueues (1 engine / 1 group / 1 wq (user/dedicated)), to deploy:
 
@@ -70,8 +48,6 @@ $ kubectl apply -k deployments/iaa_plugin/overlays/iaa_initcontainer/
 ```
 
 The provisioning [script](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/demo/idxd-init.sh) and [template](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/demo/iaa.conf) are available for customization.
-
-### Deploy with initcontainer and provisioning config in the ConfigMap
 
 The provisioning config can be optionally stored in the ProvisioningConfig configMap which is then passed to initcontainer through the volume mount.
 
@@ -83,29 +59,7 @@ To create a custom provisioning config:
 $ kubectl create configmap --namespace=inteldeviceplugins-system intel-iaa-config --from-file=demo/iaa.conf
 ```
 
-### Deploy by hand
-
-For development purposes, it is sometimes convenient to deploy the plugin 'by hand' on a node.
-In this case, you do not need to build the complete container image, and can build just the plugin.
-
-#### Build the plugin
-
-First we build the plugin:
-
-```bash
-$ make iaa_plugin
-```
-
-#### Run the plugin as administrator
-
-Now we can run the plugin directly on the node:
-
-```bash
-$ sudo -E ./cmd/iaa_plugin/iaa_plugin
-device-plugin registered
-```
-
-### Verify plugin registration
+### Verify Plugin Registration
 
 You can verify the plugin has been registered with the expected nodes by searching for the relevant
 resource allocation status on the nodes:
@@ -120,7 +74,7 @@ node1
  iaa.intel.com/wq-user-shared: 30
 ```
 
-### Testing the plugin
+## Testing and Demos
 
 We can test the plugin is working by deploying the provided example iaa-qpl-demo test image.
 


### PR DESCRIPTION
Currently, each individual plugin README documents roughly the same
daily development steps to git clone, build, and deploy. Re-purpose
the plugin READMEs more towards cluster admin type of documentation
and start moving all development related documentation to DEVEL.md.

The same is true for e2e testing documentation which is scattered
in places where they don't belong to. Having all day-to-day
development Howtos is good to have in a centralized place.

Finally, the cleanup includes some harmonization to plugins'
table of contents which now follows the pattern:

* [Introduction](#introduction)
(* [Modes and Configuration Options](#modes-and-configuration-options))
* [Installation](#installation)
    (* [Prerequisites](#prerequisites))
    * [Pre-built Images](#pre-built-images)
    * [Verify Plugin Registration](#verify-plugin-registration)
* [Testing and Demos](#testing-and-demos)
    * ...

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>