### PR TITLE
qat: fix dpdk core selection on high core count systems

### DIFF
--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -8,14 +8,14 @@ RUN echo "deb-src http://deb.debian.org/debian unstable main" >> \
 RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential meson ninja-build python3-pyelftools libnuma-dev python3-pip pkg-config dpkg-dev libipsec-mb-dev
 
 # Download & unpack DPDK tarball
-ARG DPDK_TARBALL=dpdk-24.03.tar.xz
-ARG DPDK_TARBALL_SHA256="33ed973b3945af4f5923096ddca250b401dc80be3b5c6393b4e4fe43a1a6c2ad"
+ARG DPDK_TARBALL=dpdk-25.03.tar.xz
+ARG DPDK_TARBALL_SHA256="6a40a731328286ebd79685b18ffa5992e6b770c13843d65fd0d1157cfccff63d"
 
 RUN wget -q https://fast.dpdk.org/rel/$DPDK_TARBALL \
     && echo "$DPDK_TARBALL_SHA256 $DPDK_TARBALL" | sha256sum -c - \
     && tar -xf $DPDK_TARBALL && rm $DPDK_TARBALL
 
-ARG SOVERSION=24
+ARG SOVERSION=25
 RUN cd dpdk-* && meson setup \
     -Dplatform=generic \
     -Dcpu_instruction_set=westmere \

--- a/demo/crypto-perf/Dockerfile
+++ b/demo/crypto-perf/Dockerfile
@@ -19,6 +19,7 @@ ARG SOVERSION=24
 RUN cd dpdk-* && meson setup \
     -Dplatform=generic \
     -Dcpu_instruction_set=westmere \
+    -Dmax_lcores=256 \
     "-Denable_drivers=common/qat,compress/qat,crypto/qat" \
     "-Denable_apps=test-crypto-perf,test-compress-perf" \
     --prefix $(pwd)/installdir \

--- a/demo/dsa-dpdk-dmadevtest/Dockerfile
+++ b/demo/dsa-dpdk-dmadevtest/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR $DIR
 RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential meson ninja-build python3-pyelftools libnuma-dev python3-pip pkg-config dpkg-dev libipsec-mb-dev
 
 # Download & unpack DPDK tarball
-ARG DPDK_TARBALL=dpdk-24.11.1.tar.xz
-ARG DPDK_TARBALL_SHA256="bcae7d42c449fc456dfb279feabcbe0599a29bebb2fe2905761e187339d96b8e"
+ARG DPDK_TARBALL=dpdk-25.03.tar.xz
+ARG DPDK_TARBALL_SHA256="6a40a731328286ebd79685b18ffa5992e6b770c13843d65fd0d1157cfccff63d"
 
 RUN wget -q https://fast.dpdk.org/rel/$DPDK_TARBALL \
     && echo "$DPDK_TARBALL_SHA256 $DPDK_TARBALL" | sha256sum -c - \


### PR DESCRIPTION
On GNR, I noticed the dpdk-test-crypto-perf failed with this error:
```
EAL: Detected CPU lcores: 128
EAL: Detected NUMA nodes: 4
EAL: lcore 128 >= RTE_MAX_LCORE (128)
EAL: lcore 129 >= RTE_MAX_LCORE (128)
EAL: To use high physical core ids, please use --lcores to map them to lcore ids below RTE_MAX_LCORE, e.g. --lcores 0@1,1@128,2@129
EAL: invalid core list syntax
EAL: FATAL: Invalid 'command line' arguments.
EAL: Invalid 'command line' arguments.
EAL: Error - exiting with code: 1
  Cause: Invalid EAL arguments!
                      '( )' can be omitted for single element group,
                      '@' can be omitted if cpus and lcores have the same value
```

In addition, update dpdk to a newer version.

These were done in July, but I had forgotten them until I ran e2e tests again.