### PR TITLE
gpu: levelzero: use correct struct for temp printing

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -396,7 +396,7 @@ func (dp *devicePlugin) healthStatusForCard(cardPath string) string {
 		return health
 	}
 
-	dt, err := dp.levelzeroService.GetDeviceTemperature(bdfAddr)
+	deviceTemps, err := dp.levelzeroService.GetDeviceTemperature(bdfAddr)
 	// In case of any errors, return the current health status
 	if err != nil {
 		klog.Warningf("Device temperature retrieval failed: %v", err)
@@ -407,9 +407,10 @@ func (dp *devicePlugin) healthStatusForCard(cardPath string) string {
 	limit := float64(dp.options.temperatureLimit)
 
 	// Temperatures for different areas
-	klog.V(4).Infof("Temperatures: Memory=%.1fC, GPU=%.1fC, Global=%.1fC", dh.MemoryTemperature, dh.GPUTemperature, dh.GlobalTemperature)
+	klog.V(4).Infof("Temperatures: Memory=%.1fC, GPU=%.1fC, Global=%.1fC",
+		deviceTemps.Memory, deviceTemps.GPU, deviceTemps.Global)
 
-	if dt.GPU > limit || dt.Global > limit || dt.Memory > limit {
+	if deviceTemps.GPU > limit || deviceTemps.Global > limit || deviceTemps.Memory > limit {
 		health = pluginapi.Unhealthy
 	}
 

--- a/cmd/gpu_plugin/levelzeroservice/levelzero_service.go
+++ b/cmd/gpu_plugin/levelzeroservice/levelzero_service.go
@@ -33,12 +33,9 @@ type LevelzeroService interface {
 }
 
 type DeviceHealth struct {
-	Memory            bool
-	Bus               bool
-	SoC               bool
-	GlobalTemperature float64
-	GPUTemperature    float64
-	MemoryTemperature float64
+	Memory bool
+	Bus    bool
+	SoC    bool
 }
 
 type DeviceTemperature struct {


### PR DESCRIPTION
And remove the temperature values from health struct.