### PR TITLE
ci: drop kind tests from Jenkins too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,13 +139,6 @@ pipeline {
             }
           }
         }
-        stage('make test-with-kind') {
-          steps {
-            dir(path: "$REPO_DIR") {
-              sh "make test-with-kind REG=intel/ TAG=devel"
-            }
-          }
-        }
         stage('push images') {
           when { not { changeRequest() } }
           steps {


### PR DESCRIPTION
kind tests were dropped from GHA long time ago as they were time consuming and did not improve test coverage.

Jenkins had those tests still running and they worked fine until they were made HW dependent.

This change drops kind tests from CI completely.