### PR TITLE
qat: handle service parsing via debugfs

### DIFF
--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
@@ -338,6 +338,11 @@ func (dp *DevicePlugin) getDpdkMounts(dpdkDeviceName string) []pluginapi.Mount {
 	}
 }
 
+// Trim services reported by the kernel into k8s resource names.
+func trimServiceName(serviceName string) string {
+	return strings.Replace(strings.TrimSpace(serviceName), ";", "-", 2)
+}
+
 func readDeviceConfiguration(pfDev string) string {
 	qatState, err := os.ReadFile(filepath.Join(pfDev, "qat/state"))
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -353,7 +358,7 @@ func readDeviceConfiguration(pfDev string) string {
 		}
 
 		if err2 == nil && len(qatCfgServices) != 0 {
-			return strings.Join(strings.SplitN(strings.TrimSpace(string(qatCfgServices)), ";", 3), "-")
+			return trimServiceName(string(qatCfgServices))
 		}
 	}
 
@@ -370,7 +375,7 @@ func readDeviceConfiguration(pfDev string) string {
 		return defaultCapabilities
 	}
 
-	return devCfg.Section("GENERAL").Key("ServicesEnabled").String()
+	return trimServiceName(devCfg.Section("GENERAL").Key("ServicesEnabled").String())
 }
 
 func getDeviceHealthiness(device string, lookup map[string]string) string {


### PR DESCRIPTION
Fixes: #2168 

The QAT out-of-tree driver does not provide sysfs based cfg_services interface to read (and write) services configurations so QAT debugfs is used as the fallback.

bad65eb16f changed how the services string is parsed and trimmed but missed the debugfs path. Because of this, the resource registration errors due to invalid resource names (e.g., "sym;dc", which should be "sym-dc").

Fix by handling the debugfs path the same way as the cfg_services sysfs path.