### PR TITLE
e2e: run DSA and IAA jobs on SPR and GNR instances

### DIFF
--- a/.github/workflows/e2e-dsa.yml
+++ b/.github/workflows/e2e-dsa.yml
@@ -21,7 +21,11 @@ permissions:
 jobs:
   e2e-dsa:
     name: e2e-dsa
-    runs-on: [simics-spr]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [simics-spr, simics-gnr]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-iaa.yml
+++ b/.github/workflows/e2e-iaa.yml
@@ -21,7 +21,11 @@ permissions:
 jobs:
   e2e-iaa:
     name: e2e-iaa
-    runs-on: [simics-spr]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [simics-spr, simics-gnr]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- Converted DLB and IAA jobs into matrix jobs
- Added simics-gnr target to the jobs

Fixes: #1044