### PR TITLE
envtest: disable controller metrics in tests

### DIFF
--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -56,7 +56,6 @@ import (
 var (
 	cfg         *rest.Config
 	k8sClient   client.Client
-	k8sManager  ctrl.Manager
 	testEnv     *envtest.Environment
 	ctx         context.Context
 	cancel      context.CancelFunc
@@ -108,7 +107,8 @@ var _ = AfterEach(func() {
 })
 
 func up() {
-	k8sManager, _ = ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+	k8sManager, managerErr := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme, MetricsBindAddress: "0"})
+	Expect(managerErr).To(BeNil())
 
 	withWebhook := true
 


### PR DESCRIPTION
to mitigate spurious errors with:

E0515 15:28:06.626887 1995892 listener.go:48] "controller-runtime/metrics: metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts" err="error lis tening on :8080: listen tcp :8080: bind: address already in use"

disable metrics completely. Moreover, check for error value from NewManager() before proceeding with the tests to avoid crashes.

This makes envtest more robust but the up()/down() logic needs careful review to ensure there are no race conditions.