### PR TITLE
dependabot: group all github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
       # Check for updates to GitHub Actions every week on Sunday
       interval: "weekly"
       day: "sunday"
+    groups:
+      # Group PRs
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
As we track pinned github actions, we get an update every time a new tag appears for any action we use. Furthermore, as we have a scheduled run on Sundays, we get many single action update PRs that have accumulated during the week to work with on Monday mornings.

Group all github-actions updates to a single PR to help with PR merges and to avoid unnecessary CI runs.