### PR TITLE
e2e: Increase nfd timeout to 300 seconds

### DIFF
--- a/test/e2e/deviceplugins_suite_test.go
+++ b/test/e2e/deviceplugins_suite_test.go
@@ -108,7 +108,7 @@ func setupFirstNode() []byte {
 	utils.Kubectl("node-feature-discovery", "apply", "-k", "deployments/nfd/overlays/node-feature-rules/kustomization.yaml")
 
 	if err = e2epod.WaitForPodsRunningReady(c, "node-feature-discovery", 2, 0,
-		200*time.Second, map[string]string{}); err != nil {
+		300*time.Second, map[string]string{}); err != nil {
 		framework.Failf("unable to wait for NFD pods to be running and ready: %v", err)
 	}
 


### PR DESCRIPTION
Apparently some of simulated CI nodes have out of sync boot configuration.

In order to be able to get the configuration in sync, the e2e NFD timeout should be increased (it takes 250-260 seconds for NFD to get up with the right boot parameters in the simulated environments).