### PR TITLE
e2e: use labels to filter tests

### DIFF
--- a/.github/workflows/lib-e2e.yaml
+++ b/.github/workflows/lib-e2e.yaml
@@ -14,7 +14,6 @@ jobs:
           - name: e2e-spr
             targetjob: e2e-spr
             runner: spr
-            skip: App:compress-perf
             images:
               - intel-qat-plugin
               - intel-qat-initcontainer
@@ -32,7 +31,6 @@ jobs:
     env:
       TARGET_JOB: ${{ matrix.targetjob || matrix.name }}
       IMAGES: ${{ join(matrix.images, ' ') }}
-      SKIP: ${{ matrix.skip || '' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -187,14 +187,14 @@ cluster. If these two conditions are satisfied, run the tests with:
 
 ```bash
 # Run all e2e tests in this repository
-go test -v ./test/e2e/...
+make e2e
 ```
 
 If you need to specify paths to your custom `kubeconfig` containing
-embedded authentication info then add the `-kubeconfig` argument:
+embedded authentication info then set KUBECONFIG environment:
 
 ```bash
-go test -v ./test/e2e/... -args -kubeconfig /path/to/kubeconfig
+KUBECONFIG=/path/to/kubeconfig make e2e
 ```
 
 The full list of available options can be obtained with:
@@ -208,73 +208,56 @@ For running a subset of tests, there are labels that you can use to pick out spe
 You can run the tests with:
 ```bash
 # Run a subset of tests
-go test -v ./test/e2e/... -args -ginkgo.focus <labels in regex> -ginkgo.skip <labels in regex>
+E2E_FILTER="qat" KUBECONFIG=/path/to/kubeconfig make e2e
 ```
 
 #### Table of Labels
 
-| Device | Mode             | Resource    | App                            |
-|:-------|:-----------------|:------------|:-------------------------------|
-| `dlb`  |-                 | `pf`, `vf`  | `libdlb`                       |
-| `dsa`  |-                 | `dedicated` | `accel-config`                 |
-| `fpga` | `af`, `region`   |             | `opae-nlb-demo`                |
-| `gpu`  |-                 | `i915`      | `busybox`, `tensorflow`        |
-| `iaa`  |-                 | `dedicated` | `accel-config`                 |
-| `qat`  | `dpdk`           | `dc`        | `openssl`, `compress-perf`     |
-| `qat`  | `dpdk`           | `cy`        | `openssl`, `crypto-perf`       |
-| `qat`  | `kernel`         | `cy1_dc0`   | `busybox`                      |
-| `sgx`  |-                 |             | `sgx-sdk-demo`                 |
+| Device Label | Focus Labels |
+|-------|-------|
+| `dlb`  |`pf`, `vf`, `libdlb`|
+| `dsa`  |`idxd`, `vfio`, `accel-config`, `dpdk-test`, `dpdk-vfio-test`|
+| `fpga` | `af`, `region`, `opae-nlb-demo`, `admissionwebhook`|
+| `gpu`  |`i915`,`xe`,`busybox`, `monitoring`, `health`, `pytorch`|
+| `iaa`  |`dedicated`, `accel-config`|
+| `qat`  | `dpdk`, `dc`, `cy`, `openssl`, `compress-perf`, `crypto-perf`|
+| `sgx`  |`sgx-sdk-demo`, `admissionwebhook`|
 
 #### Examples
 
 ```bash
 # DLB for VF resource without any app running
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:dlb.*Resource:vf.*App:noapp"
+E2E_FILTER="dlb && vf" make e2e
 
-# FPGA with af mode with opae-nlb-demo app running
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:fpga.*Mode:af.*App:opae-nlb-demo"
-
-# GPU with running only tensorflow app
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:gpu.*App:tensorflow"
+# GPU with running only pytorch app
+E2E_FILTER="gpu && pytorch" make e2e
 #or
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:gpu" -ginkgo.skip "App:busybox"
+E2E_FILTER="gpu && busybox && i915" make e2e
 
 # QAT for qat4 cy resource with openssl app running
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:qat.*Resource:cy.*App:openssl"
-
-# SGX without running sgx-sdk-demo app
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:sgx" -ginkgo.skip "App:sgx-sdk-demo"
+E2E_FILTER="qat && cy && openssl" make e2e
 
 # All of Sapphire Rapids device plugins
-go test -v ./test/e2e/... -args -ginkgo.focus "Device:(dlb|dsa|iaa|qat|sgx)"
+E2E_FILTER="qat || sgx || dsa || iaa" make e2e
 ```
 
 ## Predefined E2E Tests
 
 It is possible to run predefined e2e tests with:
 ```
-make e2e-<device> [E2E_LEVEL={basic|full}] [FOCUS=<labels in regex>] [SKIP=<labels in regex>]
+make e2e-<device>
 ```
 
-| `E2E_LEVEL`   | Equivalent `FOCUS` or `SKIP` | Explanation                                                                                      |
-:-------------- |:---------------------------- |:------------------------------------------------------------------------------------------------ |
-| `basic`       | `FOCUS=App:noapp`            | `basic` does not run any app pod, but checks if the plugin works and the resources are available |
-| `full`        | `SKIP=App:noapp`             | `full` checks all resources, runs all apps except the spec kept for no app running               |
+> Possible devices are: qat, sgx, gpu, dsa, iaa
 
 ### Examples
 
 ```bash
-# DLB for both of pf and vf resources with running libdlb app
-make e2e-dlb E2E_LEVEL=full
+# all QAT tests
+make e2e-qat
 
-# QAT for cy resource with running only openssl app
-make e2e-qat FOCUS=Resource:cy.*App:openssl
-
-# QAT for dc resource without running any app
-make e2e-qat E2E_LEVEL=basic FOCUS=Resource:dc
-
-# GPU without running tensorflow app
-make e2e-gpu E2E_LEVEL=full SKIP=tensorflow
+# or all GPU tests
+make e2e-gpu
 ```
 
 It is also possible to run the tests which don't depend on hardware

--- a/Makefile
+++ b/Makefile
@@ -139,34 +139,35 @@ REG?=$(ORG)/
 TAG?=devel
 export TAG
 
-ifeq ($(E2E_LEVEL), $(filter $(E2E_LEVEL), full))
-  GENERATED_SKIP_OPT=-ginkgo.skip "App:noapp"
-else ifeq ($(E2E_LEVEL),basic)
-  ADDITIONAL_FOCUS_REGEX=App:noapp
+# Set dry-run arg if E2E_DRYRUN is set
+ifeq ($(E2E_DRYRUN), $())
+E2E_DRYRUN=--ginkgo.dry-run=false
 else
-  $(error Unsupported E2E_LEVEL value: $(E2E_LEVEL). Possible options: full, basic)
+E2E_DRYRUN=--ginkgo.dry-run=true
 endif
-GENERATED_SKIP_OPT += $(if $(SKIP),-ginkgo.skip "$(SKIP)")
-ADDITIONAL_FOCUS_REGEX := $(if $(FOCUS),$(FOCUS).*$(ADDITIONAL_FOCUS_REGEX),$(ADDITIONAL_FOCUS_REGEX))
 
 e2e-qat:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:qat.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "qat && !operator" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 e2e-sgx:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:sgx.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "sgx && !operator && !admissionwebhook" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 e2e-gpu:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:gpu.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "gpu && !operator && i915" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 e2e-dsa:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:dsa.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "dsa && !operator && idxd" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 e2e-iaa:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:iaa.*$(ADDITIONAL_FOCUS_REGEX)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "iaa && !operator" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 # This is a CI specific target to run all tests that are possible in the SPR host
 e2e-spr:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events -ginkgo.focus "Device:qat.*Mode:dpdk.*Resource:(cy|dc).*" -ginkgo.focus "Device:sgx.*|(SGX Admission)" $(GENERATED_SKIP_OPT) -delete-namespace-on-failure=false -e2e-verify-service-account=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "(qat && !compress-perf && dpdk && (cy || dc) || sgx) && !operator " $(E2E_DRYRUN) -delete-namespace-on-failure=false -e2e-verify-service-account=false
+
+# Target to run a subset of tests depending on the given filter arg. By default, runs all tests.
+e2e:
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "$(E2E_FILTER)" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 pre-pull:
 ifeq ($(TAG),devel)

--- a/pkg/controllers/qat/controller_test.go
+++ b/pkg/controllers/qat/controller_test.go
@@ -16,6 +16,7 @@
 package qat
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -192,7 +193,7 @@ func TestNewDaemonSetQAT(t *testing.T) {
 
 	plugin := &devicepluginv1.QatDevicePlugin{}
 	plugin.Name = "testing"
-	plugin.Spec.InitImage = "intel/intel-qat-initcontainer:" + controllers.ImageMinVersion.String()
+	plugin.Spec.InitImage = fmt.Sprintf("%s:%s", "intel/intel-qat-initcontainer", controllers.ImageMinVersion.String())
 
 	expected := c.newDaemonSetExpected(plugin)
 	actual := c.NewDaemonSet(plugin)

--- a/test/e2e/dlb/dlb.go
+++ b/test/e2e/dlb/dlb.go
@@ -39,7 +39,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("DLB plugin [Device:dlb]", describe)
+	ginkgo.Describe("DLB plugin", ginkgo.Label("dlb"), describe)
 }
 
 func describe() {
@@ -81,7 +81,7 @@ func describe() {
 		}
 	})
 
-	ginkgo.Context("When PF resources are available [Resource:pf]", func() {
+	ginkgo.Context("When PF resources are available", ginkgo.Label("pf"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			resource := v1.ResourceName("dlb.intel.com/pf")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, resource, 30*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -89,16 +89,16 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("can run demo app [App:libdlb]", func(ctx context.Context) {
+		ginkgo.It("can run demo app", ginkgo.Label("libdlb"), func(ctx context.Context) {
 			runDemoApp(ctx, "PF", demoPFYaml, f)
 		})
 
-		ginkgo.When("there is no app to run [App:noapp]", func() {
+		ginkgo.When("there is no app to run", func() {
 			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When VF resources are available [Resource:vf]", func() {
+	ginkgo.Context("When VF resources are available", ginkgo.Label("vf"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			resource := v1.ResourceName("dlb.intel.com/vf")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, resource, 30*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -106,12 +106,8 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("can run demo app [App:libdlb]", func(ctx context.Context) {
+		ginkgo.It("can run demo app", ginkgo.Label("libdlb"), func(ctx context.Context) {
 			runDemoApp(ctx, "VF", demoVFYaml, f)
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 }

--- a/test/e2e/dsa/dsa.go
+++ b/test/e2e/dsa/dsa.go
@@ -74,7 +74,7 @@ func describe() {
 		framework.Failf("unable to locate %q: %v", dpdkDemoYaml, errFailedToLocateRepoFile)
 	}
 
-	ginkgo.Context("When DSA resources are available [Resource:dedicated]", func() {
+	ginkgo.Context("When DSA resources are available", ginkgo.Label("dsa"), ginkgo.Label("idxd"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			kustomizationPath, errFailedToLocateRepoFile = utils.LocateRepoFile(kustomizationYaml)
 			if errFailedToLocateRepoFile != nil {
@@ -122,7 +122,7 @@ func describe() {
 			}
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "delete", "configmap", "intel-dsa-config")
 		})
-		ginkgo.It("deploys a demo app [App:accel-config]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app (accel-config)", ginkgo.Label("accel-config"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 			ginkgo.By("waiting for the DSA demo to succeed")
@@ -130,20 +130,16 @@ func describe() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, podName, podName))
 		})
 
-		ginkgo.It("deploys a demo app [App:dpdk-test]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app (dpdk-test)", ginkgo.Label("dpdk-test"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoDpdkPath)
 
 			ginkgo.By("waiting for the DSA DPDK demo to succeed")
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, dpdkPodName, f.Namespace.Name, 200*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, dpdkPodName, dpdkPodName))
 		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
-		})
 	})
 
-	ginkgo.Context("When DSA VFIO resources are available [Resource:vfio]", func() {
+	ginkgo.Context("When DSA VFIO resources are available", ginkgo.Label("dsa"), ginkgo.Label("vfio"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			kustomizationPath, errFailedToLocateRepoFile = utils.LocateRepoFile(kustomVfioYaml)
 			if errFailedToLocateRepoFile != nil {
@@ -185,16 +181,12 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a demo app [App:dpdk-vfio-test]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app", ginkgo.Label("dpdk-vfio-test"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoDpdkVfioPath)
 
 			ginkgo.By("waiting for the DSA DPDK VFIO demo to succeed")
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, dpdkVfioPodName, f.Namespace.Name, 200*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, dpdkVfioPodName, dpdkVfioPodName))
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 }

--- a/test/e2e/fpga/fpga.go
+++ b/test/e2e/fpga/fpga.go
@@ -47,7 +47,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("FPGA Plugin [Device:fpga]", describe)
+	ginkgo.Describe("FPGA Plugin", ginkgo.Label("fpga"), describe)
 }
 
 func describe() {
@@ -71,7 +71,7 @@ func describe() {
 		fmw.DeleteNamespace(ctx, fmw.Namespace.Name)
 	})
 
-	ginkgo.Context("When FPGA plugin is running in region mode [Mode:region]", func() {
+	ginkgo.Context("When FPGA plugin is running in region mode", ginkgo.Label("region"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, arria10NodeResource, "region")
 		})
@@ -81,32 +81,24 @@ func describe() {
 		})
 	})
 
-	ginkgo.Context("When FPGA plugin is running in af mode [Mode:af]", func() {
+	ginkgo.Context("When FPGA plugin is running in af mode", ginkgo.Label("af"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, nlb0NodeResource, "af")
 		})
-		ginkgo.It("runs an opae-nlb-demo pod [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod", ginkgo.Label("opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "af", nlb0PodResourceAF, "nlb0", "nlb3")
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 
-	ginkgo.Context("When FPGA plugin is running in region mode [Mode:region]", func() {
+	ginkgo.Context("When FPGA plugin is running in region mode", ginkgo.Label("region"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			runDevicePlugin(ctx, fmw, pluginKustomizationPath, mappingsCollectionPath, arria10NodeResource, "region")
 		})
-		ginkgo.It("runs [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod nlb3-nlb0", ginkgo.Label("opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "region", nlb3PodResource, "nlb3", "nlb0")
 		})
-		ginkgo.It("runs an opae-nlb-demo pod [App:opae-nlb-demo]", func(ctx context.Context) {
+		ginkgo.It("runs an opae-nlb-demo pod nlb0-nlb3", ginkgo.Label("opae-nlb-demo"), func(ctx context.Context) {
 			runTestCase(ctx, fmw, "region", nlb0PodResource, "nlb0", "nlb3")
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 }

--- a/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
+++ b/test/e2e/fpgaadmissionwebhook/fpgaadmissionwebhook.go
@@ -36,7 +36,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("FPGA Admission Webhook", describe)
+	ginkgo.Describe("FPGA Admission Webhook", ginkgo.Label("fpga"), ginkgo.Label("admissionwebhook"), describe)
 }
 
 func describe() {

--- a/test/e2e/gpu/gpu.go
+++ b/test/e2e/gpu/gpu.go
@@ -47,7 +47,7 @@ const (
 
 func init() {
 	// This needs to be Ordered because only one GPU plugin can function on the node at once.
-	ginkgo.Describe("GPU plugin [Device:gpu]", describe, ginkgo.Ordered)
+	ginkgo.Describe("GPU plugin", ginkgo.Label("gpu"), describe, ginkgo.Ordered)
 }
 
 func createPluginAndVerifyExistence(f *framework.Framework, ctx context.Context, kustomizationPath, baseResource string) {
@@ -93,7 +93,7 @@ func describe() {
 		framework.Failf("unable to locate %q: %v", healthMgmtYaml, errFailedToLocateRepoFile)
 	}
 
-	ginkgo.Context("When GPU plugin is deployed [Resource:i915]", func() {
+	ginkgo.Context("When GPU plugin is deployed", ginkgo.Label("i915"), func() {
 		ginkgo.AfterEach(func(ctx context.Context) {
 			framework.Logf("Removing gpu-plugin manually")
 
@@ -107,7 +107,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("checks availability of GPU resources [App:busybox]", func(ctx context.Context) {
+		ginkgo.It("checks availability of GPU resources", ginkgo.Label("busybox"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/i915")
 
 			podListFunc := framework.ListObjects(f.ClientSet.CoreV1().Pods(f.Namespace.Name).List, metav1.ListOptions{})
@@ -178,7 +178,7 @@ func describe() {
 			framework.Logf("found card and renderD from the log")
 		})
 
-		ginkgo.Context("When [Deployment:monitoring] deployment is applied [Resource:i915]", func() {
+		ginkgo.Context("When monitoring deployment is applied", ginkgo.Label("i915"), ginkgo.Label("monitoring"), func() {
 			ginkgo.It("check if monitoring resource is available", func(ctx context.Context) {
 				createPluginAndVerifyExistence(f, ctx, monitoringPath, "gpu.intel.com/i915")
 
@@ -189,13 +189,13 @@ func describe() {
 			})
 		})
 
-		ginkgo.Context("When [Deployment:healthManagement] deployment is applied [Resource:i915]", func() {
+		ginkgo.Context("When health deployment is applied", ginkgo.Label("i915"), ginkgo.Label("health"), func() {
 			ginkgo.It("check if i915 resources is available", func(ctx context.Context) {
 				createPluginAndVerifyExistence(f, ctx, healthMgmtPath, "gpu.intel.com/i915")
 			})
 		})
 
-		ginkgo.It("run a small workload on the GPU [App:pytorch]", func(ctx context.Context) {
+		ginkgo.It("run a small workload on the GPU", ginkgo.Label("pytorch"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/i915")
 
 			kustomYaml, err := utils.LocateRepoFile(ptKustomizationYaml)
@@ -214,14 +214,10 @@ func describe() {
 
 			framework.Logf("tensorflow execution succeeded!")
 		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
-		})
 	})
 
-	ginkgo.Context("When GPU resources are available [Resource:xe]", func() {
-		ginkgo.It("checks availability of GPU resources [App:busybox]", func(ctx context.Context) {
+	ginkgo.Context("When GPU resources are available", ginkgo.Label("xe"), func() {
+		ginkgo.It("checks availability of GPU resources", ginkgo.Label("busybox"), func(ctx context.Context) {
 			createPluginAndVerifyExistence(f, ctx, vanillaPath, "gpu.intel.com/xe")
 
 			ginkgo.By("submitting a pod requesting GPU resources")
@@ -262,10 +258,6 @@ func describe() {
 			}
 
 			framework.Logf("found card and renderD from the log")
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 }

--- a/test/e2e/iaa/iaa.go
+++ b/test/e2e/iaa/iaa.go
@@ -40,7 +40,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("IAA plugin [Device:iaa]", describe)
+	ginkgo.Describe("IAA plugin", ginkgo.Label("iaa"), describe)
 }
 
 func describe() {
@@ -94,7 +94,7 @@ func describe() {
 		}
 	})
 
-	ginkgo.Context("When IAA resources are available [Resource:dedicated]", func() {
+	ginkgo.Context("When IAA resources are available", ginkgo.Label("dedicated"), func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			ginkgo.By("checking if the resource is allocatable")
 			if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, "iaa.intel.com/wq-user-dedicated", 300*time.Second, utils.WaitForPositiveResource); err != nil {
@@ -102,16 +102,12 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a demo app [App:accel-config]", func(ctx context.Context) {
+		ginkgo.It("deploys a demo app", ginkgo.Label("accel-config"), func(ctx context.Context) {
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", demoPath)
 
 			ginkgo.By("waiting for the IAA demo to succeed")
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, podName, f.Namespace.Name, 360*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, podName, podName))
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 }

--- a/test/e2e/operator/operator.go
+++ b/test/e2e/operator/operator.go
@@ -36,7 +36,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("Device Plugins Operator", describe)
+	ginkgo.Describe("Device Plugins Operator", ginkgo.Label("operator"), describe)
 }
 
 func describe() {
@@ -66,16 +66,20 @@ func describe() {
 		gomega.Expect(err).To(gomega.BeNil())
 	})
 
-	ginkgo.It("deploys IAA plugin with operator", func(ctx context.Context) {
+	ginkgo.It("deploys IAA plugin with operator", ginkgo.Label("iaa"), func(ctx context.Context) {
 		testPluginWithOperator("iaa", []v1.ResourceName{"iaa.intel.com/wq-user-dedicated"}, f, ctx)
 	})
 
-	ginkgo.It("deploys DSA plugin with operator", func(ctx context.Context) {
+	ginkgo.It("deploys DSA plugin with operator", ginkgo.Label("dsa"), func(ctx context.Context) {
 		testPluginWithOperator("dsa", []v1.ResourceName{"dsa.intel.com/wq-user-dedicated"}, f, ctx)
 	})
 
-	ginkgo.It("deploys SGX plugin with operator", func(ctx context.Context) {
+	ginkgo.It("deploys SGX plugin with operator", ginkgo.Label("sgx"), func(ctx context.Context) {
 		testPluginWithOperator("sgx", []v1.ResourceName{"sgx.intel.com/epc", "sgx.intel.com/enclave", "sgx.intel.com/provision"}, f, ctx)
+	})
+
+	ginkgo.It("deploys QAT plugin with operator", ginkgo.Label("qat"), func(ctx context.Context) {
+		testPluginWithOperator("qat", []v1.ResourceName{"qat.intel.com/cy"}, f, ctx)
 	})
 }
 

--- a/test/e2e/qat/qatplugin_dpdk.go
+++ b/test/e2e/qat/qatplugin_dpdk.go
@@ -56,7 +56,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("QAT plugin in DPDK mode [Device:qat] [Mode:dpdk]", describeQatDpdkPlugin)
+	ginkgo.Describe("QAT plugin in DPDK mode", ginkgo.Label("qat"), ginkgo.Label("dpdk"), describeQatDpdkPlugin)
 }
 
 func describeQatDpdkPlugin() {
@@ -115,7 +115,7 @@ func describeQatDpdkPlugin() {
 		}
 	})
 
-	ginkgo.Context("When QAT resources are continuously available with crypto (cy) services enabled [Resource:cy]", func() {
+	ginkgo.Context("When QAT resources are continuously available with crypto (cy) services enabled", ginkgo.Label("cy"), func() {
 		// This BeforeEach runs even before the JustBeforeEach above.
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating a configMap before plugin gets deployed")
@@ -125,7 +125,7 @@ func describeQatDpdkPlugin() {
 			resourceName = cyResource
 		})
 
-		ginkgo.It("deploys a crypto pod (openssl) requesting QAT resources [App:openssl]", func(ctx context.Context) {
+		ginkgo.It("deploys a crypto pod (openssl) requesting QAT resources", ginkgo.Label("openssl"), func(ctx context.Context) {
 			command := []string{
 				"cpa_sample_code",
 				"runTests=" + strconv.Itoa(symmetric),
@@ -138,7 +138,7 @@ func describeQatDpdkPlugin() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, pod.ObjectMeta.Name, pod.Spec.Containers[0].Name))
 		})
 
-		ginkgo.It("deploys a crypto pod (dpdk crypto-perf) requesting QAT resources [App:crypto-perf]", func(ctx context.Context) {
+		ginkgo.It("deploys a crypto pod (dpdk crypto-perf) requesting QAT resources", ginkgo.Label("crypto-perf"), func(ctx context.Context) {
 			ginkgo.By("submitting a crypto pod requesting QAT resources")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(cryptoTestYamlPath))
 
@@ -147,7 +147,7 @@ func describeQatDpdkPlugin() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, "qat-dpdk-test-crypto-perf", "crypto-perf"))
 		})
 
-		ginkgo.It("deploys a crypto pod (qat-engine testapp) [App:qat-engine]", func(ctx context.Context) {
+		ginkgo.It("deploys a crypto pod (qat-engine testapp)", ginkgo.Label("qat-engine"), func(ctx context.Context) {
 			command := []string{
 				"testapp",
 				"-engine", "qathwtest",
@@ -164,13 +164,9 @@ func describeQatDpdkPlugin() {
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, pod.ObjectMeta.Name, f.Namespace.Name, 300*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, pod.ObjectMeta.Name, pod.Spec.Containers[0].Name))
 		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
-		})
 	})
 
-	ginkgo.Context("When QAT resources are continuously available with compress (dc) services enabled [Resource:dc]", func() {
+	ginkgo.Context("When QAT resources are continuously available with compress (dc) services enabled", ginkgo.Label("dc"), func() {
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("creating a configMap before plugin gets deployed")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "create", "configmap", "--from-literal", "qat.conf=ServicesEnabled=dc", "qat-config")
@@ -179,7 +175,7 @@ func describeQatDpdkPlugin() {
 			resourceName = dcResource
 		})
 
-		ginkgo.It("deploys a compress pod (openssl) requesting QAT resources [App:openssl]", func(ctx context.Context) {
+		ginkgo.It("deploys a compress pod (openssl) requesting QAT resources", ginkgo.Label("openssl"), func(ctx context.Context) {
 			command := []string{
 				"cpa_sample_code",
 				"runTests=" + strconv.Itoa(compression),
@@ -192,7 +188,7 @@ func describeQatDpdkPlugin() {
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, pod.ObjectMeta.Name, pod.Spec.Containers[0].Name))
 		})
 
-		ginkgo.It("deploys a compress pod (dpdk compress-perf) requesting QAT resources [App:compress-perf]", func(ctx context.Context) {
+		ginkgo.It("deploys a compress pod (dpdk compress-perf) requesting QAT resources", ginkgo.Label("compress-perf"), func(ctx context.Context) {
 			ginkgo.By("submitting a compress pod requesting QAT resources")
 			e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "apply", "-k", filepath.Dir(compressTestYamlPath))
 
@@ -200,13 +196,9 @@ func describeQatDpdkPlugin() {
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, "qat-dpdk-test-compress-perf", f.Namespace.Name, 300*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, "qat-dpdk-test-compress-perf", "compress-perf"))
 		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
-		})
 	})
 
-	ginkgo.Context("When a QAT device goes unresponsive", func() {
+	ginkgo.Context("When a QAT device goes unresponsive", ginkgo.Label("nft"), func() {
 		ginkgo.When("QAT's auto-reset is off", func() {
 			ginkgo.BeforeEach(func() {
 				ginkgo.By("creating a configMap before plugin gets deployed")
@@ -216,7 +208,7 @@ func describeQatDpdkPlugin() {
 				resourceName = dcResource
 			})
 
-			ginkgo.It("checks if unhealthy status is reported [Functionality:heartbeat]", func(ctx context.Context) {
+			ginkgo.It("checks if unhealthy status is reported", ginkgo.Label("heartbeat"), func(ctx context.Context) {
 				injectError(ctx, f, resourceName)
 
 				ginkgo.By("waiting node resources become zero")
@@ -235,7 +227,7 @@ func describeQatDpdkPlugin() {
 				resourceName = dcResource
 			})
 
-			ginkgo.It("checks if an injected error gets solved [Functionality:auto-reset]", func(ctx context.Context) {
+			ginkgo.It("checks if an injected error gets solved", ginkgo.Label("autoreset"), func(ctx context.Context) {
 				injectError(ctx, f, resourceName)
 
 				ginkgo.By("seeing if there is zero resource")

--- a/test/e2e/sgx/sgx.go
+++ b/test/e2e/sgx/sgx.go
@@ -41,7 +41,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("SGX plugin [Device:sgx]", describe)
+	ginkgo.Describe("SGX plugin", ginkgo.Label("sgx"), describe)
 }
 
 func describe() {
@@ -93,7 +93,7 @@ func describe() {
 			}
 		})
 
-		ginkgo.It("deploys a sgx-sdk-demo pod requesting SGX enclave resources [App:sgx-sdk-demo]", func(ctx context.Context) {
+		ginkgo.It("deploys a sgx-sdk-demo pod requesting SGX enclave resources", ginkgo.Label("sgx-sdk-demo"), func(ctx context.Context) {
 			podSpec := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "sgxplugin-tester"},
 				Spec: v1.PodSpec{
@@ -118,10 +118,6 @@ func describe() {
 			ginkgo.By("waiting the pod to finish successfully")
 			err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, pod.ObjectMeta.Name, f.Namespace.Name, 60*time.Second)
 			gomega.Expect(err).To(gomega.BeNil(), utils.GetPodLogs(ctx, f, pod.ObjectMeta.Name, "testcontainer"))
-		})
-
-		ginkgo.When("there is no app to run [App:noapp]", func() {
-			ginkgo.It("does nothing", func() {})
 		})
 	})
 

--- a/test/e2e/sgxadmissionwebhook/sgxaadmissionwebhook.go
+++ b/test/e2e/sgxadmissionwebhook/sgxaadmissionwebhook.go
@@ -37,7 +37,7 @@ const (
 )
 
 func init() {
-	ginkgo.Describe("SGX Admission Webhook", describe)
+	ginkgo.Describe("SGX Admission Webhook", ginkgo.Label("sgx"), ginkgo.Label("admissionwebhook"), describe)
 }
 
 func describe() {


### PR DESCRIPTION
In preparation to adding operator e2e tests, I took a stab at the label conversion.

Fixes: #1862

This also fixes one annoying thing related to "make set-version" use. It adds an extra tag in QAT's controller test which I've always needed to remove manually.