### PR TITLE
Change the regular expression of the device type to support sIOV device

### DIFF
--- a/cmd/qat_plugin/kerneldrv/kerneldrv.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	adfCtlRegex = regexp.MustCompile(`type: (?P<devtype>[[:alnum:]]+), .* inst_id: (?P<instid>[0-9]+), .* bsf: ([0-9a-f]{4}:)?(?P<bsf>[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]), .* state: (?P<state>[[:alpha:]]+)$`)
+	adfCtlRegex = regexp.MustCompile(`type: (?P<devtype>[[:print:]]+), .* inst_id: (?P<instid>[0-9]+), .* bsf: ([0-9a-f]{4}:)?(?P<bsf>[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]), .* state: (?P<state>[[:alpha:]]+)$`)
 )
 
 type endpoint struct {


### PR DESCRIPTION
…OV device of QAT

The string of the sIOV device type exceeds the range of [[alnum]], such as: # adf_ctl status
Checking status of all devices.
There is 2 QAT acceleration device(s) in the system:
 qat_dev0 - type: vqat-adi,  inst_id: 0,  node_id: 0,  bsf: 0000:00:08.0,  #accel: 1 #engines: 1 state: up
 qat_dev1 - type: vqat-adi,  inst_id: 1,  node_id: 0,  bsf: 0000:00:09.0,  #accel: 1 #engines: 1 state: up