### PR TITLE
workflow: fix permissions for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,15 @@ jobs:
   trivy:
     name: Trivy
     uses: "./.github/workflows/lib-trivy.yaml"
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     with:
       deployments: false
       dockerfiles: false
       export-csv: true
+      upload-to-github-security-tab: false
 
   build:
     name: Build & Publish


### PR DESCRIPTION
Attempt to fix this:
[Invalid workflow file: .github/workflows/release.yaml#L23](https://github.com/intel/intel-device-plugins-for-kubernetes/actions/runs/7273880873/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 23, Col: 3): Error calling workflow 'intel/intel-device-plugins-for-kubernetes/.github/workflows/lib-trivy.yaml@49d59d4eb60baae858d3403eb3f07b3e52b830d0'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'. .github/workflows/release.yaml (Line: 23, Col: 3): Error calling workflow 'intel/intel-device-plugins-for-kubernetes/.github/workflows/lib-trivy.yaml@49d59d4eb60baae858d3403eb3f07b3e52b830d0'. The nested job 'trivy-scan-vulns' is requesting 'security-events: write', but is only allowed 'security-events: none'.