### PR TITLE
operator: change name prefix of controller-manager

### DIFF
--- a/deployments/operator/default/kustomization.yaml
+++ b/deployments/operator/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: inteldeviceplugins-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: inteldeviceplugins-
+namePrefix: intel-deviceplugins-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/deployments/operator/device/dlb/dlb.yaml
+++ b/deployments/operator/device/dlb/dlb.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:

--- a/deployments/operator/device/dsa/dsa.yaml
+++ b/deployments/operator/device/dsa/dsa.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:

--- a/deployments/operator/device/fpga/fpga.yaml
+++ b/deployments/operator/device/fpga/fpga.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:

--- a/deployments/operator/device/gpu/gpu.yaml
+++ b/deployments/operator/device/gpu/gpu.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:

--- a/deployments/operator/device/qat/qat.yaml
+++ b/deployments/operator/device/qat/qat.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:

--- a/deployments/operator/device/sgx/sgx.yaml
+++ b/deployments/operator/device/sgx/sgx.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inteldeviceplugins-controller-manager
+  name: intel-deviceplugins-controller-manager
   namespace: inteldeviceplugins-system
 spec:
   template:


### PR DESCRIPTION
To sync with operator bundle that has been 'intel-deviceplugins-' since 0.30.0 version, change the name prefix.