### PR TITLE
e2e: update e2e tests to use -label-filter

### DIFF
--- a/.github/workflows/lib-e2e.yaml
+++ b/.github/workflows/lib-e2e.yaml
@@ -28,7 +28,7 @@ jobs:
               - accel-config-demo
               - intel-deviceplugin-operator
           - name: e2e-qat-gnrd
-            targetjob: e2e-qat FOCUS="Mode:dpdk" SKIP="(App:(crypto-perf|compress-perf)|Functionality)"
+            targetjob: e2e-qat LABEL_FILTER="Mode:dpdk && !/App:(crypto-perf|compress-perf|noapp)/ && !/Functionality:.+/"
             runner: simics-gnrd
             images:
               - intel-qat-plugin
@@ -42,7 +42,7 @@ jobs:
               - intel-fpga-admissionwebhook
               - opae-nlb-demo
           - name: e2e-spr
-            targetjob: e2e-spr SKIP="App:compress-perf"
+            targetjob: e2e-spr LABEL_FILTER="!App:compress-perf && !App:noapp"
             runner: spr
             images:
               - intel-qat-plugin

--- a/Makefile
+++ b/Makefile
@@ -141,38 +141,37 @@ TAG?=devel
 export TAG
 
 ifeq ($(E2E_LEVEL), $(filter $(E2E_LEVEL), full))
-  GENERATED_SKIP_OPT=-ginkgo.skip "App:noapp"
+  DEFAULT_LABEL_FILTER="!App:noapp"
 else ifeq ($(E2E_LEVEL),basic)
-  ADDITIONAL_FOCUS_REGEX=App:noapp
+  DEFAULT_LABEL_FILTER="App:noapp"
 else
   $(error Unsupported E2E_LEVEL value: $(E2E_LEVEL). Possible options: full, basic)
 endif
-GENERATED_SKIP_OPT += $(if $(SKIP),-ginkgo.skip "$(SKIP)")
-ADDITIONAL_FOCUS_REGEX := $(if $(FOCUS),$(FOCUS).*$(ADDITIONAL_FOCUS_REGEX),$(ADDITIONAL_FOCUS_REGEX))
+LABEL_FILTER := $(if $(LABEL_FILTER),$(LABEL_FILTER),$(DEFAULT_LABEL_FILTER))
 
 e2e-fpga:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:fpga.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:fpga && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-qat:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:qat.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:qat && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-sgx:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:sgx.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:sgx && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-gpu:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:gpu.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:gpu && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-dsa:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:dsa.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:dsa && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-iaa:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:iaa.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:iaa && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-dlb:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:dlb.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "Device:dlb && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 e2e-spr:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:(iaa|dsa)|Device:qat.*Mode:dpdk.*Resource:(cy|dc).*" -ginkgo.focus "Device:sgx.*|(SGX Admission)" -ginkgo.focus "Device:gpu.*Resource:i915" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.label-filter "(/Device:(dsa|iaa|sgx)/ || (Device:qat && Mode:dpdk && !/Functionality:.+/) || (Device:gpu && Resource:i915)) && $(LABEL_FILTER)" -delete-namespace-on-failure=false
 
 pre-pull:
 ifeq ($(TAG),devel)

--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -39,7 +39,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("DLB plugin [Device:dlb]", describe)
+	ginkgo.Describe("DLB plugin", ginkgo.Label("Device:dlb"), describe)
 }
 
 func describe() {
@@ -81,7 +81,7 @@ func describe() {
 		}
 	})
 
-	ginkgo.Context("When PF resources are available [Resource:pf]", func() {
+	ginkgo.Context("When PF resources are available", ginkgo.Label("Resource:pf"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			resource := v1.ResourceName("dlb.intel.com/pf")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, resource, 30*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -89,16 +89,16 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("can run demo app [App:libdlb]", func(ctx context.Context) {
+		ginkgo.It("can run demo app", ginkgo.Label("App:libdlb"), func(ctx context.Context) {
 			runDemoApp(ctx, "PF", demoPFYaml, f)
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When VF resources are available [Resource:vf]", func() {
+	ginkgo.Context("When VF resources are available", ginkgo.Label("Resource:vf"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			resource := v1.ResourceName("dlb.intel.com/vf")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, resource, 30*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -106,11 +106,11 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("can run demo app [App:libdlb]", func(ctx context.Context) {
+		ginkgo.It("can run demo app", ginkgo.Label("App:libdlb"), func(ctx context.Context) {
 			runDemoApp(ctx, "VF", demoVFYaml, f)
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/dsa/dsa.go
+++ b/test/e2e/dsa/dsa.go
@@ -40,7 +40,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("DSA plugin [Device:dsa]", describe)
+	ginkgo.Describe("DSA plugin", ginkgo.Label("Device:dsa"), describe)
 }
 
 func describe() {
@@ -94,7 +94,7 @@ func describe() {
 		}
 	})
 
-	ginkgo.Context("When DSA resources are available [Resource:dedicated]", func() {
+	ginkgo.Context("When DSA resources are available", ginkgo.Label("Resource:dedicated"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "dsa.intel.com/wq-user-dedicated", 300*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -102,7 +102,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a demo app [App:accel-config]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app", ginkgo.Label("App:accel-config"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 			ginkgo.By("waiting for the DSA demo to succeed")
@@ -110,7 +110,7 @@ func describe() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, podName, podName))
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -47,7 +47,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("FPGA Plugin [Device:fpga]", describe)
+	ginkgo.Describe("FPGA Plugin", ginkgo.Label("Device:fpga"), describe)
 }
 
 func describe() {
@@ -64,41 +64,41 @@ func describe() {
 	fmw := framework.NewDefaultFramework("fpgaplugin-e2e")
 	fmw.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
-	ginkgo.Context("When FPGA plugin is running in region mode [Mode:region]", func() {
+	ginkgo.Context("When FPGA plugin is running in region mode", ginkgo.Label("Mode:region"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, arria10NodeResource, "region")
 		})
-		ginkgo.It("runs an opae-nlb-demo pod two times [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod two times", ginkgo.Label("App:opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "region", nlb3PodResource, "nlb3", "nlb0")
 			runTestCase(ctx, fmw, "region", nlb0PodResource, "nlb0", "nlb3")
 		})
 	})
 
-	ginkgo.Context("When FPGA plugin is running in af mode [Mode:af]", func() {
+	ginkgo.Context("When FPGA plugin is running in af mode", ginkgo.Label("Mode:af"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, nlb0NodeResource, "af")
 		})
-		ginkgo.It("runs an opae-nlb-demo pod [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod", ginkgo.Label("App:opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "af", nlb0PodResourceAF, "nlb0", "nlb3")
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When FPGA plugin is running in region mode [Mode:region]", func() {
+	ginkgo.Context("When FPGA plugin is running in region mode", ginkgo.Label("Mode:region"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, arria10NodeResource, "region")
 		})
-		ginkgo.It("runs [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs", ginkgo.Label("App:opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "region", nlb3PodResource, "nlb3", "nlb0")
 		})
-		ginkgo.It("runs an opae-nlb-demo pod [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod", ginkgo.Label("App:opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "region", nlb0PodResource, "nlb0", "nlb3")
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
+++ b/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
@@ -36,7 +36,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("FPGA Admission Webhook", describe)
+	ginkgo.Describe("FPGA Admission Webhook", ginkgo.Label("Device:fpga"), ginkgo.Label("Admission Webhook"), describe)
 }
 
 func describe() {

--- a/test/e2e/gpu/gpu.go
+++ b/test/e2e/gpu/gpu.go
@@ -48,7 +48,7 @@ const (
 
 func init() {
 	// This needs to be Ordered because only one GPU plugin can function on the node at once.
-	ginkgo.Describe("GPU plugin [Device:gpu]", describe, ginkgo.Ordered)
+	ginkgo.Describe("GPU plugin", ginkgo.Label("Device:gpu"), describe, ginkgo.Ordered)
 }
 
 func createPluginAndVerifyExistence(f *framework.Framework, ctx context.Context, kustomizationPath, baseResource string) {
@@ -104,7 +104,7 @@ func describe() {
 		framework.Failf("unable to locate %q: %v", healthMgmtYaml, errFailedToLocateRepoFile)
 	}
 
-	ginkgo.Context("When GPU plugin is deployed [Resource:i915]", func() {
+	ginkgo.Context("When GPU plugin is deployed", ginkgo.Label("Resource:i915"), func() {
 		ginkgo.AfterEach(func(ctx context.Context) {
 			framework.Logf("Removing gpu-plugin manually")
 
@@ -118,7 +118,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("checks availability of GPU resources [App:busybox]", func(ctx context.Context) {
+		ginkgo.It("checks availability of GPU resources", ginkgo.Label("App:busybox"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/i915")
 
 			podListFunc := framework.ListObjects(f.ClientSet.CoreV1().Pods(f.Namespace.Name).List, metav1.ListOptions{})
@@ -189,7 +189,7 @@ func describe() {
 			framework.Logf("found card and renderD from the log")
 		})
 
-		ginkgo.Context("When [Deployment:monitoring] deployment is applied [Resource:i915]", func() {
+		ginkgo.Context("When [Deployment:monitoring] deployment is applied", ginkgo.Label("Resource:i915"), func() {
 			ginkgo.It("check if monitoring resource is available", func(ctx context.Context) {
 				createPluginAndVerifyExistence(f, ctx, monitoringPath, "gpu.intel.com/i915")
 
@@ -200,13 +200,13 @@ func describe() {
 			})
 		})
 
-		ginkgo.Context("When [Deployment:healthManagement] deployment is applied [Resource:i915]", func() {
+		ginkgo.Context("When [Deployment:healthManagement] deployment is applied", ginkgo.Label("Resource:i915"), func() {
 			ginkgo.It("check if i915 resources is available", func(ctx context.Context) {
 				createPluginAndVerifyExistence(f, ctx, healthMgmtPath, "gpu.intel.com/i915")
 			})
 		})
 
-		ginkgo.Context("When [Deployment:resourceManager] deployment is applied [Resource:i915]", func() {
+		ginkgo.Context("When [Deployment:resourceManager] deployment is applied", ginkgo.Label("Resource:i915"), func() {
 			ginkgo.It("check if i915 resources is available", func(ctx context.Context) {
 				e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(nfdRulesPath))
 
@@ -227,7 +227,7 @@ func describe() {
 			})
 		})
 
-		ginkgo.It("run a small workload on the GPU [App:tensorflow]", func(ctx context.Context) {
+		ginkgo.It("run a small workload on the GPU", ginkgo.Label("App:tensorflow"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/i915")
 
 			kustomYaml, err := utils.LocateRepoFile(tfKustomizationYaml)
@@ -247,13 +247,13 @@ func describe() {
 			framework.Logf("tensorflow execution succeeded!")
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When GPU resources are available [Resource:xe]", func() {
-		ginkgo.It("checks availability of GPU resources [App:busybox]", func(ctx context.Context) {
+	ginkgo.Context("When GPU resources are available", ginkgo.Label("Resource:xe"), func() {
+		ginkgo.It("checks availability of GPU resources", ginkgo.Label("App:busybox"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/xe")
 
 			ginkgo.By("submitting a pod requesting GPU resources")
@@ -296,7 +296,7 @@ func describe() {
 			framework.Logf("found card and renderD from the log")
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/iaa/iaa.go
+++ b/test/e2e/iaa/iaa.go
@@ -40,7 +40,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("IAA plugin [Device:iaa]", describe)
+	ginkgo.Describe("IAA plugin", ginkgo.Label("Device:iaa"), describe)
 }
 
 func describe() {
@@ -94,7 +94,7 @@ func describe() {
 		}
 	})
 
-	ginkgo.Context("When IAA resources are available [Resource:dedicated]", func() {
+	ginkgo.Context("When IAA resources are available", ginkgo.Label("Resource:dedicated"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "iaa.intel.com/wq-user-dedicated", 300*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -102,7 +102,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a demo app [App:accel-config]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app", ginkgo.Label("App:accel-config"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 			ginkgo.By("waiting for the IAA demo to succeed")
@@ -110,7 +110,7 @@ func describe() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, podName, podName))
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/qat/qatplugin_dpdk.go
+++ b/test/e2e/qat/qatplugin_dpdk.go
@@ -55,7 +55,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("QAT plugin in DPDK mode [Device:qat] [Mode:dpdk]", describeQatDpdkPlugin)
+	ginkgo.Describe("QAT plugin in DPDK mode", ginkgo.Label("Device:qat"), ginkgo.Label("Mode:dpdk"), describeQatDpdkPlugin)
 }
 
 func describeQatDpdkPlugin() {
@@ -114,7 +114,7 @@ func describeQatDpdkPlugin() {
 		}
 	})
 
-	ginkgo.Context("When QAT resources are continuously available with crypto (cy) services enabled [Resource:cy]", func() {
+	ginkgo.Context("When QAT resources are continuously available with crypto (cy) services enabled", ginkgo.Label("Resource:cy"), func() {
 		// This BeforeEach runs even before the JustBeforeEach above.
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating a configMap before plugin gets deployed")
@@ -124,11 +124,11 @@ func describeQatDpdkPlugin() {
 			resourceName = cyResource
 		})
 
-		ginkgo.It("deploys a crypto pod (openssl) requesting QAT resources [App:openssl]", func(ctx context.Context) {
+		ginkgo.It("deploys a crypto pod (openssl) requesting QAT resources", ginkgo.Label("App:openssl"), func(ctx context.Context) {
 			runCpaSampleCode(ctx, f, symmetric, resourceName)
 		})
 
-		ginkgo.It("deploys a crypto pod (dpdk crypto-perf) requesting QAT resources [App:crypto-perf]", func(ctx context.Context) {
+		ginkgo.It("deploys a crypto pod (dpdk crypto-perf) requesting QAT resources", ginkgo.Label("App:crypto-perf"), func(ctx context.Context) {
 			ginkgo.By("submitting a crypto pod requesting QAT resources")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(cryptoTestYamlPath))
 
@@ -137,12 +137,12 @@ func describeQatDpdkPlugin() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, "qat-dpdk-test-crypto-perf", "crypto-perf"))
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When QAT resources are continuously available with compress (dc) services enabled [Resource:dc]", func() {
+	ginkgo.Context("When QAT resources are continuously available with compress (dc) services enabled", ginkgo.Label("Resource:dc"), func() {
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating a configMap before plugin gets deployed")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "--from-literal", "qat.conf=ServicesEnabled=dc", "qat-config")
@@ -151,11 +151,11 @@ func describeQatDpdkPlugin() {
 			resourceName = dcResource
 		})
 
-		ginkgo.It("deploys a compress pod (openssl) requesting QAT resources [App:openssl]", func(ctx context.Context) {
+		ginkgo.It("deploys a compress pod (openssl) requesting QAT resources", ginkgo.Label("App:openssl"), func(ctx context.Context) {
 			runCpaSampleCode(ctx, f, compression, resourceName)
 		})
 
-		ginkgo.It("deploys a compress pod (dpdk compress-perf) requesting QAT resources [App:compress-perf]", func(ctx context.Context) {
+		ginkgo.It("deploys a compress pod (dpdk compress-perf) requesting QAT resources", ginkgo.Label("App:compress-perf"), func(ctx context.Context) {
 			ginkgo.By("submitting a compress pod requesting QAT resources")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(compressTestYamlPath))
 
@@ -164,7 +164,7 @@ func describeQatDpdkPlugin() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, "qat-dpdk-test-compress-perf", "compress-perf"))
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
@@ -179,7 +179,7 @@ func describeQatDpdkPlugin() {
 				resourceName = dcResource
 			})
 
-			ginkgo.It("checks if unhealthy status is reported [Functionality:heartbeat]", func(ctx context.Context) {
+			ginkgo.It("checks if unhealthy status is reported", ginkgo.Label("Functionality:heartbeat"), func(ctx context.Context) {
 				injectError(ctx, f, resourceName)
 
 				ginkgo.By("waiting node resources become zero")
@@ -198,7 +198,7 @@ func describeQatDpdkPlugin() {
 				resourceName = dcResource
 			})
 
-			ginkgo.It("checks if an injected error gets solved [Functionality:auto-reset]", func(ctx context.Context) {
+			ginkgo.It("checks if an injected error gets solved", ginkgo.Label("Functionality:auto-reset"), func(ctx context.Context) {
 				injectError(ctx, f, resourceName)
 
 				ginkgo.By("seeing if there is zero resource")

--- a/test/e2e/qat/qatplugin_kernel.go
+++ b/test/e2e/qat/qatplugin_kernel.go
@@ -37,7 +37,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("QAT plugin in kernel mode [Device:qat] [Mode:kernel]", describeQatKernelPlugin)
+	ginkgo.Describe("QAT plugin in kernel mode", ginkgo.Label("Device:qat"), ginkgo.Label("Mode:kernel"), describeQatKernelPlugin)
 }
 
 func describeQatKernelPlugin() {
@@ -79,7 +79,7 @@ func describeQatKernelPlugin() {
 		}
 	})
 
-	ginkgo.Context("When QAT resources are available [Resource:cy1_dc0]", func() {
+	ginkgo.Context("When QAT resources are available", ginkgo.Label("Resource:cy1_dc0"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "qat.intel.com/cy1_dc0", 30*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -87,13 +87,14 @@ func describeQatKernelPlugin() {
 			}
 		})
 
-		ginkgo.It("deploys a pod requesting QAT resources [App:busybox]", func(ctx context.Context) {
+		ginkgo.It("deploys a pod requesting QAT resources", ginkgo.Label("App:busybox"), func(ctx context.Context) {
 			ginkgo.By("submitting a pod requesting QAT resources")
 			podSpec := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "qatplugin-tester"},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+
 							Args:    []string{"-c", "echo mode"},
 							Name:    "testcontainer",
 							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
@@ -115,7 +116,7 @@ func describeQatKernelPlugin() {
 			e2epod.NewPodClient(f).WaitForFinish(ctx, pod.ObjectMeta.Name, 60*time.Second)
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -41,7 +41,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("SGX plugin [Device:sgx]", describe)
+	ginkgo.Describe("SGX plugin", ginkgo.Label("Device:sgx"), describe)
 }
 
 func describe() {
@@ -93,7 +93,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a sgx-sdk-demo pod requesting SGX enclave resources [App:sgx-sdk-demo]", func(ctx context.Context) {
+		ginkgo.It("deploys a sgx-sdk-demo pod requesting SGX enclave resources", ginkgo.Label("App:sgx-sdk-demo"), func(ctx context.Context) {
 			podSpec := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "sgxplugin-tester"},
 				Spec: v1.PodSpec{
@@ -120,7 +120,7 @@ func describe() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, pod.ObjectMeta.Name, "testcontainer"))
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", ginkgo.Label("App:noapp"), func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})

--- a/test/e2e/sgxadmissionwebhook/sgxaadmissionwebhook.go
+++ b/test/e2e/sgxadmissionwebhook/sgxaadmissionwebhook.go
@@ -37,7 +37,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("SGX Admission Webhook", describe)
+	ginkgo.Describe("SGX Admission Webhook", ginkgo.Label("Device:sgx"), ginkgo.Label("Admission Webhook"), describe)
 }
 
 func describe() {


### PR DESCRIPTION
fixes: #1862 
Current system with FOCUS and SKIP is complicated. Introduce label filter, update plain text labels of e2e tests to ginkgo.Label(), and update Makefile.

In addition, put labels to admission webhooks for fpga and sgx.