### PR TITLE
Added selinux labels for GPU plugins

### DIFF
--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -18,6 +18,8 @@ spec:
         image: intel/intel-gpu-initcontainer:devel
         imagePullPolicy: IfNotPresent
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_init_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         volumeMounts:
@@ -33,6 +35,8 @@ spec:
         image: intel/intel-gpu-plugin:devel
         imagePullPolicy: IfNotPresent
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -196,6 +196,9 @@ func setInitContainer(spec *v1.PodSpec, imageName string) {
 			ImagePullPolicy: "IfNotPresent",
 			Name:            "intel-gpu-initcontainer",
 			SecurityContext: &v1.SecurityContext{
+				SELinuxOptions: &v1.SELinuxOptions{
+					Type: "container_device_plugin_init_t",
+				},
 				ReadOnlyRootFilesystem: &yes,
 			},
 			VolumeMounts: []v1.VolumeMount{

--- a/pkg/controllers/gpu/controller_test.go
+++ b/pkg/controllers/gpu/controller_test.go
@@ -79,6 +79,9 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							Image:           devicePlugin.Spec.Image,
 							ImagePullPolicy: "IfNotPresent",
 							SecurityContext: &v1.SecurityContext{
+								SELinuxOptions: &v1.SELinuxOptions{
+									Type: "container_device_plugin_t",
+								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
 							},


### PR DESCRIPTION
Added selinux labels for Intel GPU plugins. This runs the gpu container as container_device_plugin_t and gpu init container
as container_device_plugin_init_t.