### PR TITLE
e2e: remove duplicate code of testing with operator

### DIFF
--- a/test/e2e/dsa/dsa.go
+++ b/test/e2e/dsa/dsa.go
@@ -119,28 +119,4 @@ func describe() {
 			})
 		})
 	})
-
-	ginkgo.Describe("With using operator", func() {
-		ginkgo.It("deploys DSA plugin with operator", func(ctx context.Context) {
-			utils.Kubectl("", "apply", "-k", "deployments/operator/default/kustomization.yaml")
-
-			if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"control-plane": "controller-manager"}.AsSelector(), 1, timeout); err != nil {
-				framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-			}
-
-			utils.Kubectl("", "apply", "-f", "deployments/operator/samples/deviceplugin_v1_dsadeviceplugin.yaml")
-
-			if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"app": "intel-dsa-plugin"}.AsSelector(), 1, timeout); err != nil {
-				framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-			}
-
-			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "dsa.intel.com/wq-user-dedicated", timeout); err != nil {
-				framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
-			}
-
-			utils.Kubectl("", "delete", "-f", "deployments/operator/samples/deviceplugin_v1_dsadeviceplugin.yaml")
-
-			utils.Kubectl("", "delete", "-k", "deployments/operator/default/kustomization.yaml")
-		})
-	})
 }

--- a/test/e2e/iaa/iaa.go
+++ b/test/e2e/iaa/iaa.go
@@ -119,28 +119,4 @@ func describe() {
 			})
 		})
 	})
-
-	ginkgo.Describe("With using operator", func() {
-		ginkgo.It("deploys IAA plugin with operator", func(ctx context.Context) {
-			utils.Kubectl("", "apply", "-k", "deployments/operator/default/kustomization.yaml")
-
-			if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"control-plane": "controller-manager"}.AsSelector(), 1, timeout); err != nil {
-				framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-			}
-
-			utils.Kubectl("", "apply", "-f", "deployments/operator/samples/deviceplugin_v1_iaadeviceplugin.yaml")
-
-			if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"app": "intel-iaa-plugin"}.AsSelector(), 1, timeout); err != nil {
-				framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-			}
-
-			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "iaa.intel.com/wq-user-dedicated", timeout); err != nil {
-				framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
-			}
-
-			utils.Kubectl("", "delete", "-f", "deployments/operator/samples/deviceplugin_v1_iaadeviceplugin.yaml")
-
-			utils.Kubectl("", "delete", "-k", "deployments/operator/default/kustomization.yaml")
-		})
-	})
 }

--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -118,34 +118,4 @@ func describe() {
 
 		e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "delete", "-k", filepath.Dir(deploymentPluginPath))
 	})
-
-	ginkgo.It("deploys SGX plugin with operator", func(ctx context.Context) {
-		utils.Kubectl("", "apply", "-k", "deployments/operator/default/kustomization.yaml")
-
-		if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"control-plane": "controller-manager"}.AsSelector(), 1, timeout); err != nil {
-			framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-		}
-
-		utils.Kubectl("", "apply", "-f", "deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml")
-
-		if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"app": "intel-sgx-plugin"}.AsSelector(), 1, timeout); err != nil {
-			framework.Failf("unable to wait for all pods to be running and ready: %v", err)
-		}
-
-		if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "sgx.intel.com/epc", 150*time.Second); err != nil {
-			framework.Failf("unable to wait for nodes to have positive allocatable epc resource: %v", err)
-		}
-
-		if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "sgx.intel.com/enclave", 30*time.Second); err != nil {
-			framework.Failf("unable to wait for nodes to have positive allocatable enclave resource: %v", err)
-		}
-
-		if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "sgx.intel.com/provision", 30*time.Second); err != nil {
-			framework.Failf("unable to wait for nodes to have positive allocatable provision resource: %v", err)
-		}
-
-		utils.Kubectl("", "delete", "-f", "deployments/operator/samples/deviceplugin_v1_sgxdeviceplugin.yaml")
-
-		utils.Kubectl("", "delete", "-k", "deployments/operator/default/kustomization.yaml")
-	})
 }


### PR DESCRIPTION
While working for #1470, I noticed that we have go-cognit's min-complexity value is 31 and in many parts, it is already so close to the value that little addition of the code causes an error message from the linter check.

I do not know if we need to decide to ignore that check for e2e tests, but there is one thing we can improve already.
Tests with operator have duplicate code, and seems to be right decision to make a common function in utils.go.
