### PR TITLE
qat init: make qat.conf optional

### DIFF
--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -44,7 +44,7 @@ The QAT plugin can take a number of command line arguments, summarised in the fo
 |:---- |:-------- |:------- |
 | -dpdk-driver | string | DPDK Device driver for configuring the QAT device (default: `vfio-pci`) |
 | -kernel-vf-drivers | string | Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, 4xxx/401xx/402xx, C4xxx and D15xx (default: `c6xxvf,4xxxvf`) |
-| -max-num-devices | int | maximum number of QAT devices to be provided to the QuickAssist device plugin (default: `32`) |
+| -max-num-devices | int | maximum number of QAT devices to be provided to the QuickAssist device plugin (default: `64`) |
 | -mode | string | plugin mode which can be either `dpdk` or `kernel` (default: `dpdk`) |
 | -allocation-policy | string | 2 possible values: balanced and packed. Balanced mode spreads allocated QAT VF resources balanced among QAT PF devices, and packed mode packs one QAT PF device full of QAT VF resources before allocating resources from the next QAT PF. (There is no default.) |
 

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -136,12 +136,11 @@ In addition to the default configuration, you can add device-specific configurat
 |:-------|:-----------------------|:-----------------|:--------|:------|
 | 4xxx, 401xx,402xx | [cfg_services](https://github.com/torvalds/linux/blob/42e66b1cc3a070671001f8a1e933a80818a192bf/Documentation/ABI/testing/sysfs-driver-qat) reports the configured services (crypto services or compression services) of the QAT device. | `ServicesEnabled=<value>` | compress:`dc`, crypto:`sym;asym` | Linux 6.0+ kernel is required. |
 
-To create a provisioning config after customizing, run as follows:
+To create a provisioning `configMap`, run the following command before deploying initcontainer:
 
 ```bash
 $ kubectl create configmap --namespace=inteldeviceplugins-system qat-config --from-file=deployments/qat_plugin/overlays/qat_initcontainer/qat.conf
 ```
-> **Note**: When deploying the overlay qat_initcontainer, such a manual creation is not necessary since ConfigMap is generated automatically. Just set the values in the config file and deploy the overlay.
 
 When using the operator for deploying the plugin with provisioning config, use `provisioningConfig` field for the name of the ConfigMap, then the config is passed to initcontainer through the volume mount.
 

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -42,7 +42,7 @@ func main() {
 	dpdkDriver := flag.String("dpdk-driver", "vfio-pci", "DPDK Device driver for configuring the QAT device")
 	kernelVfDrivers := flag.String("kernel-vf-drivers", "c6xxvf,4xxxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, C4xxx, 4xxx, and D15xx")
 	preferredAllocationPolicy := flag.String("allocation-policy", "", "Modes of allocating QAT devices: balanced and packed")
-	maxNumDevices := flag.Int("max-num-devices", 32, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
+	maxNumDevices := flag.Int("max-num-devices", 64, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
 	flag.Parse()
 
 	switch *mode {

--- a/deployments/qat_plugin/overlays/qat_initcontainer/kustomization.yaml
+++ b/deployments/qat_plugin/overlays/qat_initcontainer/kustomization.yaml
@@ -2,7 +2,3 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - qat_initcontainer.yaml
-configMapGenerator:
-- name: qat-config
-  files:
-  - qat.conf

--- a/deployments/qat_plugin/overlays/qat_initcontainer/qat.conf
+++ b/deployments/qat_plugin/overlays/qat_initcontainer/qat.conf
@@ -1,1 +1,0 @@
-ServicesEnabled=sym;asym

--- a/deployments/qat_plugin/overlays/qat_initcontainer/qat_initcontainer.yaml
+++ b/deployments/qat_plugin/overlays/qat_initcontainer/qat_initcontainer.yaml
@@ -28,4 +28,5 @@ spec:
       - name: qat-config
         configMap:
           name: qat-config
+          optional: true
           defaultMode: 0440


### PR DESCRIPTION
divide the current test case into two cases:
-without any configMap set
-with configMap set for cy service

The structure of e2e test flows is as follows:
** Case 1: without configMap set

- JustBeforeEach(deploying QAT plugin)

- Context

  - It(checks if resources are available)



** Case 2: with configMap set
- BeforeEach(createing a configMap)
- JustBeforeEach(deploying QAT plugin)
- Context
   - JustBeforeEach(checks if resources are available)
   - It(runs a test pod)
   - [It(runs another test pod)]*
