### PR TITLE
Add cpu/memory requests and limits

### DIFF
--- a/deployments/dlb_plugin/base/intel-dlb-plugin.yaml
+++ b/deployments/dlb_plugin/base/intel-dlb-plugin.yaml
@@ -32,6 +32,13 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         terminationMessagePath: /tmp/termination-log          
+        resources:
+          requests:
+            memory: "15Mi"
+            cpu: 40m
+          limits:
+            memory: "30Mi"
+            cpu: 100m
         volumeMounts:
         - name: devfs
           mountPath: /dev

--- a/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
+++ b/deployments/dsa_plugin/base/intel-dsa-plugin.yaml
@@ -33,6 +33,13 @@ spec:
             type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+        resources:
+          requests:
+            memory: "25Mi"
+            cpu: 50m
+          limits:
+            memory: "50Mi"
+            cpu: 100m
         volumeMounts:
         - name: devfs
           mountPath: /dev/dsa

--- a/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml
+++ b/deployments/fpga_plugin/base/intel-fpga-plugin-daemonset.yaml
@@ -44,6 +44,13 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+        resources:
+          requests:
+            memory: "30Mi"
+            cpu: 80m
+          limits:
+            memory: "60Mi"
+            cpu: 160m
         volumeMounts:
         - name: devfs
           mountPath: /dev

--- a/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
+++ b/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
@@ -36,6 +36,13 @@ spec:
             type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+        resources:
+          requests:
+            memory: "45Mi"
+            cpu: 40m
+          limits:
+            memory: "90Mi"
+            cpu: 100m
         volumeMounts:
         - name: devfs
           mountPath: /dev/dri

--- a/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
+++ b/deployments/iaa_plugin/base/intel-iaa-plugin.yaml
@@ -33,6 +33,13 @@ spec:
             type: "container_device_plugin_t"
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+        resources:
+          requests:
+            memory: "25Mi"
+            cpu: 60m
+          limits:
+            memory: "50Mi"
+            cpu: 120m
         volumeMounts:
         - name: devfs
           mountPath: /dev/iax

--- a/deployments/qat_plugin/base/intel-qat-plugin.yaml
+++ b/deployments/qat_plugin/base/intel-qat-plugin.yaml
@@ -37,6 +37,13 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            memory: "15Mi"
+            cpu: 70m
+          limits:
+            memory: "30Mi"
+            cpu: 140m
         volumeMounts:
         - name: devdir
           mountPath: /dev/vfio

--- a/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
+++ b/deployments/sgx_plugin/base/intel-sgx-plugin.yaml
@@ -28,6 +28,13 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            memory: "15Mi"
+            cpu: 40m
+          limits:
+            memory: "30Mi"
+            cpu: 100m
         volumeMounts:
         - name: kubeletsockets
           mountPath: /var/lib/kubelet/device-plugins

--- a/pkg/controllers/dlb/controller_test.go
+++ b/pkg/controllers/dlb/controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -91,6 +92,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 							SecurityContext: &v1.SecurityContext{
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("30Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("40m"),
+									v1.ResourceMemory: resource.MustParse("15Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/pkg/controllers/dsa/controller_test.go
+++ b/pkg/controllers/dsa/controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -95,6 +96,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("25Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/pkg/controllers/fpga/controller_test.go
+++ b/pkg/controllers/fpga/controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -94,6 +95,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								AllowPrivilegeEscalation: &no,
 							},
 							TerminationMessagePath: "/tmp/termination-log",
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("160m"),
+									v1.ResourceMemory: resource.MustParse("60Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("80m"),
+									v1.ResourceMemory: resource.MustParse("30Mi"),
+								},
+							},
 							VolumeMounts: []v1.VolumeMount{
 								{
 									MountPath: "/dev",

--- a/pkg/controllers/gpu/controller_test.go
+++ b/pkg/controllers/gpu/controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -105,6 +106,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("90Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("40m"),
+									v1.ResourceMemory: resource.MustParse("45Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/pkg/controllers/iaa/controller_test.go
+++ b/pkg/controllers/iaa/controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -95,6 +96,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("120m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("60m"),
+									v1.ResourceMemory: resource.MustParse("25Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/pkg/controllers/qat/controller_test.go
+++ b/pkg/controllers/qat/controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -99,6 +100,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("140m"),
+									v1.ResourceMemory: resource.MustParse("30Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("70m"),
+									v1.ResourceMemory: resource.MustParse("15Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/pkg/controllers/sgx/controller_test.go
+++ b/pkg/controllers/sgx/controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -87,6 +88,16 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 								},
 								ReadOnlyRootFilesystem:   &yes,
 								AllowPrivilegeEscalation: &no,
+							},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("30Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("40m"),
+									v1.ResourceMemory: resource.MustParse("15Mi"),
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{


### PR DESCRIPTION
Operator maturity level 3 requires cpu/memory requests and limits for operands. Add them to all plugins deployed by operator.