### PR TITLE
codeql: install libze to allow full analysis

### DIFF
--- a/.github/workflows/lib-codeql.yaml
+++ b/.github/workflows/lib-codeql.yaml
@@ -24,6 +24,10 @@ jobs:
         go-version-file: go.mod
         check-latest: true
 
+    - name: install levelzero dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libze1 libze-dev
     - name: Initialize CodeQL
       uses: github/codeql-action/init@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
       with:


### PR DESCRIPTION
Noticed some time ago that codeql phase had this error in the logs:
```
cd cmd/gpu_levelzero; go build -tags ""
  # github.com/intel/intel-device-plugins-for-kubernetes/cmd/gpu_levelzero
  ze.c:19:10: fatal error: ze_api.h: No such file or directory
     19 | #include <ze_api.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:115: gpu_levelzero] Error 1
  2024/11/26 10:56:36 Running /usr/bin/make [make] failed, continuing anyway: exit status 2
```
This is an attempt to fix it.