### PR TITLE
fix opae-nlb-demo build

### DIFF
--- a/demo/opae-nlb-demo/Dockerfile
+++ b/demo/opae-nlb-demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable-slim AS builder
+FROM debian:stable-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y curl python3-dev git gcc g++ make cmake uuid-dev libjson-c-dev libedit-dev libudev-dev


### PR DESCRIPTION
Temporarily swtiched to debian-stable-slim to fix cmake installation failure:
```
   cmake : Depends: cmake-data (= 3.25.0-1) but it is not installable
         Recommends: gcc but it is not going to be installed
         Recommends: make
```