### PR TITLE
operator: fix setting QAT provisioning config volumeMount

### DIFF
--- a/test/envtest/qatdeviceplugin_controller_test.go
+++ b/test/envtest/qatdeviceplugin_controller_test.go
@@ -136,7 +136,7 @@ var _ = Describe("QatDevicePlugin Controller", func() {
 			}
 			mode := int32(0440)
 			expectedVolume := v1.Volume{
-				Name: "qat-config",
+				Name: "intel-qat-config-volume",
 				VolumeSource: v1.VolumeSource{
 					ConfigMap: &v1.ConfigMapVolumeSource{
 						LocalObjectReference: v1.LocalObjectReference{Name: updatedProvisioningConfig},


### PR DESCRIPTION
setInitContainer() adds "init-sriov-numvfs" to initContainers but uses initcontainerName constant to search where to add the QAT configMap volumeMount. Fix by moving all code to use the const.

It was also noticed in the controller logs that setting Pod Volumes is not idempotent but broken DaemonSet gets created:

""intel-device-plugins-manager: Reconciler error "err="DaemonSet.apps \"intel-qat-plugin\" is invalid: spec.template.spec.volumes[6].name: Duplicate value: \"qat-config\"" controller="qatdeviceplugin" controllerGroup="deviceplugin.intel.com"

Finally, change 'qat-config' to 'intel-qat-config-volume' to better describe that it's a volume.