### PR TITLE
sgx: use sgx-sdk-demo app instead of busybox

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
             images: intel-qat-plugin intel-qat-initcontainer openssl-qat-engine
           - name: e2e-sgx
             runner: sgx
-            images: intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook intel-deviceplugin-operator
+            images: intel-sgx-plugin intel-sgx-initcontainer intel-sgx-admissionwebhook sgx-sdk-demo intel-deviceplugin-operator
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/demo/sgx-sdk-demo/Dockerfile
+++ b/demo/sgx-sdk-demo/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 # SGX SDK is installed in /opt/intel directory.
 WORKDIR /opt/intel
 
-ARG DCAP_VERSION=DCAP_1.15
+ARG DCAP_VERSION=DCAP_1.17
 
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" | \
     tee -a /etc/apt/sources.list.d/intel-sgx.list \
@@ -36,7 +36,7 @@ RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://d
     libsgx-quote-ex-dev
 
 # Install SGX SDK
-ARG SGX_SDK_URL=https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.18.100.3.bin
+ARG SGX_SDK_URL=https://download.01.org/intel-sgx/sgx-linux/2.20/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.20.100.4.bin
 RUN wget ${SGX_SDK_URL} \
  && export SGX_SDK_INSTALLER=$(basename $SGX_SDK_URL) \
  && chmod +x $SGX_SDK_INSTALLER \

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -15,8 +15,8 @@ if [ $# != 1 ] || [ "$1" = "?" ] || [ "$1" = "--help" ]; then
     exit 1
 fi
 
-files=$(git grep -l '^TAG?*=\|intel/accel-config-demo:\|intel/crypto-perf:\|intel/opae-nlb-demo:\|intel/openssl-qat-engine:\|intel/dlb-libdlb-demo:\|intel/intel-[^ ]*:\|version=\|appVersion:\|tag:' Makefile deployments demo/*accel-config*.yaml demo/*fpga*.yaml demo/*openssl*.yaml demo/dlb-libdlb*.yaml pkg/controllers/*/*_test.go build/docker/*.Dockerfile test/e2e/*/*.go)
+files=$(git grep -l '^TAG?*=\|intel/accel-config-demo:\|intel/crypto-perf:\|intel/opae-nlb-demo:\|intel/openssl-qat-engine:\|intel/dlb-libdlb-demo:\|intel/sgx-sdk-demo:\|intel/intel-[^ ]*:\|version=\|appVersion:\|tag:' Makefile deployments demo/*accel-config*.yaml demo/*fpga*.yaml demo/*openssl*.yaml demo/dlb-libdlb*.yaml pkg/controllers/*/*_test.go build/docker/*.Dockerfile test/e2e/*/*.go)
 
 for file in $files; do
-    sed -i -e "s;\(^TAG?*=\|intel/accel-config-demo:\|intel/crypto-perf:\|intel/opae-nlb-demo:\|intel/openssl-qat-engine:\|intel/dlb-libdlb-demo:\|intel/intel-[^ ]*:\|version=\|appVersion: [^ ]\|tag: [^ ]\)[^ \"]*;\1$1;g" "$file";
+    sed -i -e "s;\(^TAG?*=\|intel/accel-config-demo:\|intel/crypto-perf:\|intel/opae-nlb-demo:\|intel/openssl-qat-engine:\|intel/dlb-libdlb-demo:\|intel/sgx-sdk-demo:\|intel/intel-[^ ]*:\|version=\|appVersion: [^ ]\|tag: [^ ]\)[^ \"]*;\1$1;g" "$file";
 done

--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -29,7 +29,6 @@ import (
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
@@ -93,16 +92,16 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a pod requesting SGX enclave resources", func(ctx context.Context) {
+		ginkgo.It("deploys a sgx-sdk-demo pod requesting SGX enclave resources", func(ctx context.Context) {
 			podSpec := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "sgxplugin-tester"},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Args:    []string{"-c", "echo hello world"},
-							Name:    "testcontainer",
-							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-							Command: []string{"/bin/sh"},
+							Name:       "testcontainer",
+							Image:      "intel/sgx-sdk-demo:devel",
+							WorkingDir: "/opt/intel/sgx-sample-app/",
+							Command:    []string{"/opt/intel/sgx-sample-app/sgx-sample-app"},
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{"sgx.intel.com/epc": resource.MustParse("42")},
 								Limits:   v1.ResourceList{"sgx.intel.com/epc": resource.MustParse("42")},


### PR DESCRIPTION
Busybox does not run anything inside the container, and it does not test with real resources. Use sgx-sdk-demo image instead.

* #1469 should be merged first, and then this should be rebased.