### PR TITLE
sgx: send nil TopologyInfo

### DIFF
--- a/cmd/sgx_plugin/sgx_plugin.go
+++ b/cmd/sgx_plugin/sgx_plugin.go
@@ -87,13 +87,13 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 	for i := uint(0); i < dp.nEnclave; i++ {
 		devID := fmt.Sprintf("%s-%d", "sgx-enclave", i)
 		nodes := []pluginapi.DeviceSpec{{HostPath: sgxEnclavePath, ContainerPath: sgxEnclavePath, Permissions: "rw"}}
-		devTree.AddDevice(deviceTypeEnclave, devID, dpapi.NewDeviceInfo(pluginapi.Healthy, nodes, nil, nil, nil))
+		devTree.AddDevice(deviceTypeEnclave, devID, dpapi.NewDeviceInfoWithTopologyHints(pluginapi.Healthy, nodes, nil, nil, nil, nil))
 	}
 
 	for i := uint(0); i < dp.nProvision; i++ {
 		devID := fmt.Sprintf("%s-%d", "sgx-provision", i)
 		nodes := []pluginapi.DeviceSpec{{HostPath: sgxProvisionPath, ContainerPath: sgxProvisionPath, Permissions: "rw"}}
-		devTree.AddDevice(deviceTypeProvision, devID, dpapi.NewDeviceInfo(pluginapi.Healthy, nodes, nil, nil, nil))
+		devTree.AddDevice(deviceTypeProvision, devID, dpapi.NewDeviceInfoWithTopologyHints(pluginapi.Healthy, nodes, nil, nil, nil, nil))
 	}
 
 	return devTree, nil


### PR DESCRIPTION
/dev/sgx_* cannot be mapped to any topology. SGX itself is topology
aware but we cannot control it with TopologyInfo.

Currently, pkg/topology returns empty TopologyInfo{Nodes:[]*NUMANode{}}
for /dev/sgx_* but kubelet TopologyManager (when enabled and with the
policy other than 'none') interpretes that as "Hint Provider has no
possible NUMA affinities for resource" and rejects the SGX resources.

What we want is "Hint Provider has no preference for NUMA affinity with
resource". This is communicated using nil TopologyInfo.

See: https://github.com/kubernetes/kubernetes/issues/112234

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>