### PR TITLE
fix dlb-dpdk-demo's argument 'dev_id' to 'hwdev_id'

### DIFF
--- a/demo/dlb-dpdk-demo/test.sh
+++ b/demo/dlb-dpdk-demo/test.sh
@@ -3,13 +3,13 @@ dlb_dev=$(ls /dev/dlb* | sed 's/\/dev\/dlb//' | head -1)
 
 echo '\n1. Order queue test'
 echo '-------------------'
-dpdk-test-eventdev --no-huge --vdev="dlb2_event,dev_id=`echo $dlb_dev`" -- --test=order_queue --nb_flows 64 --nb_pkts 512  --plcores 1 --wlcores 2-7
+dpdk-test-eventdev --no-huge --vdev="dlb2_event,hwdev_id=`echo $dlb_dev`" -- --test=order_queue --nb_flows 64 --nb_pkts 512  --plcores 1 --wlcores 2-7
 echo '\n2. Perf queue test'
 echo '------------------'
-dpdk-test-eventdev --no-huge --vdev="dlb2_event,dev_id=`echo $dlb_dev`" -- --test perf_queue  --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7 --stlist o,a,a,o
+dpdk-test-eventdev --no-huge --vdev="dlb2_event,hwdev_id=`echo $dlb_dev`" -- --test perf_queue  --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7 --stlist o,a,a,o
 echo '\n3. Order atq test'
 echo '-----------------'
-dpdk-test-eventdev --no-huge --vdev="dlb2_event,dev_id=`echo $dlb_dev`" -- --test order_atq   --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7
+dpdk-test-eventdev --no-huge --vdev="dlb2_event,hwdev_id=`echo $dlb_dev`" -- --test order_atq   --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7
 echo '\n4. Perf atq test'
 echo '----------------'
-dpdk-test-eventdev --no-huge --vdev="dlb2_event,dev_id=`echo $dlb_dev`" -- --test perf_atq    --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7 --stlist o,a,a,o
+dpdk-test-eventdev --no-huge --vdev="dlb2_event,hwdev_id=`echo $dlb_dev`" -- --test perf_atq    --nb_flows 64 --nb_pkts 1024 --plcores 1 --wlcores 2-7 --stlist o,a,a,o


### PR DESCRIPTION
Fixes: #1293 
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>