### PR TITLE
github: disable gnr(d) e2e targets

### DIFF
--- a/.github/workflows/lib-e2e.yaml
+++ b/.github/workflows/lib-e2e.yaml
@@ -11,27 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: e2e-dsa-gnr
-            targetjob: e2e-dsa SKIP="(App:(dpdk-test|accel-config))"
-            runner: simics-gnr
-            images:
-              - intel-dsa-plugin
-              - intel-idxd-config-initcontainer
-              - intel-deviceplugin-operator
-          - name: e2e-iaa-gnr
-            targetjob: e2e-iaa SKIP="(App:accel-config)"
-            runner: simics-gnr
-            images:
-              - intel-iaa-plugin
-              - intel-idxd-config-initcontainer
-              - intel-deviceplugin-operator
-          - name: e2e-qat-gnrd
-            targetjob: e2e-qat FOCUS="Mode:dpdk" SKIP="(App:(crypto-perf|compress-perf|qat-engine)|Functionality)"
-            runner: simics-gnrd
-            images:
-              - intel-qat-plugin
-              - intel-qat-initcontainer
-              - openssl-qat-engine
           - name: e2e-spr
             targetjob: e2e-spr SKIP="App:compress-perf"
             runner: spr


### PR DESCRIPTION
Due to infrastructure updates, these e2e targets will have to be disabled.