### PR TITLE
Allow providing a pull secret for the plugin daemonsets

### DIFF
--- a/pkg/controllers/dlb/controller_test.go
+++ b/pkg/controllers/dlb/controller_test.go
@@ -45,7 +45,7 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: c.ns,
+			Namespace: c.args.Namespace,
 			Name:      appLabel + "-" + devicePlugin.Name,
 			Labels: map[string]string{
 				"app": appLabel,
@@ -155,6 +155,12 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 		},
 	}
 
+	if len(c.args.ImagePullSecretName) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{Name: c.args.ImagePullSecretName},
+		}
+	}
+
 	return &daemonSet
 }
 
@@ -170,5 +176,13 @@ func TestNewDaemonSetDLB(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected and actuall daemonsets differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
+	}
+
+	c.args.ImagePullSecretName = "mysecret"
+
+	expected = c.newDaemonSetExpected(plugin)
+	actual = c.NewDaemonSet(plugin)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected and actual daemonsets with secret differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
 	}
 }

--- a/pkg/controllers/dsa/controller.go
+++ b/pkg/controllers/dsa/controller.go
@@ -47,13 +47,13 @@ var defaultNodeSelector = deployments.DSAPluginDaemonSet().Spec.Template.Spec.No
 // +kubebuilder:rbac:groups=deviceplugin.intel.com,resources=dsadeviceplugins/finalizers,verbs=update
 
 // SetupReconciler creates a new reconciler for DsaDevicePlugin objects.
-func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error {
-	c := &controller{scheme: mgr.GetScheme(), ns: namespace}
+func SetupReconciler(mgr ctrl.Manager, args controllers.ControllerOptions) error {
+	c := &controller{scheme: mgr.GetScheme(), args: args}
 	if err := controllers.SetupWithManager(mgr, c, devicepluginv1.GroupVersion.String(), "DsaDevicePlugin", ownerKey); err != nil {
 		return err
 	}
 
-	if withWebhook {
+	if args.WithWebhook {
 		return (&devicepluginv1.DsaDevicePlugin{}).SetupWebhookWithManager(mgr)
 	}
 
@@ -63,7 +63,7 @@ func SetupReconciler(mgr ctrl.Manager, namespace string, withWebhook bool) error
 type controller struct {
 	controllers.DefaultServiceAccountFactory
 	scheme *runtime.Scheme
-	ns     string
+	args   controllers.ControllerOptions
 }
 
 func (c *controller) CreateEmptyObject() client.Object {
@@ -200,12 +200,18 @@ func (c *controller) NewDaemonSet(rawObj client.Object) *apps.DaemonSet {
 		daemonSet.Spec.Template.Spec.Tolerations = devicePlugin.Spec.Tolerations
 	}
 
-	daemonSet.ObjectMeta.Namespace = c.ns
+	daemonSet.ObjectMeta.Namespace = c.args.Namespace
 	daemonSet.Spec.Template.Spec.Containers[0].Args = getPodArgs(devicePlugin)
 	daemonSet.Spec.Template.Spec.Containers[0].Image = devicePlugin.Spec.Image
 
 	if devicePlugin.Spec.InitImage != "" {
 		addInitContainer(daemonSet, devicePlugin)
+	}
+
+	if len(c.args.ImagePullSecretName) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{Name: c.args.ImagePullSecretName},
+		}
 	}
 
 	return daemonSet

--- a/pkg/controllers/dsa/controller_test.go
+++ b/pkg/controllers/dsa/controller_test.go
@@ -47,7 +47,7 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: c.ns,
+			Namespace: c.args.Namespace,
 			Name:      appLabel + "-" + devicePlugin.Name,
 			Labels: map[string]string{
 				"app": appLabel,
@@ -177,6 +177,12 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 		addInitContainer(&daemonSet, devicePlugin)
 	}
 
+	if len(c.args.ImagePullSecretName) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{Name: c.args.ImagePullSecretName},
+		}
+	}
+
 	return &daemonSet
 }
 
@@ -192,5 +198,13 @@ func TestNewDaemonSetDSA(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected and actuall daemonsets differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
+	}
+
+	c.args.ImagePullSecretName = "mysecret"
+
+	expected = c.newDaemonSetExpected(plugin)
+	actual = c.NewDaemonSet(plugin)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected and actual daemonsets with secret differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
 	}
 }

--- a/pkg/controllers/iaa/controller_test.go
+++ b/pkg/controllers/iaa/controller_test.go
@@ -47,7 +47,7 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: c.ns,
+			Namespace: c.args.Namespace,
 			Name:      appLabel + "-" + devicePlugin.Name,
 			Labels: map[string]string{
 				"app": appLabel,
@@ -177,6 +177,12 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 		addInitContainer(&daemonSet, devicePlugin)
 	}
 
+	if len(c.args.ImagePullSecretName) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{Name: c.args.ImagePullSecretName},
+		}
+	}
+
 	return &daemonSet
 }
 
@@ -192,5 +198,14 @@ func TestNewDaemonSetIAA(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected and actuall daemonsets differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
+	}
+
+	c.args.ImagePullSecretName = "mysecret"
+
+	expected = c.newDaemonSetExpected(plugin)
+	actual = c.NewDaemonSet(plugin)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected and actual daemonsets with secret differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
 	}
 }

--- a/pkg/controllers/qat/controller_test.go
+++ b/pkg/controllers/qat/controller_test.go
@@ -48,7 +48,7 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: c.ns,
+			Namespace: c.args.Namespace,
 			Name:      appLabel + "-" + devicePlugin.Name,
 			Labels: map[string]string{
 				"app": appLabel,
@@ -176,6 +176,12 @@ func (c *controller) newDaemonSetExpected(rawObj client.Object) *apps.DaemonSet 
 		setInitContainer(&daemonSet.Spec.Template.Spec, devicePlugin.Spec)
 	}
 
+	if len(c.args.ImagePullSecretName) > 0 {
+		daemonSet.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{Name: c.args.ImagePullSecretName},
+		}
+	}
+
 	return &daemonSet
 }
 
@@ -193,5 +199,14 @@ func TestNewDaemonSetQAT(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected and actuall daemonsets differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
+	}
+
+	c.args.ImagePullSecretName = "mysecret"
+
+	expected = c.newDaemonSetExpected(plugin)
+	actual = c.NewDaemonSet(plugin)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected and actual daemonsets with secret differ: %+s", diff.ObjectGoPrintDiff(expected, actual))
 	}
 }

--- a/pkg/controllers/reconciler.go
+++ b/pkg/controllers/reconciler.go
@@ -94,6 +94,12 @@ type DevicePluginController interface {
 	Upgrade(ctx context.Context, obj client.Object) (upgrade bool)
 }
 
+type ControllerOptions struct {
+	Namespace           string
+	ImagePullSecretName string
+	WithWebhook         bool
+}
+
 type reconciler struct {
 	controller DevicePluginController
 	client.Client

--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -113,21 +113,21 @@ func up() {
 	k8sManager, managerErr := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme, Metrics: metricsserver.Options{BindAddress: "0"}, Controller: config.Controller{SkipNameValidation: &yes}})
 	Expect(managerErr).To(BeNil())
 
-	withWebhook := true
+	args := ctr.ControllerOptions{Namespace: ns, WithWebhook: false}
 
-	Expect(dlbctr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(dlbctr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(dsactr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(dsactr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(fpgactr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(fpgactr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(gpuctr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(gpuctr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(iaactr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(iaactr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(qatctr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(qatctr.SetupReconciler(k8sManager, args)).To(BeNil())
 
-	Expect(sgxctr.SetupReconciler(k8sManager, ns, !withWebhook)).To(BeNil())
+	Expect(sgxctr.SetupReconciler(k8sManager, args)).To(BeNil())
 
 	ctx, cancel = context.WithCancel(context.TODO())
 


### PR DESCRIPTION
Change is split into two commits, one adding the support to provide the secrets, and  another to restructure how data is passed to the controllers. The restructuring can be dropped or the two can be merged.

Fixes #https://github.com/intel/intel-device-plugins-for-kubernetes/issues/1981