### PR TITLE
operator, qat: fix a bug that removes default annotation

### DIFF
--- a/pkg/controllers/qat/controller.go
+++ b/pkg/controllers/qat/controller.go
@@ -82,8 +82,11 @@ func (c *controller) NewDaemonSet(rawObj client.Object) *apps.DaemonSet {
 
 	daemonSet := deployments.QATPluginDaemonSet()
 	daemonSet.Name = controllers.SuffixedName(daemonSet.Name, devicePlugin.Name)
-	daemonSet.Annotations = annotations
-	daemonSet.Spec.Template.Annotations = annotations
+
+	for annotation, value := range annotations {
+		daemonSet.Annotations[annotation] = value
+		daemonSet.Spec.Template.Annotations[annotation] = value
+	}
 
 	if devicePlugin.Spec.Tolerations != nil {
 		daemonSet.Spec.Template.Spec.Tolerations = devicePlugin.Spec.Tolerations


### PR DESCRIPTION
fix a bug that removes default annotation for apparmor and add a unit test for the case that was not covered before

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>