### PR TITLE
Use more generic name for NFD features host directory volume

### DIFF
--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -24,7 +24,7 @@ spec:
           allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/node-feature-discovery/source.d/
-          name: nfd-source-hooks
+          name: nfd-features
       containers:
       - name: intel-gpu-plugin
         env:
@@ -58,7 +58,7 @@ spec:
       - name: kubeletsockets
         hostPath:
           path: /var/lib/kubelet/device-plugins
-      - name: nfd-source-hooks
+      - name: nfd-features
         hostPath:
           path: /etc/kubernetes/node-feature-discovery/source.d/
           type: DirectoryOrCreate

--- a/deployments/sgx_plugin/overlays/epc-hook-initcontainer/add-epc-nfd-initcontainer.yaml
+++ b/deployments/sgx_plugin/overlays/epc-hook-initcontainer/add-epc-nfd-initcontainer.yaml
@@ -14,9 +14,9 @@ spec:
           allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/node-feature-discovery/source.d/
-          name: nfd-source-hooks
+          name: nfd-features
       volumes:
-      - name: nfd-source-hooks
+      - name: nfd-features
         hostPath:
           path: /etc/kubernetes/node-feature-discovery/source.d/
           type: DirectoryOrCreate

--- a/deployments/sgx_plugin/overlays/epc-nfd/add-epc-nfd-initcontainer.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/add-epc-nfd-initcontainer.yaml
@@ -14,9 +14,9 @@ spec:
           allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /etc/kubernetes/node-feature-discovery/source.d/
-          name: nfd-source-hooks
+          name: nfd-features
       volumes:
-      - name: nfd-source-hooks
+      - name: nfd-features
         hostPath:
           path: /etc/kubernetes/node-feature-discovery/source.d/
           type: DirectoryOrCreate

--- a/pkg/controllers/gpu/controller.go
+++ b/pkg/controllers/gpu/controller.go
@@ -142,7 +142,7 @@ func (c *controller) NewDaemonSet(rawObj client.Object) *apps.DaemonSet {
 
 	if devicePlugin.Spec.InitImage == "" {
 		daemonSet.Spec.Template.Spec.InitContainers = nil
-		daemonSet.Spec.Template.Spec.Volumes = removeVolume(daemonSet.Spec.Template.Spec.Volumes, "nfd-source-hooks")
+		daemonSet.Spec.Template.Spec.Volumes = removeVolume(daemonSet.Spec.Template.Spec.Volumes, "nfd-features")
 	} else {
 		setInitContainer(&daemonSet.Spec.Template.Spec, devicePlugin.Spec.InitImage)
 	}
@@ -204,11 +204,11 @@ func setInitContainer(spec *v1.PodSpec, imageName string) {
 			VolumeMounts: []v1.VolumeMount{
 				{
 					MountPath: "/etc/kubernetes/node-feature-discovery/source.d/",
-					Name:      "nfd-source-hooks",
+					Name:      "nfd-features",
 				},
 			},
 		}}
-	addVolumeIfMissing(spec, "nfd-source-hooks", "/etc/kubernetes/node-feature-discovery/source.d/", v1.HostPathDirectoryOrCreate)
+	addVolumeIfMissing(spec, "nfd-features", "/etc/kubernetes/node-feature-discovery/source.d/", v1.HostPathDirectoryOrCreate)
 }
 
 func removeVolume(volumes []v1.Volume, name string) []v1.Volume {
@@ -246,7 +246,7 @@ func (c *controller) UpdateDaemonSet(rawObj client.Object, ds *apps.DaemonSet) (
 	if dp.Spec.InitImage == "" {
 		if ds.Spec.Template.Spec.InitContainers != nil {
 			ds.Spec.Template.Spec.InitContainers = nil
-			ds.Spec.Template.Spec.Volumes = removeVolume(ds.Spec.Template.Spec.Volumes, "nfd-source-hooks")
+			ds.Spec.Template.Spec.Volumes = removeVolume(ds.Spec.Template.Spec.Volumes, "nfd-features")
 			updated = true
 		}
 	} else {

--- a/pkg/controllers/sgx/controller.go
+++ b/pkg/controllers/sgx/controller.go
@@ -114,11 +114,11 @@ func setInitContainer(spec *v1.PodSpec, imageName string) {
 			VolumeMounts: []v1.VolumeMount{
 				{
 					MountPath: "/etc/kubernetes/node-feature-discovery/source.d/",
-					Name:      "nfd-source-hooks",
+					Name:      "nfd-features",
 				},
 			},
 		}}
-	addVolumeIfMissing(spec, "nfd-source-hooks", "/etc/kubernetes/node-feature-discovery/source.d/", v1.HostPathDirectoryOrCreate)
+	addVolumeIfMissing(spec, "nfd-features", "/etc/kubernetes/node-feature-discovery/source.d/", v1.HostPathDirectoryOrCreate)
 }
 
 func (c *controller) NewDaemonSet(rawObj client.Object) *apps.DaemonSet {
@@ -165,7 +165,7 @@ func (c *controller) UpdateDaemonSet(rawObj client.Object, ds *apps.DaemonSet) (
 	if dp.Spec.InitImage == "" {
 		if ds.Spec.Template.Spec.InitContainers != nil {
 			ds.Spec.Template.Spec.InitContainers = nil
-			ds.Spec.Template.Spec.Volumes = removeVolume(ds.Spec.Template.Spec.Volumes, "nfd-source-hooks")
+			ds.Spec.Template.Spec.Volumes = removeVolume(ds.Spec.Template.Spec.Volumes, "nfd-features")
 			updated = true
 		}
 	} else {


### PR DESCRIPTION
NFD hooks are deprecated and going away:
https://github.com/kubernetes-sigs/node-feature-discovery/issues/856

This makes the mount names more future-proof, and shows where later changes need to be done (to change operator mount directory, and switch hook-using deployments e.g. to feature files).

I decided to split this from PR https://github.com/intel/intel-device-plugins-for-kubernetes/pull/1118, so that same change can be done for all plugins (GPU + SGX), to avoid complicating later switch away from hooks.  Added SGX part is not tested, but that change is identical to GPU one.