### PR TITLE
 dlb: make init script end with exit 0 when sriov_numvfs not found 

### DIFF
--- a/demo/dlb-init.sh
+++ b/demo/dlb-init.sh
@@ -5,8 +5,8 @@ enable_and_configure_vfs() {
   
   sriov_numvfs_path="$devpath/sriov_numvfs"
   if ! test -w "$sriov_numvfs_path"; then
-    echo "error: $sriov_numvfs_path is not found or not writable. Check if dlb driver module is loaded"
-    exit 1
+    echo "$sriov_numvfs_path is not found or not writable. In case there is no configured VF yet, check if dlb driver module is loaded"
+    exit 0
   fi
   if [ "$(cat "$sriov_numvfs_path")" -ne 0 ]; then
     echo "$devpath already configured"


### PR DESCRIPTION
Even if sriov_numvfs is not found, do not finish with an error.
It is necessary because VM still recognizes VF's BDF as xx.xx.0,
and script tries to find sriov_numvfs. So, chnage the script just
print some informational message and end with exit 0.