### PR TITLE
e2e: use JustBeforeEach for deploying plugins

### DIFF
--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -51,7 +51,7 @@ func describe() {
 
 	var dpPodName string
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.JustBeforeEach(func() {
 		ginkgo.By("deploying DLB plugin")
 		e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
@@ -80,7 +80,7 @@ func describe() {
 	})
 
 	ginkgo.Context("When PF resources are available", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			resource := v1.ResourceName("dlb.intel.com/pf")
 			if err := utils.WaitForNodesWithResource(f.ClientSet, resource, 30*time.Second); err != nil {
 				framework.Failf("unable to wait for nodes to have positive allocatable resource %s: %v", resource, err)
@@ -93,7 +93,7 @@ func describe() {
 	})
 
 	ginkgo.Context("When VF resources are available", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			resource := v1.ResourceName("dlb.intel.com/vf")
 			if err := utils.WaitForNodesWithResource(f.ClientSet, resource, 30*time.Second); err != nil {
 				framework.Failf("unable to wait for nodes to have positive allocatable resource %s: %v", resource, err)

--- a/test/e2e/dsa/dsa.go
+++ b/test/e2e/dsa/dsa.go
@@ -63,7 +63,7 @@ func describe() {
 	var dpPodName string
 
 	ginkgo.Describe("Without using operator", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			ginkgo.By("deploying DSA plugin")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "intel-dsa-config", "--from-file="+configmap)
 
@@ -94,7 +94,7 @@ func describe() {
 		})
 
 		ginkgo.Context("When DSA resources are available", func() {
-			ginkgo.BeforeEach(func() {
+			ginkgo.JustBeforeEach(func() {
 				ginkgo.By("checking if the resource is allocatable")
 				if err := utils.WaitForNodesWithResource(f.ClientSet, "dsa.intel.com/wq-user-dedicated", 300*time.Second); err != nil {
 					framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)

--- a/test/e2e/iaa/iaa.go
+++ b/test/e2e/iaa/iaa.go
@@ -63,7 +63,7 @@ func describe() {
 	var dpPodName string
 
 	ginkgo.Describe("Without using operator", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			ginkgo.By("deploying IAA plugin")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "intel-iaa-config", "--from-file="+configmap)
 
@@ -94,7 +94,7 @@ func describe() {
 		})
 
 		ginkgo.Context("When IAA resources are available", func() {
-			ginkgo.BeforeEach(func() {
+			ginkgo.JustBeforeEach(func() {
 				ginkgo.By("checking if the resource is allocatable")
 				if err := utils.WaitForNodesWithResource(f.ClientSet, "iaa.intel.com/wq-user-dedicated", 300*time.Second); err != nil {
 					framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)

--- a/test/e2e/qat/qatplugin_dpdk.go
+++ b/test/e2e/qat/qatplugin_dpdk.go
@@ -65,7 +65,7 @@ func describeQatDpdkPlugin() {
 
 	var dpPodName string
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.JustBeforeEach(func() {
 		ginkgo.By("deploying QAT plugin in DPDK mode")
 		e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(kustomizationPath))
 
@@ -94,7 +94,7 @@ func describeQatDpdkPlugin() {
 	})
 
 	ginkgo.Context("When QAT Gen4 resources are available", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(f.ClientSet, "qat.intel.com/cy", 30*time.Second); err != nil {
 				framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
@@ -115,7 +115,7 @@ func describeQatDpdkPlugin() {
 	})
 
 	ginkgo.Context("When QAT Gen2 resources are available", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(f.ClientSet, "qat.intel.com/generic", 30*time.Second); err != nil {
 				framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)

--- a/test/e2e/qat/qatplugin_kernel.go
+++ b/test/e2e/qat/qatplugin_kernel.go
@@ -51,7 +51,7 @@ func describeQatKernelPlugin() {
 
 	var dpPodName string
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.JustBeforeEach(func() {
 		ginkgo.By("deploying QAT plugin in kernel mode")
 		e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "create", "-f", yamlPath)
 
@@ -80,7 +80,7 @@ func describeQatKernelPlugin() {
 	})
 
 	ginkgo.Context("When QAT resources are available", func() {
-		ginkgo.BeforeEach(func() {
+		ginkgo.JustBeforeEach(func() {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(f.ClientSet, "qat.intel.com/cy1_dc0", 30*time.Second); err != nil {
 				framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)


### PR DESCRIPTION
There can be some cases that something should be done before deploying a plugin (e.g. creation of a configMap). To make plugin gets deployed after some other works are done only in some 'Context', we need to make plugins deployed in 'JustBeforeEach' so that 'BeforeEach' can run first even if it is inside 'Context'.