### PR TITLE
operator: update image name and version

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -142,12 +142,14 @@ $ make bundle-build
 ```
 
 > **Note**: You need to push the image to a registry if you want to follow the verification process below.
+If pushing to the Docker hub, specify `docker.io/` in front of the image name for running bundle.
+If pushing to the local registry, put the option `--use-http` for running bundle.
 
 Verify the operator deployment works OK via OLM in your development cluster:
 ```
 $ operator-sdk olm install
 $ kubectl create namespace testoperator
-$ operator-sdk run bundle <Registry>/<Tag> -n testoperator --use-http
+$ operator-sdk run bundle <Registry>:<Tag> -n testoperator
 # do verification checks
 ...
 # do clean up

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -8,7 +8,7 @@ Table of Contents
    * [Build Container Images](#build-container-images)
    * [Build Against a Newer Version of Kubernetes](#build-against-a-newer-version-of-kubernetes)
    * [Work with Intel Device Plugins Operator Modifications](#work-with-intel-device-plugins-operator-modifications)
-   * [Publish a New Version of the Intel Device Plugins Operator to operatorhub.io](#publish-a-new-version-of-the-intel-device-plugins-operator-to-operatorhub.io)
+   * [Publish a New Version of the Intel Device Plugins Operator to operatorhub.io](#publish-a-new-version-of-the-intel-device-plugins-operator-to-operatorhubio)
    * [Run E2E Tests](#run-e2e-tests)
    * [Run Controller Tests with a Local Control Plane](#run-controller-tests-with-a-local-control-plane)
 * [How to Develop Simple Device Plugins](#how-to-develop-simple-device-plugins)
@@ -126,9 +126,11 @@ There are few useful steps when working with changes to Device Plugins CRDs and 
 
 ### Publish a New Version of the Intel Device Plugins Operator to operatorhub.io
 
-Update metadata.annotations.containerImage and metadata.annotations.createdAT fields in the base CSV manifest file
-deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
-to match current operator version and current date
+Check if the fields mentioned below in the [base CSV manifest file](deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml) have the correct values. If not, fix them manually (operator-sdk does not support updating these fields in any other way).
+- spec.version
+- spec.replaces
+- metadata.annotations.containerImage
+- metadata.annotations.createdAT
 
 Fork the [Community Operators](https://github.com/k8s-operatorhub/community-operators) repo and clone it:
 ```
@@ -141,9 +143,9 @@ $ make bundle TAG=0.X.Y CHANNELS=alpha DEFAULT_CHANNEL=alpha
 $ make bundle-build
 ```
 
-> **Note**: You need to push the image to a registry if you want to follow the verification process below.
-If pushing to the Docker hub, specify `docker.io/` in front of the image name for running bundle.
-If pushing to the local registry, put the option `--use-http` for running bundle.
+Push the image to a registry:
+- If pushing to the Docker hub, specify `docker.io/` in front of the image name for running bundle.
+- If pushing to the local registry, put the option `--use-http` for running bundle.
 
 Verify the operator deployment works OK via OLM in your development cluster:
 ```
@@ -158,21 +160,18 @@ $ kubectl delete namespace testoperator
 $ operator-sdk olm uninstall
 ```
 
-Review the package manifests by uploading the generated `packagemanifests` folder to
-https://operatorhub.io -> Contribute -> Package Your Operator.
-
-Commit files
+Commit files:
 ```
 $ cd community-operators
 $ git add operators/intel-device-plugins-operator/0.X.Y
-$ git commit -am 'operators intel-device-plugins-operator (0.X.Y)' -S
+$ git commit -am 'operators intel-device-plugins-operator (0.X.Y)' -s
 ```
 
-Submit a PR
+Submit a PR to [Community Operators](https://github.com/k8s-operatorhub/community-operators) repo.
 
 Check operator page
 https://operatorhub.io/operator/intel-device-plugins-operator
-after PR is merged
+after PR is merged.
 
 ### Run E2E Tests
 

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -137,7 +137,7 @@ $ git clone https://github.com/<GitHub Username>/community-operators
 
 Generate bundle and build bundle image:
 ```
-$ make bundle OPERATOR_VERSION=0.X.Y CHANNELS=alpha DEFAULT_CHANNEL=alpha
+$ make bundle TAG=0.X.Y CHANNELS=alpha DEFAULT_CHANNEL=alpha
 $ make bundle-build
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,8 @@ CONTROLLER_GEN_VERSION ?= v0.10.0
 GOLANGCI_LINT_VERSION ?= v1.50.0
 KIND_VERSION ?= v0.16.0
 GOLICENSES_VERSION ?= v1.4.0
-# Current Operator version
-OPERATOR_VERSION ?= 0.24.0
 # Default bundle image tag
-BUNDLE_IMG ?= intel-device-plugins-controller-bundle:$(OPERATOR_VERSION)
+BUNDLE_IMG ?= intel-device-plugins-controller-bundle:$(TAG)
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
@@ -26,7 +24,7 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 OLM_MANIFESTS = deployments/operator/manifests
-BUNDLE_DIR = community-operators/operators/intel-device-plugins-operator/$(OPERATOR_VERSION)
+BUNDLE_DIR = community-operators/operators/intel-device-plugins-operator/$(TAG)
 
 TESTDATA_DIR = pkg/topology/testdata
 
@@ -122,7 +120,7 @@ bundle:
 	rm -rf $(BUNDLE_DIR)
 	mkdir -p $(BUNDLE_DIR)
 	$(OPERATOR_SDK) generate kustomize manifests -q --input-dir $(OLM_MANIFESTS) --output-dir $(OLM_MANIFESTS) --apis-dir pkg/apis
-	$(KUSTOMIZE) build $(OLM_MANIFESTS) | sed "s|intel-deviceplugin-operator:devel|intel-deviceplugin-operator:$(OPERATOR_VERSION)|" | $(OPERATOR_SDK) generate bundle -q --overwrite --kustomize-dir $(OLM_MANIFESTS) --version $(OPERATOR_VERSION) $(BUNDLE_METADATA_OPTS) --output-dir .
+	$(KUSTOMIZE) build $(OLM_MANIFESTS) | sed "s|intel-deviceplugin-operator:devel|intel-deviceplugin-operator:$(TAG)|" | $(OPERATOR_SDK) generate bundle -q --overwrite --kustomize-dir $(OLM_MANIFESTS) --version $(TAG) $(BUNDLE_METADATA_OPTS) --output-dir .
 	# Remove unneeded resources
 	rm manifests/*service.yaml
 	rm manifests/*clusterrole.yaml

--- a/deployments/operator/manager/manager.yaml
+++ b/deployments/operator/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - image: intel/intel-deviceplugin-operator:devel
+      - image: docker.io/intel/intel-deviceplugin-operator:devel
         imagePullPolicy: IfNotPresent
         name: manager
         livenessProbe:

--- a/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
+++ b/deployments/operator/manifests/bases/intel-device-plugins-operator.clusterserviceversion.yaml
@@ -5,15 +5,15 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: Drivers and plugins
-    containerImage: intel/intel-deviceplugin-operator:0.24.0
-    createdAt: "2022-05-20"
+    containerImage: docker.io/intel/intel-deviceplugin-operator:0.25.0
+    createdAt: "2022-11-09"
     description: This operator is a Kubernetes custom controller whose goal is to
       serve the installation and lifecycle management of Intel device plugins for
       Kubernetes.
-    operators.operatorframework.io/builder: operator-sdk-v1.20.0
+    operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/intel/intel-device-plugins-for-kubernetes
-  name: intel-device-plugins-operator.v0.24.0
+  name: intel-device-plugins-operator.v0.25.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -122,5 +122,5 @@ spec:
   provider:
     name: Intel® Corporation
     url: https://intel.com
-  replaces: intel-device-plugins-operator.v0.23.0
-  version: 0.24.0
+  replaces: intel-device-plugins-operator.v0.24.0
+  version: 0.25.0


### PR DESCRIPTION
https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle/
According to the documentation of operator-sdk, docker.io should be speficied.

In addition, we update the operator version to 0.25.0.

Also, publishing to operatorhub part in DEVEL.md has been updated/fixed.

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>  