### PR TITLE
ci: bump to golangi-lint v2

### DIFF
--- a/.github/workflows/lib-validate.yaml
+++ b/.github/workflows/lib-validate.yaml
@@ -44,9 +44,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libze1 libze-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
         with:
-          version: v1.64.5
+          version: v2.0.2
           args: -v --timeout 5m
   build:
     name: Build and check device plugins

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,25 @@
+version: "2"
 run:
-  tests: true
   build-tags:
     - kerneldrv
-
+  tests: true
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
-    - dogsled
-    - errcheck
     - copyloopvar
+    - dogsled
+    - err113
+    - errcheck
     - gocognit
     - goconst
     - gocyclo
     - godot
-    - err113
-    - gofmt
-    - goimports
     - gomodguard
-    - gosimple
+    - goprintffuncname
     - gosec
     - govet
-    - goprintffuncname
     - ineffassign
     - misspell
     - nakedret
@@ -31,46 +28,67 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
     - wsl
-
-linters-settings:
-  revive:
+  settings:
+    gocognit:
+      min-complexity: 31
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - fieldalignment
+        - shadow
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: unused-parameter
-        disabled: true
-  gofmt:
-    simplify: true
-  goconst:
-    ignore-tests: true
-  govet:
-    enable:
-    - "fieldalignment"
-    - "shadow"
-  gocyclo:
-    min-complexity: 15
-  gocognit:
-    min-complexity: 31
-
-issues:
-  exclude-rules:
-    - linters:
-        - gosec
-      text: "G115"
-    - path: _test\.go
-      linters:
-        - gocognit
-        - wsl
-        - gocyclo
-    - path: test/e2e/
-      linters:
-        - wsl
-        - gocognit
-        - gocyclo
-    - path: cmd/gpu_fakedev/
-      linters:
-        - wsl
+      - linters:
+          - staticcheck
+        text: QF100(1|4|8)
+      - linters:
+          - gosec
+        text: G115
+      - linters:
+          - gocognit
+          - gocyclo
+          - wsl
+        path: _test\.go
+      - linters:
+          - gocognit
+          - gocyclo
+          - wsl
+        path: test/e2e/
+      - linters:
+          - wsl
+        path: cmd/gpu_fakedev/
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ EXTRA_BUILD_ARGS ?= ""
 
 CERT_MANAGER_VERSION ?= v1.15.2
 CONTROLLER_GEN_VERSION ?= v0.17.0
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v2.0.2
 KIND_VERSION ?= v0.23.0
 GOLICENSES_VERSION ?= v1.6.0
 # Default bundle image tag
@@ -44,7 +44,7 @@ vendor:
 
 install-tools:
 	GO111MODULE=on $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	$(GO) install sigs.k8s.io/kind@${KIND_VERSION}
 
 go-mod-tidy:


### PR DESCRIPTION
The config file is migrated using golangci-lint migrate. Three new staticcheck checks got disabled (QF100x, 1,4, and 8).