### PR TITLE
build: drop dlb and fpga related images

### DIFF
--- a/.github/workflows/lib-build.yaml
+++ b/.github/workflows/lib-build.yaml
@@ -13,16 +13,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - intel-fpga-admissionwebhook
-          - intel-fpga-initcontainer
           - intel-gpu-fakedev
           - intel-gpu-initcontainer
           - intel-gpu-plugin
           - intel-gpu-levelzero
-          - intel-fpga-plugin
           - intel-qat-initcontainer
           - intel-qat-plugin
-          - intel-qat-plugin-kerneldrv
           - intel-deviceplugin-operator
           - intel-sgx-admissionwebhook
           - intel-sgx-plugin
@@ -30,20 +26,15 @@ jobs:
           - intel-dsa-plugin
           - intel-iaa-plugin
           - intel-idxd-config-initcontainer
-          - intel-dlb-plugin
-          - intel-dlb-initcontainer
           - intel-xpumanager-sidecar
 
           # # Demo images
           - crypto-perf
           - accel-config-demo
           - intel-opencl-icd
-          - opae-nlb-demo
           - openssl-qat-engine
           - sgx-sdk-demo
           - sgx-aesmd-demo
-          - dlb-dpdk-demo
-          - dlb-libdlb-demo
         builder: [buildah, docker]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/lib-e2e.yaml
+++ b/.github/workflows/lib-e2e.yaml
@@ -34,13 +34,6 @@ jobs:
               - intel-qat-plugin
               - intel-qat-initcontainer
               - openssl-qat-engine
-          - name: e2e-fpga
-            runner: fpga
-            images:
-              - intel-fpga-plugin
-              - intel-fpga-initcontainer
-              - intel-fpga-admissionwebhook
-              - opae-nlb-demo
           - name: e2e-spr
             targetjob: e2e-spr SKIP="App:compress-perf"
             runner: spr

--- a/.github/workflows/lib-publish.yaml
+++ b/.github/workflows/lib-publish.yaml
@@ -44,12 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - intel-fpga-admissionwebhook
-          - intel-fpga-initcontainer
           - intel-gpu-initcontainer
           - intel-gpu-plugin
           - intel-gpu-levelzero
-          - intel-fpga-plugin
           - intel-qat-initcontainer
           - intel-qat-plugin
           - intel-deviceplugin-operator
@@ -59,8 +56,6 @@ jobs:
           - intel-dsa-plugin
           - intel-iaa-plugin
           - intel-idxd-config-initcontainer
-          - intel-dlb-plugin
-          - intel-dlb-initcontainer
           - intel-xpumanager-sidecar
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,6 @@ endif
 GENERATED_SKIP_OPT += $(if $(SKIP),-ginkgo.skip "$(SKIP)")
 ADDITIONAL_FOCUS_REGEX := $(if $(FOCUS),$(FOCUS).*$(ADDITIONAL_FOCUS_REGEX),$(ADDITIONAL_FOCUS_REGEX))
 
-e2e-fpga:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:fpga.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
-
 e2e-qat:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:qat.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
 
@@ -168,9 +165,6 @@ e2e-dsa:
 e2e-iaa:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:iaa.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
 
-e2e-dlb:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:dlb.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
-
 e2e-spr:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:(iaa|dsa)|Device:qat.*Mode:dpdk.*Resource:(cy|dc).*" -ginkgo.focus "Device:sgx.*|(SGX Admission)" -ginkgo.focus "Device:gpu.*Resource:i915" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
 
@@ -183,7 +177,7 @@ endif
 
 dockerlib = build/docker/lib
 dockertemplates = build/docker/templates
-images = $(shell basename -s .Dockerfile.in -a $(dockertemplates)/*.Dockerfile.in)
+images = $(shell basename -s .Dockerfile.in -a $(dockertemplates)/*.Dockerfile.in | grep -v -e dlb -e fpga -e kerneldrv)
 dockerfiles = $(shell basename -s .in -a $(dockertemplates)/*.Dockerfile.in | xargs -I"{}" echo build/docker/{})
 
 test-image-base-layer:
@@ -213,7 +207,7 @@ $(images): $(dockerfiles)
 
 images: $(images)
 
-demos = $(shell basename -a demo/*/)
+demos = $(shell basename -a demo/*/ | grep -v -e dlb -e opae-nlb-demo)
 
 $(demos):
 	@cd demo/ && ./build-image.sh $(REG)$@ $(BUILDER)


### PR DESCRIPTION
also remove e2e-fpga from workflows

part of #1946 
part of #1765 