### PR TITLE
fpga: add subsystem vendor & device fields to PCIDevice

### DIFF
--- a/pkg/fpga/pci_linux.go
+++ b/pkg/fpga/pci_linux.go
@@ -43,6 +43,8 @@ type PCIDevice struct {
 	BDF       string
 	Vendor    string
 	Device    string
+	SubVendor string
+	SubDevice string
 	Class     string
 	CPUs      string
 	NUMA      string
@@ -78,13 +80,15 @@ func NewPCIDevice(devPath string) (*PCIDevice, error) {
 	}
 
 	fileMap := map[string]*string{
-		"vendor":         &pci.Vendor,
-		"device":         &pci.Device,
-		"class":          &pci.Class,
-		"local_cpulist":  &pci.CPUs,
-		"numa_node":      &pci.NUMA,
-		"sriov_numvfs":   &pci.VFs,
-		"sriov_totalvfs": &pci.TotalVFs,
+		"vendor":           &pci.Vendor,
+		"device":           &pci.Device,
+		"subsystem_vendor": &pci.SubVendor,
+		"subsystem_device": &pci.SubDevice,
+		"class":            &pci.Class,
+		"local_cpulist":    &pci.CPUs,
+		"numa_node":        &pci.NUMA,
+		"sriov_numvfs":     &pci.VFs,
+		"sriov_totalvfs":   &pci.TotalVFs,
 	}
 
 	if err = readFilesInDirectory(fileMap, pci.SysFsPath); err != nil {


### PR DESCRIPTION
Adds subsystem vendor and device information to PCIDevice struct.

Useful for distinguishing different FPGA boards driven by the DFL driver, where vendor and device ID are the same ([DFL PCI IDs](https://github.com/OFS/dfl-feature-id/blob/main/dfl-pci-ids.rst)).