### PR TITLE
qat: drop c6xxvf from defaults

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,8 +106,8 @@ initImage:
 
 dpdkDriver: vfio-pci
 kernelVfDrivers:
-  - c6xxvf
   - 4xxxvf
+  - 420xxvf
 maxNumDevices: 128
 logLevel: 4
 

--- a/cmd/qat_plugin/README.md
+++ b/cmd/qat_plugin/README.md
@@ -41,7 +41,7 @@ The QAT plugin can take a number of command line arguments, summarised in the fo
 | Flag | Argument | Meaning |
 |:---- |:-------- |:------- |
 | -dpdk-driver | string | DPDK Device driver for configuring the QAT device (default: `vfio-pci`) |
-| -kernel-vf-drivers | string | Comma separated list of the QuickAssist VFs to search and use in the system. Devices supported: DH895xCC, C62x, C3xxx, 4xxx/401xx/402xx, 420xx, C4xxx and D15xx (default: `c6xxvf,4xxxvf,420xxvf`) |
+| -kernel-vf-drivers | string | Comma separated list of the QuickAssist VFs to search and use in the system. Devices supported: DH895xCC, C62x, C3xxx, 4xxx/401xx/402xx, 420xx, C4xxx and D15xx (default: `4xxxvf,420xxvf`) |
 | -max-num-devices | int | maximum number of QAT devices to be provided to the QuickAssist device plugin (default: `64`) |
 | -mode | string | Deprecated: plugin mode which can be either `dpdk` or `kernel` (default: `dpdk`).|
 | -allocation-policy | string | 2 possible values: balanced and packed. Balanced mode spreads allocated QAT VF resources balanced among QAT PF devices, and packed mode packs one QAT PF device full of QAT VF resources before allocating resources from the next QAT PF. (There is no default.) |

--- a/cmd/qat_plugin/qat_plugin.go
+++ b/cmd/qat_plugin/qat_plugin.go
@@ -40,7 +40,7 @@ func main() {
 	mode := flag.String("mode", "dpdk", "plugin mode which can be either dpdk (default) or kernel")
 
 	dpdkDriver := flag.String("dpdk-driver", "vfio-pci", "DPDK Device driver for configuring the QAT device")
-	kernelVfDrivers := flag.String("kernel-vf-drivers", "c6xxvf,4xxxvf,420xxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, C4xxx, 4xxx, 420xxx, and D15xx")
+	kernelVfDrivers := flag.String("kernel-vf-drivers", "4xxxvf,420xxvf", "Comma separated VF Device Driver of the QuickAssist Devices in the system. Devices supported: DH895xCC, C62x, C3xxx, C4xxx, 4xxx, 420xxx, and D15xx")
 	preferredAllocationPolicy := flag.String("allocation-policy", "", "Modes of allocating QAT devices: balanced and packed")
 	maxNumDevices := flag.Int("max-num-devices", 64, "maximum number of QAT devices to be provided to the QuickAssist device plugin")
 	flag.Parse()

--- a/deployments/operator/samples/deviceplugin_v1_qatdeviceplugin.yaml
+++ b/deployments/operator/samples/deviceplugin_v1_qatdeviceplugin.yaml
@@ -13,7 +13,6 @@ spec:
   initImage: intel/intel-qat-initcontainer:0.30.0
   dpdkDriver: vfio-pci
   kernelVfDrivers:
-    - c6xxvf
     - 4xxxvf
     - 420xxvf
   maxNumDevices: 1


### PR DESCRIPTION
The devices searched by default are QAT Gen4+ only.