### PR TITLE
workflow: improve trivy vulnerability scanning

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -15,8 +15,6 @@ jobs:
       contents: read
       security-events: write
     uses: "./.github/workflows/lib-trivy.yaml"
-    with:
-      upload-to-github-security-tab: true
 
   validate:
     uses: "./.github/workflows/lib-validate.yaml"

--- a/.github/workflows/lib-trivy.yaml
+++ b/.github/workflows/lib-trivy.yaml
@@ -81,52 +81,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Run Trivy in fs mode
-      continue-on-error: true
       uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
       with:
         scan-type: fs
         scan-ref: .
         exit-code: 1
         list-all-pkgs: true
-        format: json
-        output: trivy-report.json
-    - name: Show report in human-readable format
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
-      with:
-        scan-type: convert
-        vuln-type: ''
-        severity: ''
-        image-ref: trivy-report.json
         format: table
-    - name: Convert report to sarif
-      if: ${{ inputs.upload-to-github-security-tab }}
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
-      with:
-        scan-type: convert
-        vuln-type: ''
-        severity: ''
-        image-ref: trivy-report.json
-        format: sarif
-        output: trivy-report.sarif
-    - name: Upload sarif report to GitHub Security tab
-      if: ${{ inputs.upload-to-github-security-tab }}
-      uses: github/codeql-action/upload-sarif@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3
-      with:
-        sarif_file: trivy-report.sarif
-    - name: Convert report to csv
-      if: ${{ inputs.export-csv }}
-      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
-      with:
-        scan-type: convert
-        vuln-type: ''
-        severity: ''
-        image-ref: trivy-report.json
-        format: template
-        template: "@.github/workflows/template/trivy-csv.tpl"
-        output: trivy-report.csv
-    - name: Upload CSV report as an artifact
-      if: ${{ inputs.export-csv }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
-      with:
-        name: trivy-report
-        path: trivy-report.csv

--- a/.github/workflows/trivy-periodic.yaml
+++ b/.github/workflows/trivy-periodic.yaml
@@ -1,0 +1,37 @@
+name: Trivy vuln scan to Github Security
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  trivy-scan-vulns:
+    permissions:
+      security-events: write
+    runs-on: ubuntu-24.04
+    name: Scan vulnerabilities
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - name: Run Trivy in fs mode
+      # Don't fail in case of vulnerabilities, report them in the next step
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+      with:
+        scan-type: fs
+        scan-ref: .
+        exit-code: 1
+        list-all-pkgs: true
+        format: sarif
+        output: trivy-report.sarif
+    - name: Upload sarif report to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3
+      with:
+        sarif_file: trivy-report.sarif


### PR DESCRIPTION
Fail trivy vuln scan cleanly and create a periodic trivy scan to upload results to Github's security.

Trivy-action doesn't work too well when it's executed multiple times in the job. The env variables the action sets spill over to the next step and the step might be executed incorrectly. In our case, the "show report in human-readable format" actually just converted the json format back to json format and it didn't show the actual vulnerability in the action's logs.