### PR TITLE
demo: do not pip install ninja

### DIFF
--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR $DIR
 RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \
     /etc/apt/sources.list.d/deb-src.list
 RUN apt-get update && apt-get install -y wget build-essential meson python3-pyelftools libnuma-dev python3-pip libssl-dev pkg-config dpkg-dev
-RUN pip install ninja
 
 # Download & unpack DPDK tarball
 ARG DPDK_TARBALL=dpdk-22.11.tar.xz

--- a/demo/dlb-dpdk-demo/Dockerfile
+++ b/demo/dlb-dpdk-demo/Dockerfile
@@ -4,7 +4,6 @@ ARG DIR=/dpdk-build
 WORKDIR $DIR
 
 RUN apt-get update && apt-get install -y wget build-essential meson python3-pyelftools libnuma-dev python3-pip
-RUN pip install ninja
 
 # Download & unpack DLB tarball
 ARG DLB_TARBALL="dlb_linux_src_release8.0.0.txz"


### PR DESCRIPTION
ninja-build is installed as a dependency to meson so we don't need to install it separately. In fact pip install fails on setups that enforce PEP-668 of externally managed environments.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>