### PR TITLE
ci: crypto-perf updates

### DIFF
--- a/.github/workflows/lib-publish.yaml
+++ b/.github/workflows/lib-publish.yaml
@@ -62,10 +62,6 @@ jobs:
           - intel-dlb-plugin
           - intel-dlb-initcontainer
           - intel-xpumanager-sidecar
-
-          # # Demo images
-          - crypto-perf
-          - opae-nlb-demo
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5

--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /install_root/licenses/dpdk && \
     apt-get source --download-only -y libatomic1 libnuma1
 
 FROM debian:sid-slim
-RUN apt-get update && apt-get install -y --no-install-recommends libipsec-mb1 libnuma1 libatomic1 && ldconfig -v
+RUN apt-get update && apt-get install -y --no-install-recommends libipsec-mb2 libnuma1 libatomic1 && ldconfig -v
 COPY --from=builder /install_root /
 COPY run-dpdk-test /usr/bin/
 


### PR DESCRIPTION
crypto-perf tests are failing on e2e-spr. Also, stop publishing `crypto-perf` and `opae-nlb-demo`. Their original purpose is now gone.