### PR TITLE
align gpu kustomize object naming with operator naming

### DIFF
--- a/deployments/gpu_plugin/overlays/fractional_resources/add-serviceaccount.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/add-serviceaccount.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: resource-reader-sa
+      serviceAccountName: gpu-manager-sa

--- a/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-role.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: resource-reader
+  name: gpu-manager-role
 rules:
 - apiGroups: [""]
   resources: ["pods"]

--- a/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-rolebinding.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: resource-reader-rb
+  name: gpu-manager-rolebinding
 subjects:
 - kind: ServiceAccount
-  name: resource-reader-sa
+  name: gpu-manager-sa
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: resource-reader
+  name: gpu-manager-role
   apiGroup: rbac.authorization.k8s.io

--- a/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-sa.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/gpu-manager-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: resource-reader-sa
+  name: gpu-manager-sa

--- a/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
@@ -1,9 +1,9 @@
 bases:
   - ../../base
 resources:
-  - resource-cluster-role-binding.yaml
-  - resource-cluster-role.yaml
-  - resource-reader-sa.yaml
+  - gpu-manager-rolebinding.yaml
+  - gpu-manager-role.yaml
+  - gpu-manager-sa.yaml
 patches:
   - path: add-serviceaccount.yaml
   - path: add-podresource-mount.yaml


### PR DESCRIPTION
Operator has used "gpu-manager" as part of the cluster object names it creates. Kustomize based deployments can be aligned with that.

Signed-off-by: Ukri Niemimuukko <ukri.niemimuukko@intel.com>