### PR TITLE
ci: fix image base layer test

### DIFF
--- a/scripts/test-image-base-layer.sh
+++ b/scripts/test-image-base-layer.sh
@@ -20,9 +20,13 @@ fi
 echo "Testing $IMG base layer"
 
 if [ -z "${BUILDER}" ] || [ "${BUILDER}" = 'docker' ] ; then
+    if [ -z "$(docker image ls -q gcr.io/distroless/static:latest)" ]; then
+        docker pull gcr.io/distroless/static:latest
+    fi
     distroless_base=$(docker inspect --format='{{index .RootFS.Layers 0}}' "gcr.io/distroless/static") || die "failed to inspect gcr.io/distroless/static"
     img_base=$(docker inspect --format='{{index .RootFS.Layers 0}}' "$IMG") || die "failed to inspect $IMG"
 elif [ "${BUILDER}" = 'buildah' ] ; then
+    buildah images -q gcr.io/distroless/static:latest 2>/dev/null || buildah pull gcr.io/distroless/static:latest
     distroless_base=$(buildah inspect --type image --format='{{index .OCIv1.RootFS.DiffIDs 0}}' "gcr.io/distroless/static") || die "failed to inspect gcr.io/distroless/static"
     img_base=$(buildah inspect --type image --format='{{index .OCIv1.RootFS.DiffIDs 0}}' "$IMG") || die "failed to inspect $IMG"
 else


### PR DESCRIPTION
with docker 23.0.0, the builder defaults to Buildx which changed how multi-stage builds are done. It looks the images used during builds are no longer part of "docker images" which make the image base layer test to fail:

Testing docker.io/intel/intel-deviceplugin-operator:devel base layer Error: No such object: gcr.io/distroless/static
ERROR: failed to inspect gcr.io/distroless/static

Therefore, we must ensure gcr.io/distroless/static is pulled before the image base layer is checked.