### PR TITLE
e2e: Remove unnecessary namespace arguments from KubectlOrDie calls

### DIFF
--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -50,7 +50,7 @@ func describe() {
 
 	ginkgo.It("runs DLB plugin and a demo workload", func() {
 		ginkgo.By("deploying DLB plugin")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
 		ginkgo.By("waiting for DLB plugin's availability")
 		if _, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,
@@ -76,7 +76,7 @@ func describe() {
 			podName := strings.TrimSuffix(filepath.Base(yaml), filepath.Ext(yaml))
 
 			ginkgo.By("submitting a pod requesting DLB " + function + " resources")
-			framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-f", demoPath)
+			framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 			ginkgo.By("waiting for the DLB demo to succeed")
 			f.PodClient().WaitForSuccess(podName, 200*time.Second)

--- a/test/e2e/dsa/dsa.go
+++ b/test/e2e/dsa/dsa.go
@@ -59,9 +59,9 @@ func describe() {
 
 	ginkgo.It("runs DSA plugin and a demo workload", func() {
 		ginkgo.By("deploying DSA plugin")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "create", "configmap", "intel-dsa-config", "--from-file="+configmap)
+		framework.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "intel-dsa-config", "--from-file="+configmap)
 
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
 		ginkgo.By("waiting for DSA plugin's availability")
 		if _, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,
@@ -76,7 +76,7 @@ func describe() {
 			framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
 		}
 
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-f", demoPath)
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 		ginkgo.By("waiting for the DSA demo to succeed")
 		f.PodClient().WaitForSuccess(podName, 200*time.Second)

--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -88,7 +88,7 @@ func runTestCase(fmw *framework.Framework, pluginKustomizationPath, mappingsColl
 	framework.RunKubectlOrDie(fmw.Namespace.Name, "apply", "-k", tmpDir)
 
 	ginkgo.By("deploying mappings")
-	framework.RunKubectlOrDie(fmw.Namespace.Name, "apply", "-n", fmw.Namespace.Name, "-f", mappingsCollectionPath)
+	framework.RunKubectlOrDie(fmw.Namespace.Name, "apply", "-f", mappingsCollectionPath)
 
 	waitForPod(fmw, "intel-fpga-plugin")
 
@@ -112,7 +112,7 @@ func runTestCase(fmw *framework.Framework, pluginKustomizationPath, mappingsColl
 	// If WaitForSuccess fails, ginkgo doesn't show the logs of the failed container.
 	// Replacing WaitForSuccess with WaitForFinish + 'kubelet logs' would show the logs
 	//fmw.PodClient().WaitForFinish(pod.ObjectMeta.Name, 60*time.Second)
-	//framework.RunKubectlOrDie(fmw.Namespace.Name, "--namespace", fmw.Namespace.Name, "logs", pod.ObjectMeta.Name)
+	//framework.RunKubectlOrDie(fmw.Namespace.Name, "logs", pod.ObjectMeta.Name)
 
 	ginkgo.By("submitting a pod requesting incorrect FPGA resources")
 

--- a/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
+++ b/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
@@ -77,7 +77,7 @@ func checkPodMutation(f *framework.Framework, mappingsNamespace string, source, 
 	_ = utils.DeployWebhook(f, kustomizationPath)
 
 	ginkgo.By("deploying mappings")
-	framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-n", mappingsNamespace, "-f", filepath.Dir(kustomizationPath)+"/../mappings-collection.yaml")
+	framework.RunKubectlOrDie(mappingsNamespace, "apply", "-f", filepath.Dir(kustomizationPath)+"/../mappings-collection.yaml")
 
 	ginkgo.By("submitting a pod for admission")
 

--- a/test/e2e/gpu/gpu.go
+++ b/test/e2e/gpu/gpu.go
@@ -53,7 +53,7 @@ func describe() {
 
 	ginkgo.It("checks availability of GPU resources", func() {
 		ginkgo.By("deploying GPU plugin")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
 		ginkgo.By("waiting for GPU plugin's availability")
 		if _, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,

--- a/test/e2e/iaa/iaa.go
+++ b/test/e2e/iaa/iaa.go
@@ -59,9 +59,9 @@ func describe() {
 
 	ginkgo.It("runs IAA plugin and a demo workload", func() {
 		ginkgo.By("deploying IAA plugin")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "create", "configmap", "intel-iaa-config", "--from-file="+configmap)
+		framework.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "intel-iaa-config", "--from-file="+configmap)
 
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
 		ginkgo.By("waiting for IAA plugin's availability")
 		if _, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,
@@ -76,7 +76,7 @@ func describe() {
 			framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
 		}
 
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-f", demoPath)
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 		ginkgo.By("waiting for the IAA demo to succeed")
 		f.PodClient().WaitForSuccess(podName, 200*time.Second)

--- a/test/e2e/qat/qatplugin_dpdk.go
+++ b/test/e2e/qat/qatplugin_dpdk.go
@@ -58,7 +58,7 @@ func describeQatDpdkPlugin() {
 
 	ginkgo.It("measures performance of DPDK", func() {
 		ginkgo.By("deploying QAT plugin in DPDK mode")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
 		ginkgo.By("waiting for QAT plugin's availability")
 		podList, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,
@@ -80,13 +80,13 @@ func describeQatDpdkPlugin() {
 		}
 
 		ginkgo.By("submitting a crypto pod requesting QAT resources")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(cryptoTestYamlPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(cryptoTestYamlPath))
 
 		ginkgo.By("waiting the crypto pod to finnish successfully")
 		f.PodClient().WaitForSuccess("qat-dpdk-test-crypto-perf-tc1", 60*time.Second)
 
 		ginkgo.By("submitting a compress pod requesting QAT resources")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "apply", "-k", filepath.Dir(compressTestYamlPath))
+		framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(compressTestYamlPath))
 
 		ginkgo.By("waiting the compress pod to finnish successfully")
 		f.PodClient().WaitForSuccess("qat-dpdk-test-compress-perf-tc1", 60*time.Second)

--- a/test/e2e/qat/qatplugin_kernel.go
+++ b/test/e2e/qat/qatplugin_kernel.go
@@ -50,7 +50,7 @@ func describeQatKernelPlugin() {
 
 	ginkgo.It("checks availability of QAT resources", func() {
 		ginkgo.By("deploying QAT plugin in kernel mode")
-		framework.RunKubectlOrDie(f.Namespace.Name, "--namespace", f.Namespace.Name, "create", "-f", yamlPath)
+		framework.RunKubectlOrDie(f.Namespace.Name, "create", "-f", yamlPath)
 
 		ginkgo.By("waiting for QAT plugin's availability")
 		if _, err := e2epod.WaitForPodsWithLabelRunningReady(f.ClientSet, f.Namespace.Name,


### PR DESCRIPTION
Signed-off-by: Tuomas Katila <tuomas.katila@intel.com>