### PR TITLE
Use 'i915' instead of 'drm' kernel mod as requirement for gpu label

### DIFF
--- a/deployments/nfd/overlays/node-feature-rules/node-feature-rules-openshift.yaml
+++ b/deployments/nfd/overlays/node-feature-rules/node-feature-rules-openshift.yaml
@@ -55,7 +55,7 @@ spec:
             class: {op: In, value: ["0300", "0380"]}
         - feature: kernel.loadedmodule
           matchExpressions:
-            drm: {op: Exists}
+            i915: {op: Exists}
 
     - name: "intel.iaa"
       labels:

--- a/deployments/nfd/overlays/node-feature-rules/node-feature-rules.yaml
+++ b/deployments/nfd/overlays/node-feature-rules/node-feature-rules.yaml
@@ -59,7 +59,7 @@ spec:
             class: {op: In, value: ["0300", "0380"]}
         - feature: kernel.loadedmodule
           matchExpressions:
-            drm: {op: Exists}
+            i915: {op: Exists}
 
     - name: "intel.iaa"
       labels:


### PR DESCRIPTION
6.0.0 kernel doesn't seem to have 'drm' module anymore and it makes more sense to depend on the i915 module.

Signed-off-by: Tuomas Katila <tuomas.katila@intel.com>