### PR TITLE
cdi: add npu and gpu examples for docker use

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -229,6 +229,8 @@ To enable CDI support, container runtime has to support it. The support varies d
 
 Kubernetes CDI support is included since 1.28 release. In 1.28 it needs to be enabled via `DevicePluginCDIDevices` feature gate. From 1.29 onwards the feature is enabled by default.
 
+Use of CDI specifications with Docker is explained in a separate [CDI documentation](./cdi.md).
+
 > *NOTE*: To use CDI outside of Kubernetes, for example with Docker or Podman, CDI specs can be generated with the [Intel CDI specs generator](https://github.com/intel/intel-resource-drivers-for-kubernetes/releases/tag/specs-generator-v0.1.0).
 
 ### KMD and UMD

--- a/cmd/gpu_plugin/cdi.md
+++ b/cmd/gpu_plugin/cdi.md
@@ -1,0 +1,55 @@
+# CDI specifications with Intel GPU devices
+
+Container Device Interface (CDI) enables defining specifications that allow greater control on how devices are exposed to containers. The most common way to expose GPU devices to containers is to use privileged mode: `docker run --privileged`. The problem with that is it exposes every device in the host as well as gives unlimited access to the host. It also lacks some details from the GPU device files; for example, the `by-path` symlinks under `/dev/dri/by-path` are not included in the container. A slightly better way to expose GPU devices is to expose the device files one by one: `docker run --device /dev/dri/card0 --device /dev/dri/renderD128`. That has better control on which devices are exposed, but it creates long and error-prone command lines.
+
+## CDI specification
+
+An improved way to access Intel GPUs is to use CDI and its device specifications to expose Intel GPUs to containers. CDI uses predefined YAML or JSON specification files to describe which device files, mounts and environment variables should be exposed to the container. An example is shown below:
+
+```
+---
+cdiVersion: 0.5.0
+kind: intel.com/gpu
+devices:
+    - name: gpu0
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dri/card0
+              hostPath: /dev/dri/card0
+              type: c
+            - path: /dev/dri/renderD128
+              hostPath: /dev/dri/renderD128
+              type: c
+        mounts:
+            - hostPath: /dev/dri/by-path
+              containerPath: /dev/dri/by-path
+              options:
+                - rw
+                - rbind
+              type: bind
+```
+
+Docker's `--device` argument can use the CDI device name:
+```
+docker run --rm -it --device intel.com/gpu=gpu0 ubuntu:24.04
+```
+
+## Generating CDI specs automatically
+
+Intel GPU DRA driver uses CDI specs extensively as DRA's functionality is based on it. It has [a tool](https://github.com/intel/intel-resource-drivers-for-kubernetes/tree/main/cmd/cdi-specs-generator) that can generate CDI specs for the devices it detects in the host.
+
+Build it:
+```
+go install github.com/intel/intel-resource-drivers-for-kubernetes/cmd/cdi-specs-generator@gpu-v0.8.0
+```
+> NOTE: Using newer tags is possible, but there are extra dependencies needed for the build to succeed.
+
+And run it:
+```
+sudo cdi-specs-generator --naming classic --cdi-dir /etc/cdi gpu
+```
+
+The tool creates a `intel.com-gpu.yaml` file under `/etc/cdi` and uses `cardX` names for the CDI devices. To use them, the docker command is as follows:
+```
+docker run --rm -it --device intel.com/gpu=card1 ubuntu:24.04
+```

--- a/cmd/npu_plugin/README.md
+++ b/cmd/npu_plugin/README.md
@@ -11,6 +11,7 @@ Table of Contents
     * [Install with Operator](#install-with-operator)
     * [Verify Plugin Registration](#verify-plugin-registration)
 * [Testing and Demos](#testing-and-demos)
+* [Leverage CDI](#leverage-cdi)
 
 ## Introduction
 
@@ -144,3 +145,32 @@ The NPU plugin functionality can be verified by deploying a [npu-plugin-demo](..
     $ kubectl logs npu-workload-xxxxx
     <log output>
     ```
+
+## Leverage CDI
+
+Container Device Interface (CDI) enables defining specifications that allow greater control on how devices are exposed to containers. The most common way to expose NPU devices to containers is to use privileged mode: `docker run --privileged`. The problem with that is it exposes every device in the host as well as gives unlimited access to the host. A slightly better way to expose NPU devices is to expose the device files one by one: `docker run --device /dev/accel/accel0`.
+
+### CDI specification
+
+An improved way to access Intel NPUs is to use CDI and its device specifications to expose Intel NPUs to containers. CDI uses predefined YAML or JSON specification files to describe which device files, mounts and environment variables should be exposed to the container. An example is shown below:
+
+```
+---
+cdiVersion: 0.5.0
+kind: intel.com/npu
+devices:
+    - name: npu0
+      containerEdits:
+        deviceNodes:
+            - path: /dev/accel/accel0
+              hostPath: /dev/accel/accel0
+              type: c
+```
+
+Docker's `--device` argument can use the CDI device name:
+```
+$ docker run --device intel.com/npu=npu0 --rm -it ubuntu:24.04
+root@8fc6b8d2c45d:/# ls -l /dev/accel/
+total 0
+crw-rw-rw- 1 root root 261, 0 Apr  8 08:08 accel0
+```


### PR DESCRIPTION
This was requested internally. I acknowledge that the device plugins project is not the perfect place for these...