### PR TITLE
deployments: fix leader election RBAC rules

### DIFF
--- a/charts/operator/templates/operator.yaml
+++ b/charts/operator/templates/operator.yaml
@@ -17,19 +17,24 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - coordination.k8s.io
   resources:
-  - configmaps/status
+  - leases
   verbs:
   - get
+  - list
+  - watch
+  - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/fpga_admissionwebhook/rbac/leader_election_role.yaml
+++ b/deployments/fpga_admissionwebhook/rbac/leader_election_role.yaml
@@ -17,16 +17,21 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - coordination.k8s.io
   resources:
-  - configmaps/status
+  - leases
   verbs:
   - get
+  - list
+  - watch
+  - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
+  - patch

--- a/deployments/operator/rbac/leader_election_role.yaml
+++ b/deployments/operator/rbac/leader_election_role.yaml
@@ -17,16 +17,21 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
+  - coordination.k8s.io
   resources:
-  - configmaps/status
+  - leases
   verbs:
   - get
+  - list
+  - watch
+  - create
   - update
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
+  - patch


### PR DESCRIPTION
controller-runtime now defaults LeaderElectionResourceLock to leases and we had missed the migration to it properly.

Update the RBAC rules to get our controllers to write their leader election locks to leases.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>