### PR TITLE
ci: unify labeling for Simics jobs

### DIFF
--- a/.github/workflows/e2e-dlb.yml
+++ b/.github/workflows/e2e-dlb.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   e2e-dlb:
     name: e2e-dlb
-    runs-on: [self-hosted, linux, x64, dlb]
+    runs-on: [simics-spr]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-dsa.yml
+++ b/.github/workflows/e2e-dsa.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   e2e-dsa:
     name: e2e-dsa
-    runs-on: [self-hosted, linux, x64, dsa]
+    runs-on: [simics-spr]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-iaa.yml
+++ b/.github/workflows/e2e-iaa.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   e2e-iaa:
     name: e2e-iaa
-    runs-on: [self-hosted, linux, x64, iaa]
+    runs-on: [simics-spr]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-qat4.yml
+++ b/.github/workflows/e2e-qat4.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   e2e-qat4:
     name: e2e-qat4
-    runs-on: [self-hosted, linux, x64, dsa]
+    runs-on: [simics-spr]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
As we have unified Simics SPR targets and they can run any Simics jobs let's unify labels too to avoid confusing configurations similar to this:

```
name: e2e-qat4
-    runs-on: [dsa]
```

This unification also helps to spread the load among runners more effectively.