### PR TITLE
release-0.24: trigger 0.24.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install terrascan
       run: |
-        curl -L "$(curl -s https://api.github.com/repos/accurics/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz")" > terrascan.tar.gz
+        curl -L "$(curl -s https://api.github.com/repos/tenable/terrascan/releases/latest | grep -o -E "https://.+?_Linux_x86_64.tar.gz")" > terrascan.tar.gz
         tar -xf terrascan.tar.gz terrascan && rm terrascan.tar.gz
         install terrascan /usr/local/bin && rm terrascan
     - name: Run Terrascan

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
         stage('make test-with-kind') {
           steps {
             dir(path: "$REPO_DIR") {
-              sh "make test-with-kind REG=intel/ TAG=0.24.0"
+              sh "make test-with-kind REG=intel/ TAG=0.24.1"
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean:
 
 ORG?=intel
 REG?=$(ORG)/
-TAG?=0.24.0
+TAG?=0.24.1
 export TAG
 
 e2e-fpga:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a framework for developing plugins for the Kubernetes
 [device plugins framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/),
 along with a number of device plugin implementations utilising that framework.
 
-The [v0.24 release](https://github.com/intel/intel-device-plugins-for-kubernetes/releases/latest)
+The [v0.24.1 release](https://github.com/intel/intel-device-plugins-for-kubernetes/releases/latest)
 is the latest feature release with its documentation available [here](https://intel.github.io/intel-device-plugins-for-kubernetes/0.24/).
 
 Table of Contents

--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-deviceplugin-operator'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® device plugin operator for Kubernetes'
 LABEL description='To simplify the deployment of the device plugins, a unified device plugins operator is implemented. Currently the operator has support for the QAT, GPU, FPGA, SGX, DSA and DLB device plugins. Each device plugin has its own custom resource definition (CRD) and the corresponding controller that watches CRUD operations to those custom resources.'

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-dlb-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® DLB device plugin for Kubernetes'
 LABEL description='The DLB device plugin supports Intel Dynamic Load Balancer accelerator(DLB)'

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-dsa-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® DSA device plugin for Kubernetes'
 LABEL description='The DSA device plugin supports acceleration using the Intel Data Streaming accelerator(DSA)'

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-admissionwebhook'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® FPGA admission controller webhook for Kubernetes'
 LABEL description='The FPGA admission controller webhook is responsible for performing mapping from user-friendly function IDs to the Interface ID and Bitstream ID that are required for FPGA programming. It also implements access control by namespacing FPGA configuration information'

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -78,7 +78,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-initcontainer'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® FPGA programming CRI hook for Kubernetes'
 LABEL description='The FPGA prestart CRI-O hook performs discovery of the requested FPGA function bitstream and programs FPGA devices based on the environment variables in the workload description'

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-fpga-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® FPGA device plugin for Kubernetes'
 LABEL description='The FPGA device plugin is responsible for discovering and reporting FPGA devices to kubelet'

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -69,7 +69,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-gpu-initcontainer'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® GPU NFD hook for Kubernetes'
 LABEL description='The GPU fractional resources, such as GPU memory is registered as a kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of GPU device plugin operator deployment and NFD is configured to register the GPU memory extended resource reported by the hook'

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-gpu-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® GPU device plugin for Kubernetes'
 LABEL description='The GPU device plugin provides access to Intel discrete (Xe) and integrated GPU HW device files'

--- a/build/docker/intel-iaa-plugin.Dockerfile
+++ b/build/docker/intel-iaa-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-iaa-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® IAA device plugin for Kubernetes'
 LABEL description='The IAA device plugin supports acceleration using the Intel Analytics accelerator(IAA)'

--- a/build/docker/intel-qat-initcontainer.Dockerfile
+++ b/build/docker/intel-qat-initcontainer.Dockerfile
@@ -46,7 +46,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-qat-initcontainer'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® QAT initcontainer for Kubernetes'
 LABEL description='Intel QAT initcontainer initializes devices'

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-qat-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® QAT device plugin for Kubernetes'
 LABEL description='The QAT plugin supports device plugin for Intel QAT adapters, and includes code showing deployment via DPDK'

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-admissionwebhook'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® SGX admission controller webhook for Kubernetes'
 LABEL description='The SGX admission webhook is responsible for performing Pod mutations based on the sgx.intel.com/quote-provider pod annotation set by the user. The purpose of the webhook is to hide the details of setting the necessary device resources and volume mounts for using SGX remote attestation in the cluster'

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -69,7 +69,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-initcontainer'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® SGX NFD hook for Kubernetes'
 LABEL description='The SGX EPC memory available on each node is registered as a Kubernetes extended resource using node-feature-discovery (NFD). A custom NFD source hook is installed as part of SGX device plugin operator deployment and NFD is configured to register the SGX EPC memory extended resource reported by the hook'

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -49,7 +49,7 @@ FROM ${FINAL_BASE}
 
 LABEL name='intel-sgx-plugin'
 LABEL vendor='Intel®'
-LABEL version=0.24.0
+LABEL version=0.24.1
 LABEL release='1'
 LABEL summary='Intel® SGX device plugin for Kubernetes'
 LABEL description='The SGX device plugin is responsible for discovering and reporting SGX device nodes to kubelet'

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,4 +3,4 @@ name: intel-device-plugins-operator
 description: A Helm chart for Intel Device Plugins Operator for Kubernetes
 type: application
 version: 0.1.0
-appVersion: "0.24.0"
+appVersion: "0.24.1"

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,4 +1,4 @@
 image:
   hub: intel
-  tag: "0.24.0"
+  tag: "0.24.1"
   pullPolicy: IfNotPresent

--- a/cmd/sgx_plugin/sgx_plugin.go
+++ b/cmd/sgx_plugin/sgx_plugin.go
@@ -94,13 +94,13 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 	for i := uint(0); i < dp.nEnclave; i++ {
 		devID := fmt.Sprintf("%s-%d", "sgx-enclave", i)
 		nodes := []pluginapi.DeviceSpec{{HostPath: sgxEnclavePath, ContainerPath: sgxEnclavePath, Permissions: "rw"}}
-		devTree.AddDevice(deviceTypeEnclave, devID, dpapi.NewDeviceInfo(pluginapi.Healthy, nodes, deprecatedMounts, nil, nil))
+		devTree.AddDevice(deviceTypeEnclave, devID, dpapi.NewDeviceInfoWithTopologyHints(pluginapi.Healthy, nodes, deprecatedMounts, nil, nil, nil))
 	}
 
 	for i := uint(0); i < dp.nProvision; i++ {
 		devID := fmt.Sprintf("%s-%d", "sgx-provision", i)
 		nodes := []pluginapi.DeviceSpec{{HostPath: sgxProvisionPath, ContainerPath: sgxProvisionPath, Permissions: "rw"}}
-		devTree.AddDevice(deviceTypeProvision, devID, dpapi.NewDeviceInfo(pluginapi.Healthy, nodes, deprecatedMounts, nil, nil))
+		devTree.AddDevice(deviceTypeProvision, devID, dpapi.NewDeviceInfoWithTopologyHints(pluginapi.Healthy, nodes, deprecatedMounts, nil, nil, nil))
 	}
 
 	return devTree, nil

--- a/demo/intelfpga-job.yaml
+++ b/demo/intelfpga-job.yaml
@@ -13,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: intelfpga-demo-job-1
-          image: intel/opae-nlb-demo:0.24.0
+          image: intel/opae-nlb-demo:0.24.1
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/demo/test-fpga-orchestrated.yaml
+++ b/demo/test-fpga-orchestrated.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: intel/opae-nlb-demo:0.24.0
+    image: intel/opae-nlb-demo:0.24.1
     imagePullPolicy: IfNotPresent
     securityContext:
       capabilities:

--- a/demo/test-fpga-preprogrammed.yaml
+++ b/demo/test-fpga-preprogrammed.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: intel/opae-nlb-demo:0.24.0
+    image: intel/opae-nlb-demo:0.24.1
     imagePullPolicy: IfNotPresent
     securityContext:
       capabilities:

--- a/deployments/dlb_plugin/base/intel-dlb-plugin.yaml
+++ b/deployments/dlb_plugin/base/intel-dlb-plugin.yaml
@@ -20,7 +20,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-dlb-plugin:0.24.0
+        image: intel/intel-dlb-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
+++ b/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
@@ -20,7 +20,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-dsa-plugin:0.24.0
+        image: intel/intel-dsa-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
+++ b/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
@@ -12,7 +12,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-idxd-config-initcontainer:0.24.0
+        image: intel/intel-idxd-config-initcontainer:0.24.1
         securityContext:
           readOnlyRootFilesystem: true
           privileged: true

--- a/deployments/fpga_admissionwebhook/manager/manager.yaml
+++ b/deployments/fpga_admissionwebhook/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - image: intel/intel-fpga-admissionwebhook:0.24.0
+      - image: intel/intel-fpga-admissionwebhook:0.24.1
         imagePullPolicy: IfNotPresent
         name: manager
         securityContext:

--- a/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml
+++ b/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
       - name: intel-fpga-initcontainer
-        image: intel/intel-fpga-initcontainer:0.24.0
+        image: intel/intel-fpga-initcontainer:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true
@@ -33,7 +33,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-fpga-plugin:0.24.0
+        image: intel/intel-fpga-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         args:
           - -mode=af

--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       initContainers:
       - name: intel-gpu-initcontainer
-        image: intel/intel-gpu-initcontainer:0.24.0
+        image: intel/intel-gpu-initcontainer:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-gpu-plugin:0.24.0
+        image: intel/intel-gpu-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
+++ b/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
@@ -20,7 +20,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-iaa-plugin:0.24.0
+        image: intel/intel-iaa-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/iaa_plugin/overlays/iaa_initcontainer/iaa_initcontainer.yaml
+++ b/deployments/iaa_plugin/overlays/iaa_initcontainer/iaa_initcontainer.yaml
@@ -14,7 +14,7 @@ spec:
                 fieldPath: spec.nodeName
           - name: IDXD_DEVICE_TYPE
             value: "iaa"
-        image: intel/intel-idxd-config-initcontainer:0.24.0
+        image: intel/intel-idxd-config-initcontainer:0.24.1
         securityContext:
           readOnlyRootFilesystem: true
           privileged: true

--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - image: intel/intel-deviceplugin-operator:0.24.0
+      - image: intel/intel-deviceplugin-operator:0.24.1
         imagePullPolicy: IfNotPresent
         name: manager
         resources:

--- a/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
+++ b/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Drivers and plugins
-    containerImage: intel/intel-deviceplugin-operator:0.24.0
+    containerImage: intel/intel-deviceplugin-operator:0.24.1
     createdAt: "2022-01-04"
     description: This operator is a Kubernetes custom controller whose goal is to
       serve the installation and lifecycle management of Intel device plugins for

--- a/deployments/operator/samples/deviceplugin_v1_dlbdeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_dlbdeviceplugin.yaml
@@ -9,7 +9,7 @@ metadata:
   # annotations:
   #   container.apparmor.security.beta.kubernetes.io/intel-dlb-plugin: unconfined
 spec:
-  image: intel/intel-dlb-plugin:0.24.0
+  image: intel/intel-dlb-plugin:0.24.1
   logLevel: 4
   nodeSelector:
     intel.feature.node.kubernetes.io/dlb: 'true'

--- a/deployments/operator/samples/deviceplugin_v1_dsadeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_dsadeviceplugin.yaml
@@ -3,7 +3,7 @@ kind: DsaDevicePlugin
 metadata:
   name: dsadeviceplugin-sample
 spec:
-  image: intel/intel-dsa-plugin:0.24.0
+  image: intel/intel-dsa-plugin:0.24.1
   sharedDevNum: 10
   logLevel: 4
   nodeSelector:

--- a/deployments/operator/samples/deviceplugin_v1_fpgadeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_fpgadeviceplugin.yaml
@@ -3,8 +3,8 @@ kind: FpgaDevicePlugin
 metadata:
   name: fpgadeviceplugin-sample
 spec:
-  image: intel/intel-fpga-plugin:0.24.0
-  initImage: intel/intel-fpga-initcontainer:0.24.0
+  image: intel/intel-fpga-plugin:0.24.1
+  initImage: intel/intel-fpga-initcontainer:0.24.1
   mode: region
   logLevel: 4
   nodeSelector:

--- a/deployments/operator/samples/deviceplugin_v1_gpudeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_gpudeviceplugin.yaml
@@ -3,8 +3,8 @@ kind: GpuDevicePlugin
 metadata:
   name: gpudeviceplugin-sample
 spec:
-  image: intel/intel-gpu-plugin:0.24.0
-  initImage: intel/intel-gpu-initcontainer:0.24.0
+  image: intel/intel-gpu-plugin:0.24.1
+  initImage: intel/intel-gpu-initcontainer:0.24.1
   sharedDevNum: 10
   logLevel: 4
   nodeSelector:

--- a/deployments/operator/samples/deviceplugin_v1_iaadeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_iaadeviceplugin.yaml
@@ -3,7 +3,7 @@ kind: IaaDevicePlugin
 metadata:
   name: iaadeviceplugin-sample
 spec:
-  image: intel/intel-iaa-plugin:0.24.0
+  image: intel/intel-iaa-plugin:0.24.1
   sharedDevNum: 10
   logLevel: 4
   # TODO: nodeSelector is supported and can be used once it becomes

--- a/deployments/operator/samples/deviceplugin_v1_qatdeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_qatdeviceplugin.yaml
@@ -9,8 +9,8 @@ metadata:
   # annotations:
   #   container.apparmor.security.beta.kubernetes.io/intel-qat-plugin: unconfined
 spec:
-  image: intel/intel-qat-plugin:0.24.0
-  initImage: intel/intel-qat-initcontainer:0.24.0
+  image: intel/intel-qat-plugin:0.24.1
+  initImage: intel/intel-qat-initcontainer:0.24.1
   dpdkDriver: vfio-pci
   kernelVfDrivers:
     - c6xxvf

--- a/deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml
@@ -3,8 +3,8 @@ kind: SgxDevicePlugin
 metadata:
   name: sgxdeviceplugin-sample
 spec:
-  image: intel/intel-sgx-plugin:0.24.0
-  initImage: intel/intel-sgx-initcontainer:0.24.0
+  image: intel/intel-sgx-plugin:0.24.1
+  initImage: intel/intel-sgx-initcontainer:0.24.1
   enclaveLimit: 110
   provisionLimit: 110
   logLevel: 4

--- a/deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml
+++ b/deployments/qat_dpdk_app/base/crypto-perf-dpdk-pod-requesting-qat.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: crypto-perf
-    image: intel/crypto-perf:0.24.0
+    image: intel/crypto-perf:0.24.1
     imagePullPolicy: IfNotPresent
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "while true; do sleep 300000; done;" ]

--- a/deployments/qat_plugin/base/intel-qat-kernel-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-kernel-plugin.yaml
@@ -19,7 +19,7 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           privileged: true
-        image: intel/intel-qat-plugin:0.24.0
+        image: intel/intel-qat-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         args: ["-mode", "kernel"]
         volumeMounts:

--- a/deployments/qat_plugin/base/intel-qat-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: intel-qat-plugin
-        image: intel/intel-qat-plugin:0.24.0
+        image: intel/intel-qat-plugin:0.24.1
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/deployments/qat_plugin/overlays/sriov_numvfs/sriov_numvfs_init.yaml
+++ b/deployments/qat_plugin/overlays/sriov_numvfs/sriov_numvfs_init.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
       - name: sriov-numvfs
-        image: intel/intel-qat-initcontainer:0.24.0
+        image: intel/intel-qat-initcontainer:0.24.1
         securityContext:
           readOnlyRootFilesystem: true
           privileged: true

--- a/deployments/sgx_admissionwebhook/manager/manager.yaml
+++ b/deployments/sgx_admissionwebhook/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - image: intel/intel-sgx-admissionwebhook:0.24.0
+      - image: intel/intel-sgx-admissionwebhook:0.24.1
         imagePullPolicy: IfNotPresent
         name: manager
         securityContext:

--- a/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
+++ b/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: intel-sgx-plugin
-        image: intel/intel-sgx-plugin:0.24.0
+        image: intel/intel-sgx-plugin:0.24.1
         securityContext:
           seLinuxOptions:
             type: "container_device_plugin_t"

--- a/deployments/sgx_plugin/overlays/epc-hook-initcontainer/add-epc-nfd-initcontainer.yaml
+++ b/deployments/sgx_plugin/overlays/epc-hook-initcontainer/add-epc-nfd-initcontainer.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
       - name: intel-sgx-initcontainer
-        image: intel/intel-sgx-initcontainer:0.24.0
+        image: intel/intel-sgx-initcontainer:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/sgx_plugin/overlays/epc-nfd/add-epc-nfd-initcontainer.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/add-epc-nfd-initcontainer.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
       - name: intel-sgx-initcontainer
-        image: intel/intel-sgx-initcontainer:0.24.0
+        image: intel/intel-sgx-initcontainer:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/deployments/sgx_plugin/overlays/epc-register/init-daemonset.yaml
+++ b/deployments/sgx_plugin/overlays/epc-register/init-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: sgx-plugin
       containers:
       - name: sgx-node-init
-        image: intel/intel-sgx-initcontainer:0.24.0
+        image: intel/intel-sgx-initcontainer:0.24.1
         imagePullPolicy: IfNotPresent
         command:
           - /usr/local/bin/sgx-sw/intel-sgx-epchook

--- a/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
+++ b/deployments/vpu_plugin/base/intel-vpu-plugin.yaml
@@ -20,7 +20,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        image: intel/intel-vpu-plugin:0.24.0
+        image: intel/intel-vpu-plugin:0.24.1
         imagePullPolicy: IfNotPresent
         securityContext:
           readOnlyRootFilesystem: true

--- a/pkg/controllers/fpga/controller_test.go
+++ b/pkg/controllers/fpga/controller_test.go
@@ -181,7 +181,7 @@ func TestNewDaemonSetFPGA(t *testing.T) {
 
 	plugin := &devicepluginv1.FpgaDevicePlugin{
 		Spec: devicepluginv1.FpgaDevicePluginSpec{
-			InitImage: "intel/intel-fpga-initcontainer:0.24.0",
+			InitImage: "intel/intel-fpga-initcontainer:0.24.1",
 		},
 	}
 

--- a/pkg/controllers/gpu/controller_test.go
+++ b/pkg/controllers/gpu/controller_test.go
@@ -186,7 +186,7 @@ func TestNewDamonSetGPU(t *testing.T) {
 		}
 
 		if tc.isInitImage {
-			plugin.Spec.InitImage = "intel/intel-gpu-initcontainer:0.24.0"
+			plugin.Spec.InitImage = "intel/intel-gpu-initcontainer:0.24.1"
 		}
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/controllers/reconciler.go
+++ b/pkg/controllers/reconciler.go
@@ -37,14 +37,14 @@ import (
 
 var (
 	bKeeper         = &bookKeeper{}
-	ImageMinVersion = versionutil.MustParseSemantic("0.24.0")
+	ImageMinVersion = versionutil.MustParseSemantic("0.24.1")
 )
 
 func init() {
 	bKeeper.pluginCounter = make(map[string]int)
 }
 
-//nolint: govet
+// nolint: govet
 type bookKeeper struct {
 	sync.Mutex
 	pluginCounter map[string]int

--- a/pkg/controllers/reconciler_test.go
+++ b/pkg/controllers/reconciler_test.go
@@ -28,16 +28,16 @@ func TestUpgrade(test *testing.T) {
 	}{
 		{
 			image:             "intel/intel-dsa-plugin:0.22.0",
-			expectedImage:     "intel/intel-dsa-plugin:0.24.0",
+			expectedImage:     "intel/intel-dsa-plugin:0.24.1",
 			initimage:         "intel/intel-idxd-config-initcontainer:0.22.0",
-			expectedInitimage: "intel/intel-idxd-config-initcontainer:0.24.0",
+			expectedInitimage: "intel/intel-idxd-config-initcontainer:0.24.1",
 			upgrade:           true,
 		},
 		{
-			image:             "intel/intel-dsa-plugin:0.24.0",
-			expectedImage:     "intel/intel-dsa-plugin:0.24.0",
-			initimage:         "intel/intel-idxd-config-initcontainer:0.24.0",
-			expectedInitimage: "intel/intel-idxd-config-initcontainer:0.24.0",
+			image:             "intel/intel-dsa-plugin:0.24.1",
+			expectedImage:     "intel/intel-dsa-plugin:0.24.1",
+			initimage:         "intel/intel-idxd-config-initcontainer:0.24.1",
+			expectedInitimage: "intel/intel-idxd-config-initcontainer:0.24.1",
 			upgrade:           false,
 		},
 		{

--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -76,7 +76,7 @@ func describe() {
 				Containers: []v1.Container{
 					{
 						Name:  "testcontainer-pf",
-						Image: "intel/dlb-libdlb-demo:0.24.0",
+						Image: "intel/dlb-libdlb-demo:0.24.1",
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{"dlb.intel.com/pf": resource.MustParse("1")},
 							Limits:   v1.ResourceList{"dlb.intel.com/pf": resource.MustParse("1")},

--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -101,7 +101,7 @@ func runTestCase(fmw *framework.Framework, pluginKustomizationPath, mappingsColl
 	}
 
 	resource = v1.ResourceName(podResource)
-	image := "intel/opae-nlb-demo:0.24.0"
+	image := "intel/opae-nlb-demo:0.24.1"
 
 	ginkgo.By("submitting a pod requesting correct FPGA resources")
 


### PR DESCRIPTION
In #850 we dropped the legacy `/dev/sgx/` hostpath mount and 0.25.0 will be the first release without the backwards compatibility. 

In #1141 we workarounded a kubelet issue with the SGX plugin when TopologyManager was enabled. 

My proposal is to create 0.24.1 release with #1141 backported for users who cannot jump to 0.25.0.