### PR TITLE
workflow: sign release containers

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -48,6 +48,9 @@ jobs:
 
   # devel image push
   publish:
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - e2e
       - build

--- a/.github/workflows/lib-publish.yaml
+++ b/.github/workflows/lib-publish.yaml
@@ -6,16 +6,24 @@ on:
         default: "devel"
         required: false
         type: string
+      registry:
+        default: "docker.io/intel"
+        required: false
+        type: string
 env:
   no_base_check: "['intel-qat-plugin-kerneldrv', 'intel-idxd-config-initcontainer', 'crypto-perf', 'opae-nlb-demo']"
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   image:
     name: Build image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -52,21 +60,33 @@ jobs:
         env:
           IMAGE_NAME: ${{ matrix.image }}
         run: |
-          REG=intel/ make ${IMAGE_NAME} BUILDER=docker
+          ORG=${{ inputs.registry }} TAG=${{ inputs.image_tag }} make ${IMAGE_NAME} BUILDER=docker
       - name: Trivy scan for image
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # 0.24.0
         with:
           scan-type: image
-          image-ref: intel/${{ matrix.image }}:${{ inputs.image_tag }}
+          image-ref: ${{ inputs.registry }}/${{ matrix.image }}:${{ inputs.image_tag }}
           exit-code: 1
       - name: Test image base layer
         # Don't run base layer check for selected images
         if: ${{ !contains(fromJson(env.no_base_check), matrix.image) }}
-        run: IMG=intel/${{ matrix.image }}:${{ inputs.image_tag }} make test-image-base-layer BUILDER=docker
+        run: IMG=${{ inputs.registry }}/${{ matrix.image }}:${{ inputs.image_tag }} make test-image-base-layer BUILDER=docker
       - name: Login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASS }}
       - name: Push
-        run: docker push intel/${{ matrix.image }}:${{ inputs.image_tag }}
+        run: docker push ${{ inputs.registry }}/${{ matrix.image }}:${{ inputs.image_tag }}
+      - name: Get image digest
+        if: ${{ inputs.image_tag != 'devel' }}
+        id: digest
+        run: |
+          echo "image_sha=$(docker inspect --format='{{index .RepoDigests 0}}' ${{ inputs.registry }}/${{ matrix.image }}:${{ inputs.image_tag }})" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        if: ${{ inputs.image_tag != 'devel' }}
+        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 #v3.6.0
+      - name: Keyless image sign
+        if: ${{ inputs.image_tag != 'devel' }}
+        run: |
+          cosign sign --yes ${{ steps.digest.outputs.image_sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
 
   build:
     name: Build & Publish
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - trivy
       - tag_fix

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
     * [Supported Kubernetes versions](#supported-kubernetes-versions)
     * [Release procedures](#release-procedures)
 * [Pre-built plugin images](#pre-built-plugin-images)
+    * [Signed container images](#signed-container-images)
 * [License](#license)
 * [Helm charts](#helm-charts)
 
@@ -290,6 +291,12 @@ the branches and releases in this repository.
 **Note:** the default deployment files and operators are configured with
 [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
 ```IfNotPresent``` and can be changed with ```scripts/set-image-pull-policy.sh```.
+
+### Signed container images
+
+Starting from 0.31 release, the images (`0.31.0` etc., not `devel`) are signed with keyless signing using `cosign`. The signing proof is stored in [rekor.sigstore.dev](https://rekor.sigstore.dev) in an append-only transparency log. The signature is also stored within the dockerhub.
+
+To verify the signing in Kubernetes, one can use [policy managers](https://docs.sigstore.dev/policy-controller/overview/) with [keyless authorities](https://docs.sigstore.dev/policy-controller/overview/#configuring-keyless-authorities).
 
 ## License
 


### PR DESCRIPTION
Signs release containers with `cosign`. Also modified the publish workflow to support other registries. Makes it easier to test changes.

Tests:
https://hub.docker.com/repository/docker/tkatila/intel-gpu-plugin/tags

Test runs:
https://github.com/tkatila/intel-device-plugins-for-kubernetes/actions/runs/10367001757/job/28697484565
https://github.com/tkatila/intel-device-plugins-for-kubernetes/actions/runs/10367083492/job/28697736086

cosign can be used to verify containers:
`cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp https://github.com/tkatila/intel-device-plugins-for-kubernetes/.github/workflows/lib-publish.yaml.* tkatila/intel-gpu-plugin:0.30.101  | jq .`