### PR TITLE
sgx: add automated DCAP registration using in-cluster PCCS caching

### DIFF
--- a/.github/workflows/lib-build.yaml
+++ b/.github/workflows/lib-build.yaml
@@ -35,6 +35,7 @@ jobs:
           - openssl-qat-engine
           - sgx-sdk-demo
           - sgx-aesmd-demo
+          - sgx-dcap-infra
           - dsa-dpdk-dmadevtest
           - intel-npu-demo
         builder: [buildah, docker]

--- a/demo/sgx-dcap-infra/Dockerfile
+++ b/demo/sgx-dcap-infra/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04 AS builder
+
+RUN apt update && \
+    env DEBIAN_FRONTEND=noninteractive apt install -y \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev
+
+WORKDIR /opt/intel
+
+ARG SGX_SDK_URL=https://download.01.org/intel-sgx/sgx-linux/2.27/distro/ubuntu24.04-server/sgx_linux_x64_sdk_2.27.100.1.bin
+
+RUN curl -sSLfO ${SGX_SDK_URL} \
+ && export SGX_SDK_INSTALLER=$(basename $SGX_SDK_URL) \
+ && chmod +x $SGX_SDK_INSTALLER \
+ && ./$SGX_SDK_INSTALLER --prefix /opt/intel \
+ && rm $SGX_SDK_INSTALLER
+
+ARG DCAP_VERSION=DCAP_1.24
+ARG DCAP_TARBALL_SHA256="c9295f5fd3f489b2fbd5f0d33836b09420976506ac834bc9c9a401f4a6a1204a"
+
+RUN curl -sSLfO https://github.com/intel/confidential-computing.tee.dcap/archive/$DCAP_VERSION.tar.gz && \
+    echo "$DCAP_TARBALL_SHA256 $DCAP_VERSION.tar.gz" | sha256sum -c - && \
+    tar xzf $DCAP_VERSION.tar.gz && mv confidential-computing.tee.dcap-* SGXDataCenterAttestationPrimitives
+
+WORKDIR SGXDataCenterAttestationPrimitives/tools/PCKRetrievalTool
+
+RUN sed -e 's:sys/firmware/efi:run:g' -i App/utility.cpp \
+    && make
+
+FROM ubuntu:24.04
+
+WORKDIR /opt/intel/sgx-pck-id-retrieval-tool/
+COPY --from=builder /opt/intel/SGXDataCenterAttestationPrimitives/tools/PCKRetrievalTool/PCKIDRetrievalTool .
+
+RUN ln -sf /lib/x86_64-linux-gnu/libsgx_id_enclave.signed.so.1 && \
+    ln -sf /lib/x86_64-linux-gnu/libsgx_pce.signed.so.1
+
+ARG SGX_SDK_VERSION=2_27_100
+RUN apt update && apt install -y --no-install-recommends curl ca-certificates gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main" | \
+    tee -a /etc/apt/sources.list.d/intel-sgx.list \
+    && curl -s https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg \
+    && curl -sSLf https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/99sgx_${SGXSDK_VERSION}_noble_custom_version.cfg | \
+    tee -a /etc/apt/preferences.d/99sgx_sdk \
+    && apt update \
+    && apt install -y --no-install-recommends \
+       tdx-qgs \
+       libsgx-ae-pce \
+       libsgx-ae-id-enclave \
+       libsgx-ra-uefi \
+       libsgx-dcap-default-qpl
+
+RUN rm /etc/qgs.conf
+
+COPY dcap-registration-flow /usr/bin
+
+ENTRYPOINT ["/opt/intel/tdx-qgs/qgs", "--no-daemon", "-n=4"]

--- a/demo/sgx-dcap-infra/dcap-registration-flow
+++ b/demo/sgx-dcap-infra/dcap-registration-flow
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ ! -x "${PWD}"/PCKIDRetrievalTool ]; then
+	echo "dcap-registration-flow: PCKIDRetrievalTool must be in the workingDir and executable"
+	exit 1
+fi
+
+echo "Waiting for the PCCS to be ready ..."
+
+if ! curl --retry 20 --retry-delay 30 -k ${PCCS_URL}/sgx/certification/v4/rootcacrl &> /dev/null; then
+	echo "ERROR: PCCS pod didn't become ready after 20 minutes"
+	exit 1
+fi
+
+echo "PCCS is online, proceeding ..."
+
+ARGS="-user_token ${USER_TOKEN} -url ${PCCS_URL} -use_secure_cert ${SECURE_CERT}"
+
+echo "Calling PCKIDRetrievalTool ..."
+
+./PCKIDRetrievalTool ${ARGS}
+
+sleep infinity

--- a/deployments/sgx_dcap/base/kustomization.yaml
+++ b/deployments/sgx_dcap/base/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- node-services.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+
+# required .env.pccs-credentials keys:
+# USER_TOKEN=
+secretGenerator:
+- name: pccs-credentials
+  envs:
+  - .env.pccs-credentials

--- a/deployments/sgx_dcap/base/node-services.yaml
+++ b/deployments/sgx_dcap/base/node-services.yaml
@@ -1,0 +1,90 @@
+# TODO
+# cert-manager / service-ca certificates
+# CURL_CA_BUNDLE once ^ is available
+# NFD (TDX) nodeSelector
+# cpu and memory resources/limits
+# split service name and port (PCCS URL)
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-dcap-node-infra
+spec:
+  selector:
+    matchLabels:
+      app: dcap-node-infra
+  template:
+    metadata:
+      annotations:
+        qcnl-conf: '{"pccs_url": "https://pccs-service:8042/sgx/certification/v4/", "use_secure_cert": false, "pck_cache_expire_hours": 168}'
+      labels:
+        app: dcap-node-infra
+        pccs-secure-cert: 'false'
+    spec:
+      automountServiceAccountToken: false
+      initContainers:
+      - name: platform-registration
+        image: intel/sgx-dcap-infra:devel
+        restartPolicy: Always
+        workingDir: "/opt/intel/sgx-pck-id-retrieval-tool/"
+        command: ['/usr/bin/dcap-registration-flow']
+        env:
+          - name: PCCS_URL
+            value: "https://pccs-service:8042"
+          - name: SECURE_CERT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['pccs-secure-cert']
+        envFrom:
+          - secretRef:
+              name: pccs-credentials
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - LINUX_IMMUTABLE
+        resources:
+          limits:
+            sgx.intel.com/registration: 1
+      containers:
+      - name: tdx-qgs
+        image: intel/sgx-dcap-infra:devel
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          limits:
+            sgx.intel.com/qe: 1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: QCNL_CONF_PATH
+          value: "/run/dcap/qcnl_conf"
+        - name: XDG_CACHE_HOME
+          value: "/run/dcap/cache"
+        volumeMounts:
+        - name: dcap-qcnl-cache
+          mountPath: /run/dcap/cache
+        - name: qgs-socket
+          mountPath: /var/run/tdx-qgs
+        - name: qcnl-config
+          mountPath: /run/dcap/
+          readOnly: true
+      volumes:
+      - name: dcap-qcnl-cache
+        emptyDir:
+          sizeLimit: 50Mi
+      - name: qgs-socket
+        hostPath:
+          path: /var/run/tdx-qgs
+          type: DirectoryOrCreate
+      - name: qcnl-config
+        downwardAPI:
+          items:
+          - path: "qcnl_conf"
+            fieldRef:
+              fieldPath: metadata.annotations['qcnl-conf']

--- a/deployments/sgx_dcap/kustomization.yaml
+++ b/deployments/sgx_dcap/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - base
+  - pccs

--- a/deployments/sgx_dcap/pccs/kustomization.yaml
+++ b/deployments/sgx_dcap/pccs/kustomization.yaml
@@ -1,0 +1,25 @@
+resources:
+- pccs.yaml
+- service.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+
+# self-signed TLS certs for pccs-tls:
+# openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout private.pem -out file.crt -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com"
+# token hashesh follow (with 'helloworld' changed to the desired secret tokens):
+# echo -n helloworld | sha512sum | tr -d '[:space:]-'
+# where helloworld is then used as the USER_TOKEN in intel-dcap-node-infra deployment:
+#
+# required .env.pccs-tokens keys:
+# PCS_API_KEY=
+# PCCS_USER_TOKEN_HASH=
+# PCCS_ADMIN_TOKEN_HASH=
+secretGenerator:
+- name: pccs-tokens
+  envs:
+  - .env.pccs-tokens
+- name: pccs-tls
+  type: "kubernetes.io/tls"
+  files:
+  - tls.key=private.pem
+  - tls.crt=file.crt

--- a/deployments/sgx_dcap/pccs/pccs.yaml
+++ b/deployments/sgx_dcap/pccs/pccs.yaml
@@ -1,0 +1,53 @@
+# TODO
+# cert-manager / service-ca certificates
+# add PCCS nodeSelector
+# cpu and memory resources/limits
+# make HTTPS_PORT configurable via env
+# fix proxy setting label
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: intel-dcap-pccs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pccs
+  template:
+    metadata:
+      labels:
+        app: pccs
+        trustedservices.intel.com/cache: pccs
+    spec:
+      containers:
+        - name: pccs
+          image: quay.io/redhat-user-workloads/ose-osc-tenant/osc-pccs@sha256:de64fc7b13aaa7e466e825d62207f77e7c63a4f9da98663c3ab06abc45f2334d
+          ports:
+            - containerPort: 8042
+              name: pccs-port
+          volumeMounts:
+            - name: pccs-cache
+              mountPath: /run/pccs
+            - name: pccs-tls
+              mountPath: /opt/app-root/src/intel/pccs/ssl_key
+              readOnly: true
+          env:
+            - name: PCCS_FILL_MODE
+              value: "REQ"
+            - name: CLUSTER_HTTPS_PROXY
+              value: ""
+          envFrom:
+            - secretRef:
+                name: pccs-tokens
+      volumes:
+        - name: pccs-cache
+          emptyDir:
+            sizeLimit: 50Mi
+        - name: pccs-tls
+          secret:
+            secretName: pccs-tls
+            items:
+            - key: tls.key
+              path: private.pem
+            - key: tls.crt
+              path: file.crt

--- a/deployments/sgx_dcap/pccs/service.yaml
+++ b/deployments/sgx_dcap/pccs/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pccs-service
+spec:
+  selector:
+    trustedservices.intel.com/cache: pccs
+  ports:
+  - name: pccs
+    protocol: TCP
+    port: 8042
+    targetPort: pccs-port

--- a/deployments/sgx_plugin/overlays/dcap-infra-resources/add-args.yaml
+++ b/deployments/sgx_plugin/overlays/dcap-infra-resources/add-args.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-sgx-plugin
+spec:
+  template:
+    spec:
+      containers:
+      - name: intel-sgx-plugin
+        args:
+          - "-dcap-infra-resources"

--- a/deployments/sgx_plugin/overlays/dcap-infra-resources/kustomization.yaml
+++ b/deployments/sgx_plugin/overlays/dcap-infra-resources/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../base
+patches:
+  - path: add-args.yaml
+    target:
+      kind: DaemonSet
+


### PR DESCRIPTION
This setup gives an automated ["online, multi-platform, PCCS based Indirect Registration"](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/02/infrastructure_setup/#on-offline-manual-multi-platform-pccs-based-indirect-registration) and TDX QGS deployment for Kubernetes based clusters. 

Building blocks:

1. in-cluster PCCS caching service deployment
2. PCKIDRetrievalTool sidecar and TDX QGS in a single daemonset

Pre-conditions:

Read the basics of Intel [TDX remote attestation infrastructure setup](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/02/infrastructure_setup/) and get an [Intel PCS API Key](https://api.portal.trustedservices.intel.com/). The node(s) have TDX and SGX enabled. The following also assumes that a user has _cloned this PR_ and has a bare-metal cluster available.

Installation:

1. Deploy SGX device plugin with the "DCAP infrastructure resources" enabled:

`kubectl apply -k deployments/sgx_plugin/overlays/dcap-infra-resources`

2. Make the new (unpublished) images available to your cluster:

```
make sgx-pccs sgx-dcap-infra
docker save intel/sgx-pccs:devel | sudo ctr -n k8s.io i import -
docker save intel/sgx-dcap-infra:devel | sudo ctr -n k8s.io i import -
```

3. Deploy PCCS

```
pushd deployments/sgx_dcap/pccs
<check notes in kustomization.yaml to populate .env.pccs-tokens>
kubectl apply -k .
popd
```

NB: if a proxy setting is needed, edit `pccs.yaml`

5. Deploy platform-registration and TDX QGS

```
pushd deployments/sgx_dcap/base
<get your USER_TOKEN to .env.pccs-credentials>
kubectl apply -k .
popd
```

NB: add `nodeSelector` to filter SGX/TDX enabled nodes if run in a multi-node cluster

6. Check things are up:

```
NAME                               READY   STATUS    RESTARTS   AGE
intel-dcap-node-infra-q9zms        2/2     Running   0          17h
intel-dcap-pccs-647568f67d-ftjb2   1/1     Running   0          17h
intel-sgx-plugin-bgfgv             1/1     Running   0          17h
```

```
$ kubectl logs -c platform-registration intel-dcap-node-infra-q9zms 
Waiting for the PCCS to be ready ...
PCCS is online, proceeding ...
Calling PCKIDRetrievalTool ...

Intel(R) Software Guard Extensions PCK Cert ID Retrieval Tool Version 1.23.100.0

Registration status has been set to completed status.
the data has been sent to cache server successfully!
```

The node should have `/var/run/tdx-qgs/qgs.socket` available for QEMU to connect.

Notes:

PCCS database is stored to a RAM based `EmptyDir` volume and currently not backed up (a backup mechanism is added later). Keep the PCCS deployment up. If quoting errors occur, full re-install after an SGX Factory Reset might be required.