### PR TITLE
pkg/deviceplugin: do not reset Envs/Annotations from previous loops

### DIFF
--- a/pkg/deviceplugin/server.go
+++ b/pkg/deviceplugin/server.go
@@ -143,6 +143,9 @@ func (srv *server) Allocate(ctx context.Context, rqt *pluginapi.AllocateRequest)
 	for _, crqt := range rqt.ContainerRequests {
 		cresp := new(pluginapi.ContainerAllocateResponse)
 
+		cresp.Envs = map[string]string{}
+		cresp.Annotations = map[string]string{}
+
 		for _, id := range crqt.DevicesIDs {
 			dev, ok := srv.devices[id]
 			if !ok {
@@ -161,13 +164,9 @@ func (srv *server) Allocate(ctx context.Context, rqt *pluginapi.AllocateRequest)
 				cresp.Mounts = append(cresp.Mounts, &dev.mounts[i])
 			}
 
-			cresp.Envs = map[string]string{}
-
 			for key, value := range dev.envs {
 				cresp.Envs[key] = value
 			}
-
-			cresp.Annotations = map[string]string{}
 
 			for key, value := range dev.annotations {
 				cresp.Annotations[key] = value


### PR DESCRIPTION
When more than one device ID is Allocate()'d to a container, Envs/Annotations for all but the last device ID get lost because their cresp.* maps are (re-)instantiated on each loop.

Fix it by doing that only once.

Fixes: 55f3e17

/cc @bart0sh need your approval