### PR TITLE
gpu: add nodeSelector to fractional overlay

### DIFF
--- a/deployments/gpu_plugin/overlays/fractional_resources/add-nodeselector-intel-gpu.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/add-nodeselector-intel-gpu.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+spec:
+  template:
+    spec:
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"

--- a/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
@@ -8,3 +8,4 @@ patches:
   - path: add-serviceaccount.yaml
   - path: add-podresource-mount.yaml
   - path: add-args.yaml
+  - path: add-nodeselector-intel-gpu.yaml


### PR DESCRIPTION
Updated documentation indicates that fractional overlay uses nfd so maybe it should.

Signed-off-by: Tuomas Katila <tuomas.katila@intel.com>