### PR TITLE
Misleading error message when PreferredAllocationPolicy is unset

### DIFF
--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_webhook.go
@@ -47,7 +47,7 @@ func (r *GpuDevicePlugin) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 func (r *GpuDevicePlugin) validatePlugin(ref *commonDevicePluginValidator) error {
 	if r.Spec.SharedDevNum == 1 && r.Spec.PreferredAllocationPolicy != "none" {
-		return fmt.Errorf("%w: PreferredAllocationPolicy is valid only when setting sharedDevNum > 1", errValidation)
+		return fmt.Errorf("%w: PreferredAllocationPolicy must be set to 'none' when sharedDevNum is 1", errValidation)
 	}
 
 	if r.Spec.AllowIDs != "" {


### PR DESCRIPTION
If you try to configure a GpuDevicePlugin resource with sharedDevNum=1 and PreferredAllocationPolicy unset, you get a misleading error:

"PreferredAllocationPolicy is valid only when setting sharedDevNum > 1"

I didn't have the field defined at all, so it was especially confusing.

This message should make it much clearer to the user.