### PR TITLE
qat: fix initcontainer to skip when sriov is already configured

### DIFF
--- a/build/docker/intel-qat-initcontainer.Dockerfile
+++ b/build/docker/intel-qat-initcontainer.Dockerfile
@@ -62,4 +62,4 @@ LABEL summary='Intel® QAT initcontainer for Kubernetes'
 LABEL description='Intel QAT initcontainer initializes devices'
 COPY --from=builder /install_root /
 COPY demo/qat-init.sh /usr/local/bin/
-ENTRYPOINT ["/usr/local/bin/qat-init.sh"]
+ENTRYPOINT [ "/bin/bash", "/usr/local/bin/qat-init.sh"]

--- a/build/docker/templates/intel-qat-initcontainer.Dockerfile.in
+++ b/build/docker/templates/intel-qat-initcontainer.Dockerfile.in
@@ -21,4 +21,4 @@ COPY --from=builder /install_root /
 
 COPY demo/qat-init.sh /usr/local/bin/
 
-ENTRYPOINT ["/usr/local/bin/qat-init.sh"]
+ENTRYPOINT [ "/bin/bash", "/usr/local/bin/qat-init.sh"]

--- a/demo/qat-init.sh
+++ b/demo/qat-init.sh
@@ -1,11 +1,17 @@
-#!/bin/bash
+#!/bin/sh -eu
 ENABLED_QAT_PF_PCIIDS=${ENABLED_QAT_PF_PCIIDS:-37c8 4940 4942}
 DEVS=$(for pf in $ENABLED_QAT_PF_PCIIDS; do lspci -n | grep -e "$pf" | grep -o -e "^\\S*"; done)
 
 for dev in $DEVS; do
   DEVPATH="/sys/bus/pci/devices/0000:$dev"
   NUMVFS="$DEVPATH/sriov_numvfs"
-  if test -w "$NUMVFS" -a "$(cat "$NUMVFS")" -eq 0 ; then
+  if ! test -w "$NUMVFS"; then
+    echo "error: $NUMVFS is not found or not writable. Check if QAT driver module is loaded"
+    exit 1
+  fi
+  if [ "$(cat "$NUMVFS")" -ne 0 ]; then
+    echo "$DEVPATH already configured"
+  else
     tee "$NUMVFS" < "$DEVPATH/sriov_totalvfs"
   fi
 done


### PR DESCRIPTION
closes: #1222

related work that adds e2e tests of checking initcontainer's idempotence: #1223 
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>