### PR TITLE
e2e: fpga: fix false failure

### DIFF
--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -64,6 +64,13 @@ func describe() {
 	fmw := framework.NewDefaultFramework("fpgaplugin-e2e")
 	fmw.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
+	// Delete namespace manually after Contexts. Without this, two plugins can run at the same time
+	// and the latter plugin will fail to run.
+	// A better way would be to delete the deployment, but it's constructed inside runDevicePlugin.
+	ginkgo.AfterEach(func(ctx context.Context) {
+		fmw.DeleteNamespace(ctx, fmw.Namespace.Name)
+	})
+
 	ginkgo.Context("When FPGA plugin is running in region mode [Mode:region]", func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, arria10NodeResource, "region")


### PR DESCRIPTION
During tests a second plugin started running before the first one had exited. It resulted in the plugin going to crashloop and the workload getting stuck.