### PR TITLE
dsa: replace token with read_buffer in conf

### DIFF
--- a/demo/dsa.conf
+++ b/demo/dsa.conf
@@ -1,13 +1,13 @@
 [
   {
     "dev":"dsaX",
-    "token_limit":0,
+    "read_buffer_limit":0,
     "groups":[
       {
         "dev":"groupX.0",
-        "tokens_reserved":0,
-        "use_token_limit":0,
-        "tokens_allowed":8,
+        "read_buffers_reserved":0,
+        "use_read_buffer_limit":0,
+        "read_buffers_allowed":8,
         "grouped_workqueues":[
           {
             "dev":"wqX.0",
@@ -30,9 +30,9 @@
       },
       {
         "dev":"groupX.1",
-        "tokens_reserved":0,
-        "use_token_limit":0,
-        "tokens_allowed":8,
+        "read_buffers_reserved":0,
+        "use_read_buffer_limit":0,
+        "read_buffers_allowed":8,
         "grouped_workqueues":[
           {
             "dev":"wqX.1",
@@ -55,9 +55,9 @@
       },
       {
         "dev":"groupX.2",
-        "tokens_reserved":0,
-        "use_token_limit":0,
-        "tokens_allowed":8,
+        "read_buffers_reserved":0,
+        "use_read_buffer_limit":0,
+        "read_buffers_allowed":8,
         "grouped_workqueues":[
           {
             "dev":"wqX.2",
@@ -80,9 +80,9 @@
       },
       {
         "dev":"groupX.3",
-        "tokens_reserved":0,
-        "use_token_limit":0,
-        "tokens_allowed":8,
+        "read_buffers_reserved":0,
+        "use_read_buffer_limit":0,
+        "read_buffers_allowed":8,
         "grouped_workqueues":[
           {
             "dev":"wqX.3",

--- a/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa-config.yaml
+++ b/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa-config.yaml
@@ -8,13 +8,13 @@ data:
     [
       {
         "dev":"dsaX",
-        "token_limit":0,
+        "read_buffer_limit":0,
         "groups":[
           {
             "dev":"groupX.0",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.0",
@@ -37,9 +37,9 @@ data:
           },
           {
             "dev":"groupX.1",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.1",
@@ -62,9 +62,9 @@ data:
           },
           {
             "dev":"groupX.2",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.2",
@@ -87,9 +87,9 @@ data:
           },
           {
             "dev":"groupX.3",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.3",
@@ -117,13 +117,13 @@ data:
     [
       {
         "dev":"dsaX",
-        "token_limit":0,
+        "read_buffer_limit":0,
         "groups":[
           {
             "dev":"groupX.0",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.0",
@@ -146,9 +146,9 @@ data:
           },
           {
             "dev":"groupX.1",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.1",
@@ -171,9 +171,9 @@ data:
           },
           {
             "dev":"groupX.2",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.2",
@@ -196,9 +196,9 @@ data:
           },
           {
             "dev":"groupX.3",
-            "tokens_reserved":0,
-            "use_token_limit":0,
-            "tokens_allowed":8,
+            "read_buffers_reserved":0,
+            "use_read_buffer_limit":0,
+            "read_buffers_allowed":8,
             "grouped_workqueues":[
               {
                 "dev":"wqX.3",


### PR DESCRIPTION
fixes: #1445 
token related attributes got deprecated. To remove warnings, replace with read_buff.