### PR TITLE
QAT: make plugin read trimmed heartbeat status

### DIFF
--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
@@ -416,7 +416,7 @@ func getDeviceHealthiness(device string, lookup map[string]string) string {
 
 	// If status reads "-1", the device is considered bad:
 	// https://github.com/torvalds/linux/blob/v6.6-rc5/Documentation/ABI/testing/debugfs-driver-qat
-	if data, err := os.ReadFile(hbStatusFile); err == nil && string(data) == "-1" {
+	if data, err := os.ReadFile(hbStatusFile); err == nil && strings.Split(string(data), "\n")[0] == "-1" {
 		healthiness = pluginapi.Unhealthy
 	}
 


### PR DESCRIPTION
Plugin used to consider only the value "-1" but there are some cases when files show "\n" or "\n\x00". This makes plugin to have wrong status of the device. So, trim the value after \n so only numerical value can be read.