### PR TITLE
Add SELinux Labels for DSA and IAA

### DIFF
--- a/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
+++ b/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
@@ -24,6 +24,8 @@ spec:
         image: intel/intel-dsa-plugin:devel
         imagePullPolicy: IfNotPresent
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
+++ b/deployments/dsa_plugin/overlays/dsa_initcontainer/dsa_initcontainer.yaml
@@ -14,6 +14,8 @@ spec:
                 fieldPath: spec.nodeName
         image: intel/intel-idxd-config-initcontainer:devel
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_init_t"
           readOnlyRootFilesystem: true
           privileged: true
         volumeMounts:

--- a/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
+++ b/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
@@ -24,6 +24,8 @@ spec:
         image: intel/intel-iaa-plugin:devel
         imagePullPolicy: IfNotPresent
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/deployments/iaa_plugin/overlays/iaa_initcontainer/iaa_initcontainer.yaml
+++ b/deployments/iaa_plugin/overlays/iaa_initcontainer/iaa_initcontainer.yaml
@@ -16,6 +16,8 @@ spec:
             value: "iaa"
         image: intel/intel-idxd-config-initcontainer:devel
         securityContext:
+          seLinuxOptions:
+            type: "container_device_plugin_init_t"
           readOnlyRootFilesystem: true
           privileged: true
         volumeMounts:

--- a/pkg/controllers/dsa/controller.go
+++ b/pkg/controllers/dsa/controller.go
@@ -130,6 +130,9 @@ func addInitContainer(ds *apps.DaemonSet, dp *devicepluginv1.DsaDevicePlugin) {
 			},
 		},
 		SecurityContext: &v1.SecurityContext{
+			SELinuxOptions: &v1.SELinuxOptions{
+				Type: "container_device_plugin_init_t",
+			},
 			ReadOnlyRootFilesystem: &yes,
 			Privileged:             &yes,
 		},

--- a/pkg/controllers/dsa/controller_test.go
+++ b/pkg/controllers/dsa/controller_test.go
@@ -79,6 +79,9 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							Image:           devicePlugin.Spec.Image,
 							ImagePullPolicy: "IfNotPresent",
 							SecurityContext: &v1.SecurityContext{
+								SELinuxOptions: &v1.SELinuxOptions{
+									Type: "container_device_plugin_t",
+								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
 							},

--- a/pkg/controllers/iaa/controller.go
+++ b/pkg/controllers/iaa/controller.go
@@ -129,6 +129,9 @@ func addInitContainer(ds *apps.DaemonSet, dp *devicepluginv1.IaaDevicePlugin) {
 			},
 		},
 		SecurityContext: &v1.SecurityContext{
+			SELinuxOptions: &v1.SELinuxOptions{
+				Type: "container_device_plugin_init_t",
+			},
 			ReadOnlyRootFilesystem: &yes,
 			Privileged:             &yes,
 		},

--- a/pkg/controllers/iaa/controller_test.go
+++ b/pkg/controllers/iaa/controller_test.go
@@ -79,6 +79,9 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							Image:           devicePlugin.Spec.Image,
 							ImagePullPolicy: "IfNotPresent",
 							SecurityContext: &v1.SecurityContext{
+								SELinuxOptions: &v1.SELinuxOptions{
+									Type: "container_device_plugin_t",
+								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
 							},


### PR DESCRIPTION
Proper SELinux labels are required for the plugins to run in SELinux enabled clusters like openshift. These labels are custom made for plugins and are part of container-selinux package. Add these labels to IAA and DSA.