### PR TITLE
logging: move away from klogr to ktesting/textlogger

### DIFF
--- a/cmd/fpga_admissionwebhook/main.go
+++ b/cmd/fpga_admissionwebhook/main.go
@@ -20,8 +20,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -38,8 +37,6 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
-
 	_ = fpgav2.AddToScheme(scheme)
 }
 
@@ -48,12 +45,14 @@ func main() {
 		enableLeaderElection bool
 	)
 
+	tlConf := textlogger.NewConfig()
+	tlConf.AddFlags(flag.CommandLine)
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(klogr.New())
+	ctrl.SetLogger(textlogger.NewLogger(tlConf))
 
 	tlsCfgFunc := func(cfg *tls.Config) {
 		cfg.MinVersion = tls.VersionTLS13

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -108,7 +108,8 @@ func main() {
 		pm                    *patcher.Manager
 	)
 
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	tlConf := textlogger.NewConfig()
+	tlConf.AddFlags(flag.CommandLine)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -118,6 +119,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Var(&devices, "devices", "Device(s) to set up.")
 	flag.Parse()
+
+	ctrl.SetLogger(textlogger.NewLogger(tlConf))
 
 	if len(devices) == 0 {
 		devices = supportedDevices

--- a/cmd/sgx_admissionwebhook/main.go
+++ b/cmd/sgx_admissionwebhook/main.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"crypto/tls"
+	"flag"
 	"os"
 
 	sgxwebhook "github.com/intel/intel-device-plugins-for-kubernetes/pkg/webhooks/sgx"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -32,12 +32,11 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-func init() {
-	klog.InitFlags(nil)
-}
-
 func main() {
-	ctrl.SetLogger(klogr.New())
+	tlConf := textlogger.NewConfig()
+	tlConf.AddFlags(flag.CommandLine)
+	flag.Parse()
+	ctrl.SetLogger(textlogger.NewLogger(tlConf))
 
 	tlsCfgFunc := func(cfg *tls.Config) {
 		cfg.MinVersion = tls.VersionTLS13

--- a/pkg/fpgacontroller/fpgacontroller_test.go
+++ b/pkg/fpgacontroller/fpgacontroller_test.go
@@ -15,30 +15,25 @@
 package fpgacontroller
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	fpgav2 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga/v2"
 	"github.com/intel/intel-device-plugins-for-kubernetes/pkg/fpgacontroller/patcher"
+	"k8s.io/klog/v2/ktesting"
 )
 
 var (
 	errClient = errors.New("client error")
-	logger    = ctrl.Log.WithName("test")
 	scheme    = runtime.NewScheme()
 )
 
 func init() {
-	ctrl.SetLogger(klogr.New())
-
 	_ = fpgav2.AddToScheme(scheme)
 }
 
@@ -64,13 +59,13 @@ func TestAcceleratorFunctionReconcile(t *testing.T) {
 
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
 			reconciler := &AcceleratorFunctionReconciler{
 				Client: &mockClient{
 					getError: tt.getError,
 				},
 				PatcherManager: patcher.NewPatcherManager(logger),
 			}
-			ctx := log.IntoContext(context.Background(), logger)
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{})
 			if err != nil && !tt.expectedErr {
 				t.Errorf("unexpected error: %+v", err)
@@ -85,10 +80,12 @@ func TestAcceleratorFunctionReconcile(t *testing.T) {
 func TestAcceleratorFunctionSetupWithManager(t *testing.T) {
 	r := &AcceleratorFunctionReconciler{}
 
+	logger, _ := ktesting.NewTestContext(t)
 	err := r.SetupWithManager(&mockManager{
 		scheme: scheme,
 		log:    logger,
 	})
+
 	if err != nil {
 		t.Errorf("unexpected error: %+v", err)
 	}
@@ -116,13 +113,13 @@ func TestFpgaRegionReconcile(t *testing.T) {
 
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
 			reconciler := &FpgaRegionReconciler{
 				Client: &mockClient{
 					getError: tt.getError,
 				},
 				PatcherManager: patcher.NewPatcherManager(logger),
 			}
-			ctx := log.IntoContext(context.Background(), logger)
 			_, err := reconciler.Reconcile(ctx, ctrl.Request{})
 			if err != nil && !tt.expectedErr {
 				t.Errorf("unexpected error: %+v", err)
@@ -137,10 +134,12 @@ func TestFpgaRegionReconcile(t *testing.T) {
 func TestFpgaRegionSetupWithManager(t *testing.T) {
 	r := &FpgaRegionReconciler{}
 
+	logger, _ := ktesting.NewTestContext(t)
 	err := r.SetupWithManager(&mockManager{
 		scheme: scheme,
 		log:    logger,
 	})
+
 	if err != nil {
 		t.Errorf("unexpected error: %+v", err)
 	}

--- a/pkg/fpgacontroller/patcher/patcher_test.go
+++ b/pkg/fpgacontroller/patcher/patcher_test.go
@@ -15,7 +15,6 @@
 package patcher
 
 import (
-	"flag"
 	"reflect"
 	"testing"
 
@@ -25,11 +24,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	fpgav2 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga/v2"
+	"k8s.io/klog/v2/ktesting"
 )
-
-func init() {
-	_ = flag.Set("v", "4")
-}
 
 func checkExpectedError(t *testing.T, expectedErr bool, err error, testName string) {
 	t.Helper()
@@ -145,7 +141,8 @@ func TestPatcherStorageFunctions(t *testing.T) {
 
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newPatcher(ctrl.Log.WithName("test"))
+			logger, _ := ktesting.NewTestContext(t)
+			p := newPatcher(logger)
 			for _, af := range tt.afsToAdd {
 				err := p.AddAf(af)
 				checkExpectedError(t, tt.expectedErr, err, tt.name)

--- a/pkg/fpgacontroller/patcher/patchermanager_test.go
+++ b/pkg/fpgacontroller/patcher/patchermanager_test.go
@@ -15,7 +15,6 @@
 package patcher
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -24,19 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2/klogr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	fpgav2 "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/fpga/v2"
+	"k8s.io/klog/v2/ktesting"
 )
 
-func init() {
-	ctrl.SetLogger(klogr.New())
-}
-
 func TestGetPatcher(t *testing.T) {
-	log := ctrl.Log.WithName("test")
+	log, _ := ktesting.NewTestContext(t)
 	namespace := "test"
 	tcases := []struct {
 		pm   *Manager
@@ -165,7 +159,7 @@ func TestMutate(t *testing.T) {
 
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
-			log := ctrl.Log.WithName("test")
+			log, ctx := ktesting.NewTestContext(t)
 			p := newPatcher(log)
 			p.AddRegion(&fpgav2.FpgaRegion{
 				ObjectMeta: metav1.ObjectMeta{
@@ -177,7 +171,7 @@ func TestMutate(t *testing.T) {
 			})
 			pm := NewPatcherManager(log)
 			pm.patchers["default"] = p
-			resp := pm.GetPodMutator()(context.TODO(), webhook.AdmissionRequest{AdmissionRequest: tcase.ar})
+			resp := pm.GetPodMutator()(ctx, webhook.AdmissionRequest{AdmissionRequest: tcase.ar})
 
 			actualPatchOps := 0
 			if tcase.expectedAllowed != resp.Allowed {

--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -76,7 +76,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 
-	logf.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	logf.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "deployments", "operator", "crd", "bases")},


### PR DESCRIPTION
klog has added ktesting/textlogger and is going to deprecate klogr. The deprecation is going to trigger golangci-lint (staticcheck) errors so rework the logging and move to ktesting/textlogger.

The commit also fixes the loglevel setting with operator.

Split from #1584 