### PR TITLE
sgx: use NodeFeatureRule SGX label in the NFD overlay

### DIFF
--- a/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/kustomization.yaml
@@ -2,6 +2,11 @@ resources:
   - ../../base
   - ../../../sgx_admissionwebhook/overlays/default-with-certmanager
 
+patches:
+- path: nfd_label.yaml
+  target:
+    name: intel-sgx-plugin
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 replacements:

--- a/deployments/sgx_plugin/overlays/epc-nfd/nfd_label.yaml
+++ b/deployments/sgx_plugin/overlays/epc-nfd/nfd_label.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-sgx-plugin
+spec:
+  template:
+    spec:
+      nodeSelector:
+        intel.feature.node.kubernetes.io/sgx: "true"


### PR DESCRIPTION
Our SGX README guides users to first deploy NFD and create NodeFeatureRules when sgx_plugin/overlays/epc-nfd is used. However, it turns out the "SGX enabled" label is not being used by the plugin DaemonSet.

Use "intel.feature.node.kubernetes.io/sgx": "true" as the nodeSelector value when the kustomization overlay with NFD is used.

/cc @ffuerste