### PR TITLE
webhooks: stop handling Pod updates

### DIFF
--- a/deployments/fpga_admissionwebhook/webhook/manifests.yaml
+++ b/deployments/fpga_admissionwebhook/webhook/manifests.yaml
@@ -20,7 +20,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/deployments/operator/webhook/manifests.yaml
+++ b/deployments/operator/webhook/manifests.yaml
@@ -161,7 +161,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None
@@ -182,7 +181,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/deployments/sgx_admissionwebhook/webhook/manifests.yaml
+++ b/deployments/sgx_admissionwebhook/webhook/manifests.yaml
@@ -21,7 +21,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/pkg/fpgacontroller/patcher/patchermanager.go
+++ b/pkg/fpgacontroller/patcher/patchermanager.go
@@ -71,7 +71,7 @@ func (pm *Manager) GetPodMutator() func(ctx context.Context, req webhook.Admissi
 	return pm.mutate
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/pods,mutating=true,failurePolicy=Ignore,groups="",resources=pods,versions=v1,name=fpga.mutator.webhooks.intel.com,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create,path=/pods,mutating=true,failurePolicy=Ignore,groups="",resources=pods,versions=v1,name=fpga.mutator.webhooks.intel.com,sideEffects=None,admissionReviewVersions=v1
 
 func (pm *Manager) mutate(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
 	podResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}

--- a/pkg/webhooks/sgx/sgx.go
+++ b/pkg/webhooks/sgx/sgx.go
@@ -29,7 +29,7 @@ import (
 
 var ErrObjectType = errors.New("invalid runtime object type")
 
-// +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=sgx.mutator.webhooks.intel.com,sideEffects=None,admissionReviewVersions=v1,reinvocationPolicy=IfNeeded
+// +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create,versions=v1,name=sgx.mutator.webhooks.intel.com,sideEffects=None,admissionReviewVersions=v1,reinvocationPolicy=IfNeeded
 
 // Mutator annotates Pods.
 type Mutator struct{}


### PR DESCRIPTION
FPGA and SGX webhooks mutate container resources which are immutable. Therefore, stop processing pod updates and act on creation only.

Fixes: #1357