### PR TITLE
operator: fix upgradeImages

### DIFF
--- a/pkg/controllers/reconciler.go
+++ b/pkg/controllers/reconciler.go
@@ -158,10 +158,13 @@ func UpgradeImages(ctx context.Context, image *string, initimage *string) (upgra
 		if s == nil {
 			continue
 		}
-
+		// e.g. intel-dsa-plugin@sha256:hash -> [intel-dsa-plugin@sha256, hash]
 		if parts := strings.SplitN(*s, ":", 2); len(parts) == 2 && len(parts[0]) > 0 {
-			name, version := parts[0], parts[1]
+			// e.g. [intel-dsa-plugin@sha256, hash] -> [intel-dsa-plugin, hash]
+			name, version := strings.TrimSuffix(parts[0], "@sha256"), parts[1]
 
+			// e.g. intel-dsa-plugin -> INTEL_DSA_PLUGIN_SHA
+			// and get the value of the env var INTEL_DSA_PLUGIN_SHA
 			envVarValue := os.Getenv(strings.ReplaceAll(strings.ToUpper(filepath.Base(name)), "-", "_") + "_SHA")
 
 			if envVarValue != "" && *s != envVarValue {


### PR DESCRIPTION
fixes: #1873 
Operatorhub bundle can have sha256 image tags that are put through env vars. When operator controller manager gets upgraded, its operands (plugin daemonsets) should be updated to the image in the env vars. But it has not been working properly because of wrong parsing.

Fix it to parse the image names that have sha256 tags correctly so env vars in operator can be used as intended.