### PR TITLE
e2e: rewrite operator tests with OCP support

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -10,6 +10,7 @@ Table of Contents
    * [Work with Intel Device Plugins Operator Modifications](#work-with-intel-device-plugins-operator-modifications)
    * [Publish a New Version of the Intel Device Plugins Operator to operatorhub.io](#publish-a-new-version-of-the-intel-device-plugins-operator-to-operatorhubio)
    * [Run E2E Tests](#run-e2e-tests)
+   * [Run Operator E2E Tests](#run-operator-e2e-tests)
    * [Run Controller Tests with a Local Control Plane](#run-controller-tests-with-a-local-control-plane)
 * [How to Develop Simple Device Plugins](#how-to-develop-simple-device-plugins)
     * [Logging](#logging)
@@ -267,6 +268,99 @@ without a pre-configured Kubernetes cluster. Just make sure you have
 ```
 make test-with-kind
 ```
+
+### Run Operator E2E Tests
+
+The operator E2E tests (`test/e2e/operator/`) verify that the Intel Device Plugins Operator
+correctly deploys each plugin DaemonSet and exposes device resources as allocatable on nodes.
+The tests cover QAT (cy, dc), SGX, DSA (idxd, vfio), IAA, and GPU plugins.
+
+The following environment variables must be set before running:
+
+| Variable | Required | Description |
+|---|---|---|
+| `PROJECT_NAMESPACE`| always | Kubernetes namespace where the operator is deployed |
+| `IMAGE_PATH`       | always | Image path under the registry (e.g. `myproject`) |
+| `PLUGIN_VERSION`   | always | Plugin image tag (e.g. `0.35.0`) |
+| `IMAGE_REGISTRY`   | K8s only | Container registry address (e.g. `registry.example.com:5000`); omit on OCP|
+
+#### Vanilla Kubernetes
+
+**Prerequisites:**
+
+- `cert-manager` must already be installed in the cluster (the `cert-manager` namespace must exist).
+  The tests will fail early if it is absent. See the [cert-manager install guide](https://cert-manager.io/docs/installation/).
+- Node Feature Discovery (NFD) is deployed automatically by the test suite if no pods are found in the `node-feature-discovery` namespace.
+- The `PROJECT_NAMESPACE` namespace is created automatically if it does not yet exist.
+- The operator is deployed from `deployments/operator/default/kustomization.yaml`.
+
+```bash
+export PLUGIN_VERSION=0.35.0
+export PROJECT_NAMESPACE=inteldeviceplugin-operator
+export IMAGE_PATH=myproject
+export IMAGE_REGISTRY=registry.example.com:5000
+KUBECONFIG=/path/to/kubeconfig make e2e-operator
+```
+
+Running operator tests with existing container images (0.35.0):
+```bash
+export PLUGIN_VERSION=0.35.0
+export PROJECT_NAMESPACE=inteldeviceplugin-operator
+export IMAGE_PATH=intel
+export IMAGE_REGISTRY=docker.io
+KUBECONFIG=/path/to/kubeconfig make e2e-operator
+```
+
+#### OpenShift (OCP)
+
+**Prerequisites:**
+
+- The OCP service-CA operator is used for TLS; `cert-manager` is **not** required and must not
+  interfere.
+- NFD is expected to already be running, either via the OpenShift NFD Operator
+  (`openshift-nfd` namespace) or standard upstream NFD (`node-feature-discovery` namespace).
+  The test suite deploys NFD automatically only if neither namespace has running pods.
+- The `PROJECT_NAMESPACE` namespace **must exist before running**; it is not created automatically
+  on OCP.  For OCP internal registry access, `PROJECT_NAMESPACE` and `IMAGE_PATH` typically refer
+  to the same OpenShift project.
+- Do **not** set `IMAGE_REGISTRY`; the tests default to the OCP internal registry
+  (`image-registry.openshift-image-registry.svc:5000`).
+- The operator is deployed from `deployments/operator/overlays/ocp/kustomization.yaml`.
+- Plugin images must be mirrored to the OCP internal registry before running:
+
+```bash
+# The TAG has to be same or greater than the current release semver
+TAG=0.35.1 make set-version dockerfiles mirror-images-ocp
+```
+
+Then run the tests:
+
+```bash
+export PROJECT_NAMESPACE=inteldeviceplugin-operator
+export IMAGE_PATH=inteldeviceplugin-operator
+export PLUGIN_VERSION=0.35.1
+KUBECONFIG=/path/to/kubeconfig make e2e-operator
+```
+
+#### Filtering Operator Tests
+
+The `make e2e-operator` target uses the label filter `operator && !(gpu || iaa)` by default.
+Use `--ginkgo.label-filter` directly when you need a different subset:
+
+```bash
+# Run only the QAT operator tests
+KUBECONFIG=/path/to/kubeconfig go test -v ./test/e2e/... \
+  -ginkgo.v --ginkgo.label-filter "operator && qat" \
+  -delete-namespace-on-failure=false
+
+# Run all operator tests including GPU and IAA
+KUBECONFIG=/path/to/kubeconfig go test -v ./test/e2e/... \
+  -ginkgo.v --ginkgo.label-filter "operator" \
+  -delete-namespace-on-failure=false
+```
+
+Available per-plugin labels: `qat`, `sgx`, `dsa`, `iaa`, `gpu`.
+Focus labels within operator tests: `cy`, `dc` (QAT), `idxd`, `vfio` (DSA), `i915` (GPU).
 
 ### Run Controller Tests with a Local Control Plane
 

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,11 @@ bundle-build:
 clean:
 	@for cmd in $(cmds) ; do pwd=$(shell pwd) ; cd cmd/$$cmd ; $(GO) clean ; cd $$pwd ; done
 
+.PHONY: mirror-images-ocp
+mirror-images-ocp:
+	@bash scripts/build-images-for-ocp.sh
+	@bash scripts/mirror-images-to-ocp.sh inteldeviceplugin-operator
+
 ORG?=intel
 REG?=$(ORG)/
 TAG?=devel
@@ -161,13 +166,25 @@ e2e-dsa:
 e2e-iaa:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "iaa && !operator" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
-# This is a CI specific target to run all tests that are possible in the SPR host
+# This is a CI specific target to run all tests that are possible in the SPR host.
+# Plugin tests run first, operator tests run second to avoid resource conflicts.
 e2e-spr:
-	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "(qat && !compress-perf && dpdk && (cy || dc) || sgx) && !operator " $(E2E_DRYRUN) -delete-namespace-on-failure=false -e2e-verify-service-account=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events \
+		--ginkgo.label-filter "(qat && !compress-perf && !nft && !operator) || (sgx && !operator)" $(E2E_DRYRUN) \
+		-delete-namespace-on-failure=false -e2e-verify-service-account=false
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events \
+		--ginkgo.label-filter "operator && (qat || sgx)" $(E2E_DRYRUN) \
+		-delete-namespace-on-failure=false -e2e-verify-service-account=false
 
 # Target to run a subset of tests depending on the given filter arg. By default, runs all tests.
 e2e:
 	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "$(E2E_FILTER)" $(E2E_DRYRUN) -delete-namespace-on-failure=false
+
+e2e-operator:
+	@echo "NOTE: This depends on 'mirror-images-ocp' target but does not depend on it directly to allow running tests without building and mirroring every time."
+	@echo "For OCP: Make sure PROJECT_NAMESPACE, IMAGE_PATH and PLUGIN_VERSION env variables are set, and IMAGE_REGISTRY _not_ set."
+	@echo "For K8s: Make sure PROJECT_NAMESPACE, IMAGE_PATH, PLUGIN_VERSION and IMAGE_REGISTRY env variables are set"
+	@$(GO) test -v ./test/e2e/... -ginkgo.v -ginkgo.show-node-events --ginkgo.label-filter "operator && !(gpu || iaa)" $(E2E_DRYRUN) -delete-namespace-on-failure=false
 
 pre-pull:
 ifeq ($(TAG),devel)

--- a/deployments/operator/overlays/ocp/kustomization.yaml
+++ b/deployments/operator/overlays/ocp/kustomization.yaml
@@ -1,0 +1,47 @@
+# OCP-specific operator overlay.
+# Replaces cert-manager TLS with the OCP service-CA operator and grants the
+# privileged SCC to the default service account in the operator namespace so
+# that device-plugin DaemonSets can access host devices.
+namePrefix: intel-deviceplugins-
+
+resources:
+- ../../crd
+- ../../rbac
+- ../../manager
+- ../../webhook
+# SCC privileged mode doesn't seem to be needed, so it's left out for now.
+# If we need it in the future, we can add it back in.
+#- scc-binding.yaml
+
+patches:
+- path: manager_metrics_patch.yaml
+  target:
+    kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
+    name: controller-manager
+- path: webhook-service-patch.yaml
+  target:
+    kind: Service
+    name: webhook-service
+- path: webhook-mutating-ca-patch.yaml
+  target:
+    kind: MutatingWebhookConfiguration
+- path: webhook-validating-ca-patch.yaml
+  target:
+    kind: ValidatingWebhookConfiguration
+# remove namespace object as we don't want to create (and delete) it in OCP overlay
+# In OCP, we must keep the namespace so the images within the ImageStream stay intact.
+- patch: |-
+    $patch: delete
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        control-plane: controller-manager
+        manager: intel-deviceplugin-operator
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/warn: privileged
+      name: system

--- a/deployments/operator/overlays/ocp/manager_metrics_patch.yaml
+++ b/deployments/operator/overlays/ocp/manager_metrics_patch.yaml
@@ -1,0 +1,7 @@
+# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: "--metrics-bind-address=:8443"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: "--metrics-secure"

--- a/deployments/operator/overlays/ocp/manager_webhook_patch.yaml
+++ b/deployments/operator/overlays/ocp/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/deployments/operator/overlays/ocp/scc-binding.yaml
+++ b/deployments/operator/overlays/ocp/scc-binding.yaml
@@ -1,0 +1,15 @@
+# Grant the privileged SCC to the default service account in the operator
+# namespace so that device-plugin DaemonSet pods can access host devices and
+# run with the required capabilities.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: privileged-scc
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: inteldeviceplugins-system
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io

--- a/deployments/operator/overlays/ocp/webhook-mutating-ca-patch.yaml
+++ b/deployments/operator/overlays/ocp/webhook-mutating-ca-patch.yaml
@@ -1,0 +1,9 @@
+# Instruct the OCP service-CA operator to inject the cluster CA bundle into
+# the MutatingWebhookConfiguration so that the API server can validate the
+# webhook server's TLS certificate.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/deployments/operator/overlays/ocp/webhook-service-patch.yaml
+++ b/deployments/operator/overlays/ocp/webhook-service-patch.yaml
@@ -1,0 +1,9 @@
+# Instruct the OCP service-CA operator to issue a signed serving certificate
+# for the webhook service and store it in the named secret.  The secret name
+# must match the volume mount defined in manager_webhook_patch.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert

--- a/deployments/operator/overlays/ocp/webhook-validating-ca-patch.yaml
+++ b/deployments/operator/overlays/ocp/webhook-validating-ca-patch.yaml
@@ -1,0 +1,9 @@
+# Instruct the OCP service-CA operator to inject the cluster CA bundle into
+# the ValidatingWebhookConfiguration so that the API server can validate the
+# webhook server's TLS certificate.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/scripts/build-images-for-ocp.sh
+++ b/scripts/build-images-for-ocp.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright 2026 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build-images-for-ocp.sh – builds all container images required for the OCP
+# e2e tests from the current project source tree.
+#
+# Usage:
+#   ./scripts/build-images-for-ocp.sh
+#
+# Environment variables (all optional, match Makefile defaults):
+#   BUILDER   – container builder binary: docker (default), podman, or buildah
+#   TAG       – image tag (default: value from Makefile, currently 0.35.1)
+#   UBI       – set to 1 to build UBI-based images instead of distroless
+#
+# After a successful run the images are available locally as:
+#   intel/<name>:<TAG>
+# Pass these to mirror-images-to-ocp.sh to push them to an OCP cluster.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# To load OCP_IMAGES
+. "${SCRIPT_DIR}/common-ocp.sh"
+
+log() { echo "[build-images-for-ocp] $*"; }
+
+cd "${REPO_ROOT}"
+
+# Ensure Dockerfiles are up to date with the .Dockerfile.in templates before
+# building.  This is a no-op if nothing has changed.
+log "Regenerating Dockerfiles from templates..."
+make dockerfiles
+
+log "Building images: ${OCP_IMAGES[*]}"
+for img in "${OCP_IMAGES[@]}"; do
+    log "  building ${img}..."
+    make "${img}" ${BUILDER:+BUILDER="${BUILDER}"} ${TAG:+TAG="${TAG}"} ${UBI:+UBI="${UBI}"}
+done
+
+# Print a summary so the caller can verify and export OCP_IMAGE_REGISTRY later.
+TAG="${TAG:-$(grep '^TAG' Makefile | head -1 | awk -F'[?=]' '{print $NF}' | tr -d ' ')}"
+log ""
+log "Build complete.  Images available locally:"
+for img in "${OCP_IMAGES[@]}"; do
+    log "  intel/${img}:${TAG}"
+done
+log ""
+log "Next step: push to your OCP cluster:"
+log "  ./scripts/mirror-images-to-ocp.sh <namespace>"

--- a/scripts/common-ocp.sh
+++ b/scripts/common-ocp.sh
@@ -1,0 +1,14 @@
+# Images required for the OCP e2e tests (operator + QAT + SGX + DSA plugins + workload containers).
+OCP_IMAGES=(
+    intel-deviceplugin-operator
+    intel-qat-plugin
+    intel-qat-initcontainer
+    intel-sgx-plugin
+    intel-dsa-plugin
+    intel-iaa-plugin
+    intel-gpu-plugin
+    intel-idxd-config-initcontainer
+    sgx-sdk-demo
+    crypto-perf
+    dsa-dpdk-dmadevtest
+)

--- a/scripts/mirror-images-to-ocp.sh
+++ b/scripts/mirror-images-to-ocp.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# mirror-images-to-ocp.sh – tags and pushes locally-built device-plugin images
+# into an OCP internal ImageStream so that e2e tests run without depending on
+# any external registry.
+#
+# Build the images first with:
+#   ./scripts/build-images-for-ocp.sh
+#
+# Usage:
+#   ./scripts/mirror-images-to-ocp.sh <namespace>
+
+set -euo pipefail
+
+log() { echo "[mirror] $*"; }
+
+resolve_registry_route() {
+    if [[ -n "${REGISTRY_ROUTE:-}" ]]; then
+        printf '%s\n' "${REGISTRY_ROUTE}"
+        return 0
+    fi
+
+    local route_host=""
+    route_host="$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || true)"
+
+    if [[ -n "${route_host}" ]]; then
+        printf '%s\n' "${route_host}"
+        return 0
+    fi
+
+    echo "ERROR: unable to determine the OpenShift registry route." >&2
+    echo "Set REGISTRY_ROUTE explicitly or expose the image registry default route." >&2
+
+    return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+NAMESPACE="${1:?Usage: $0 <namespace>}"
+
+# Get registry route from the cluster to avoid hardcoding it.
+# Prefer an explicit env var and otherwise use the image registry default route.
+log "Getting registry route from cluster..."
+
+REGISTRY_ROUTE="$(resolve_registry_route)"
+
+DST="${REGISTRY_ROUTE}/${NAMESPACE}"
+
+BUILDER="${BUILDER:-docker}"
+
+PUSHER_SA="registry-pusher"
+
+# Resolve TAG: honour the env var, otherwise fall back to the Makefile default.
+if [[ -z "${TAG:-}" ]]; then
+    TAG="$(grep '^TAG' "${REPO_ROOT}/Makefile" | head -1 | awk -F'[?=]' '{print $NF}' | tr -d ' ')"
+fi
+
+# To load OCP_OCP_IMAGES
+. "${SCRIPT_DIR}/common-ocp.sh"
+
+# Verify that all images are present locally before touching the cluster.
+log "Verifying locally-built images (tag: ${TAG})..."
+missing=()
+for name in "${OCP_IMAGES[@]}"; do
+    if ! "${BUILDER}" image inspect "intel/${name}:${TAG}" &>/dev/null; then
+        missing+=("intel/${name}:${TAG}")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: the following images are not available locally:" >&2
+    printf '  %s\n' "${missing[@]}" >&2
+    echo "Run ./scripts/build-images-for-ocp.sh first." >&2
+    exit 1
+fi
+
+# Ensure the namespace/project exists before creating ImageStreams.
+if ! oc get namespace "${NAMESPACE}" &>/dev/null; then
+    log "Creating namespace ${NAMESPACE}..."
+    oc new-project "${NAMESPACE}" || oc create namespace "${NAMESPACE}"
+fi
+
+# Create user for ImageStream pushing and get a token for authentication.
+log "Setting up permissions for pushing to ${DST}..."
+if ! oc get sa "${PUSHER_SA}" -n "${NAMESPACE}" &>/dev/null; then
+    oc create sa "${PUSHER_SA}" -n $NAMESPACE &&
+    oc adm policy add-role-to-user registry-editor \
+    -z "${PUSHER_SA}" -n $NAMESPACE || {
+        echo "Failed to set up permissions for pushing to ${DST}, exiting" >&2
+        exit 1
+}
+fi
+
+export TOKEN=$(oc create token "${PUSHER_SA}" -n $NAMESPACE)
+
+# Log in to the OCP internal registry using the current oc session token.
+log "Logging in to ${REGISTRY_ROUTE}..."
+
+echo -n "$TOKEN" | "${BUILDER}" login  \
+    -u registry-pusher --password-stdin "${REGISTRY_ROUTE}"
+
+# Ensure every ImageStream exists before pushing.
+for name in "${OCP_IMAGES[@]}"; do
+    if ! oc get imagestream "${name}" -n "${NAMESPACE}" &>/dev/null; then
+        log "Creating ImageStream ${name}..."
+        oc create imagestream "${name}" -n "${NAMESPACE}"
+    fi
+done
+
+# Tag and push each locally-built image.
+for name in "${OCP_IMAGES[@]}"; do
+    src="intel/${name}:${TAG}"
+    dst="${DST}/${name}:${TAG}"
+
+    log "Pushing ${src} → ${dst}"
+    "${BUILDER}" tag "${src}" "${dst}"
+    "${BUILDER}" push "${dst}"
+done
+
+log ""
+log "All images pushed to ${DST}"
+log ""
+log "Pods inside the cluster pull images via the internal registry."
+log "Export PROJECT_NAMESPACE, IMAGE_PATH & PLUGIN_VERSION before running OCP e2e tests:"
+log "  export PROJECT_NAMESPACE=${NAMESPACE}"
+log "  export IMAGE_PATH=${NAMESPACE}"
+log "  export PLUGIN_VERSION=${TAG}"

--- a/test/e2e/deviceplugins_suite_test.go
+++ b/test/e2e/deviceplugins_suite_test.go
@@ -30,7 +30,6 @@ import (
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/fpgaadmissionwebhook"
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/gpu"
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/iaa"
-	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/operator"
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/qat"
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/sgx"
 	_ "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/sgxadmissionwebhook"

--- a/test/e2e/operator/operator.go
+++ b/test/e2e/operator/operator.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Intel Corporation. All Rights Reserved.
+// Copyright 2026 Intel Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,91 +12,561 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package inteldevicepluginsoperator implements E2E tests for Intel Device Plugins Operator.
-package inteldevicepluginsoperator
+// Package operator implements e2e tests for the Intel Device Plugins
+// Operator. The operator is deployed using a kustomize overlay
+// (deployments/operator/overlays/ocp) that replaces cert-manager TLS handling
+// with the OCP service-CA operator and grants the required SCC to the default
+// service account.
+//
+// Each plugin (QAT, SGX, DSA) is exercised by applying the corresponding
+// Custom Resource and verifying that:
+//  1. The plugin DaemonSet pod becomes Running and Ready.
+//  2. The expected device resource appears as allocatable on at least one node.
+package operator
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
-	"github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/utils"
+	dpapi "github.com/intel/intel-device-plugins-for-kubernetes/pkg/apis/deviceplugin/v1"
+	operutils "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/operator/utils"
+	e2eutils "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/utils"
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	kustomizationYaml = "deployments/operator/default/kustomization.yaml"
-	ns                = "inteldeviceplugins-system"
-	timeout           = time.Second * 120
+	operatorOverlay    = "deployments/operator/default/kustomization.yaml"
+	operatorOCPOverlay = "deployments/operator/overlays/ocp/kustomization.yaml"
+	operatorLabel      = "control-plane=controller-manager"
+	pluginTimeout      = 90 * time.Second
+	resourceTimeout    = 60 * time.Second
+
+	cryptoTestYaml   = "deployments/qat_dpdk_app/crypto-perf/crypto-perf-dpdk-pod-requesting-qat-cy.yaml"
+	compressTestYaml = "deployments/qat_dpdk_app/compress-perf/compress-perf-dpdk-pod-requesting-qat-dc.yaml"
+
+	dpdkDemoYaml = "demo/dsa-dpdk-dmadevtest.yaml"
+	dpdkPodName  = "dpdk"
 )
 
+var (
+	operatorNS string
+)
+
+type workloadFunc func(ctx context.Context, f *framework.Framework)
+
 func init() {
-	ginkgo.Describe("Device Plugins Operator", ginkgo.Label("operator"), describe)
+	ginkgo.Describe("Device Plugins Operator", ginkgo.Label("operator"), ginkgo.Ordered, describe)
 }
 
 func describe() {
-	f := framework.NewDefaultFramework("inteldevicepluginsoperator")
+	f := framework.NewDefaultFramework("inteldeviceplugin-operator-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	// All test actions happen in operatorNS, not in a per-spec namespace.
+	// Prevent the framework from creating (and leaking) unused namespaces.
+	f.SkipNamespaceCreation = true
 
-	var webhook v1.Pod
+	var (
+		tempDir string
+		// BeforeAll/AfterAll run outside the framework's BeforeEach lifecycle so
+		// f.ClientSet is nil at that point.  Load the clientset directly here.
+		suiteClient clientset.Interface
+	)
 
-	ginkgo.BeforeEach(func(ctx context.Context) {
-		ginkgo.By("deploying operator")
-		utils.Kubectl("", "apply", "-k", kustomizationYaml)
+	ginkgo.BeforeAll(func(ctx context.Context) {
+		var err error
 
-		if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"control-plane": "controller-manager"}.AsSelector(), 1, timeout); err != nil {
-			framework.Failf("unable to wait for all pods to be running and ready: %v", err)
+		suiteClient, err = framework.LoadClientset()
+		if err != nil {
+			framework.Failf("failed to load clientset for BeforeAll: %v", err)
+		}
+
+		operatorNS = operutils.ProjectNamespace()
+
+		var overlayFile string
+		if operutils.IsRunningOnOCP(ctx, suiteClient) {
+			overlayFile = operatorOCPOverlay
+		} else {
+			overlayFile = operatorOverlay
+		}
+
+		overlayPath, err := e2eutils.LocateRepoFile(overlayFile)
+		if err != nil {
+			framework.Failf("unable to locate kustomize overlay %q: %v", overlayFile, err)
+		}
+
+		tempDir, err = os.MkdirTemp("", "operator-e2e-")
+		if err != nil {
+			framework.Failf("unable to create temp directory: %v", err)
+		}
+
+		ginkgo.By("creating kustomize overlay (with optional image overrides)")
+
+		if err = operutils.CreateKustomizationOverlay(filepath.Dir(overlayPath), tempDir, operutils.PluginVersion(), operatorNS); err != nil {
+			framework.Failf("unable to create kustomization overlay: %v", err)
+		}
+
+		ginkgo.By("deploying the device plugins operator via kustomize overlay")
+		e2ekubectl.RunKubectlOrDie("", "apply", "-k", tempDir)
+
+		ginkgo.By(fmt.Sprintf("waiting for the operator controller-manager pod to be ready in %s namespace", operatorNS))
+
+		if _, err = e2epod.WaitForPods(
+			ctx, suiteClient, operatorNS,
+			metav1.ListOptions{LabelSelector: labels.Set{"control-plane": "controller-manager"}.String()},
+			e2epod.Range{MinMatching: 1},
+			pluginTimeout, "be running and ready", e2epod.RunningReady,
+		); err != nil {
+			e2edebug.DumpAllNamespaceInfo(ctx, suiteClient, operatorNS)
+			e2ekubectl.LogFailedContainers(ctx, suiteClient, operatorNS, framework.Logf)
+			framework.Failf("operator controller-manager did not become ready: %v", err)
 		}
 	})
 
-	ginkgo.AfterEach(func() {
-		ginkgo.By("undeploying operator")
-		utils.Kubectl("", "delete", "-k", kustomizationYaml)
+	ginkgo.AfterAll(func(ctx context.Context) {
+		ginkgo.By("removing the device plugins operator")
+
+		if tempDir != "" {
+			e2ekubectl.RunKubectlOrDie("", "delete", "--ignore-not-found=true", "-k", tempDir)
+			os.RemoveAll(tempDir)
+		}
 	})
 
-	ginkgo.It("checks the operator webhook pod is safely configured", func(ctx context.Context) {
-		err := utils.TestContainersRunAsNonRoot([]v1.Pod{webhook})
-		gomega.Expect(err).To(gomega.BeNil())
-		err = utils.TestWebhookServerTLS(ctx, f, "https://inteldeviceplugins-webhook-service")
-		gomega.Expect(err).To(gomega.BeNil())
+	ginkgo.It("deploys crypto QAT plugin with operator and runs an optional workload", ginkgo.Label("qat", "cy"), func(ctx context.Context) {
+		createQatConfigMap(ctx, f, "sym;asym")
+		defer deleteQatConfigMap(ctx, f)
+		testPluginWithOperator(
+			ctx, f,
+			buildQATPluginCR(),
+			"qatdeviceplugin-sample",
+			"intel-qat-plugin",
+			[]v1.ResourceName{"qat.intel.com/cy"},
+			qatCyWorkload,
+		)
+	})
+
+	ginkgo.It("deploys data compress QAT plugin with operator and runs an optional workload", ginkgo.Label("qat", "dc"), func(ctx context.Context) {
+		createQatConfigMap(ctx, f, "dc")
+		defer deleteQatConfigMap(ctx, f)
+		testPluginWithOperator(
+			ctx, f,
+			buildQATPluginCR(),
+			"qatdeviceplugin-sample",
+			"intel-qat-plugin",
+			[]v1.ResourceName{"qat.intel.com/dc"},
+			qatDcWorkload,
+		)
+	})
+
+	ginkgo.It("deploys SGX plugin with operator and runs an optional workload", ginkgo.Label("sgx"), func(ctx context.Context) {
+		testPluginWithOperator(
+			ctx, f,
+			buildSGXPluginCR(),
+			"sgxdeviceplugin-sample",
+			"intel-sgx-plugin",
+			[]v1.ResourceName{"sgx.intel.com/epc", "sgx.intel.com/enclave", "sgx.intel.com/provision"},
+			sgxWorkload,
+		)
+	})
+
+	ginkgo.It("deploys IDXD DSA plugin with operator", ginkgo.Label("dsa", "idxd"), func(ctx context.Context) {
+		testPluginWithOperator(
+			ctx, f,
+			buildDSAPluginCR("idxd"),
+			"dsadeviceplugin-sample",
+			"intel-dsa-plugin",
+			[]v1.ResourceName{"dsa.intel.com/wq-user-dedicated"},
+			dsaDpdkWorkload,
+		)
+	})
+
+	ginkgo.It("deploys VFIO DSA plugin with operator", ginkgo.Label("dsa", "vfio"), func(ctx context.Context) {
+		testPluginWithOperator(
+			ctx, f,
+			buildDSAPluginCR("vfio-pci"),
+			"dsadeviceplugin-sample",
+			"intel-dsa-plugin",
+			[]v1.ResourceName{"dsa.intel.com/vfio"},
+		)
 	})
 
 	ginkgo.It("deploys IAA plugin with operator", ginkgo.Label("iaa"), func(ctx context.Context) {
-		testPluginWithOperator("iaa", []v1.ResourceName{"iaa.intel.com/wq-user-dedicated"}, f, ctx)
+		testPluginWithOperator(
+			ctx, f,
+			buildIAAPluginCR(),
+			"iaadeviceplugin-sample",
+			"intel-iaa-plugin",
+			[]v1.ResourceName{"iaa.intel.com/wq-user-dedicated"},
+		)
 	})
 
-	ginkgo.It("deploys DSA plugin with operator", ginkgo.Label("dsa"), func(ctx context.Context) {
-		testPluginWithOperator("dsa", []v1.ResourceName{"dsa.intel.com/wq-user-dedicated"}, f, ctx)
-	})
-
-	ginkgo.It("deploys SGX plugin with operator", ginkgo.Label("sgx"), func(ctx context.Context) {
-		testPluginWithOperator("sgx", []v1.ResourceName{"sgx.intel.com/epc", "sgx.intel.com/enclave", "sgx.intel.com/provision"}, f, ctx)
-	})
-
-	ginkgo.It("deploys QAT plugin with operator", ginkgo.Label("qat"), func(ctx context.Context) {
-		testPluginWithOperator("qat", []v1.ResourceName{"qat.intel.com/cy"}, f, ctx)
+	ginkgo.It("deploys GPU plugin with operator", ginkgo.Label("gpu", "i915"), func(ctx context.Context) {
+		testPluginWithOperator(
+			ctx, f,
+			buildGPUPluginCR(),
+			"gpudeviceplugin-sample",
+			"intel-gpu-plugin",
+			[]v1.ResourceName{"gpu.intel.com/i915"},
+		)
 	})
 }
 
-func testPluginWithOperator(deviceName string, resourceNames []v1.ResourceName, f *framework.Framework, ctx context.Context) {
-	dpSampleYaml := "deployments/operator/samples/deviceplugin_v1_" + deviceName + "deviceplugin.yaml"
-
-	utils.Kubectl("", "apply", "-f", dpSampleYaml)
-
-	if _, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, f.ClientSet, ns, labels.Set{"app": "intel-" + deviceName + "-plugin"}.AsSelector(), 1, timeout); err != nil {
-		framework.Failf("unable to wait for all pods to be running and ready: %v", err)
+// testPluginWithOperator applies the given CR YAML, waits for the plugin
+// DaemonSet pod to become ready and for the expected resources to appear as
+// allocatable on at least one node, then deletes the CR.
+func testPluginWithOperator(
+	ctx context.Context,
+	f *framework.Framework,
+	crYAML, crName, pluginLabel string,
+	resourceNames []v1.ResourceName,
+	workloadFunc ...workloadFunc,
+) {
+	tmpFile, err := os.CreateTemp("", "cr-*.yaml")
+	if err != nil {
+		framework.Failf("unable to create temp CR file: %v", err)
 	}
 
-	for _, resourceName := range resourceNames {
-		if err := utils.WaitForNodesWithResource(ctx, f.ClientSet, resourceName, timeout, utils.WaitForPositiveResource); err != nil {
-			framework.Failf("unable to wait for nodes to have positive allocatable resource: %v", err)
+	defer os.Remove(tmpFile.Name())
+
+	if _, err = tmpFile.WriteString(crYAML); err != nil {
+		framework.Failf("unable to write CR YAML: %v", err)
+	}
+
+	tmpFile.Close()
+
+	ginkgo.By(fmt.Sprintf("applying %s CR", crName))
+	e2ekubectl.RunKubectlOrDie("", "apply", "-f", tmpFile.Name())
+
+	defer func() {
+		ginkgo.By(fmt.Sprintf("deleting %s CR", crName))
+		e2ekubectl.RunKubectlOrDie("", "delete", "--ignore-not-found=true", "-f", tmpFile.Name())
+	}()
+
+	ginkgo.By(fmt.Sprintf("waiting for %s plugin pod to be ready", pluginLabel))
+
+	if _, err = e2epod.WaitForPods(
+		ctx, f.ClientSet, operatorNS,
+		metav1.ListOptions{LabelSelector: labels.Set{"app": pluginLabel}.String()},
+		e2epod.Range{MinMatching: 1},
+		pluginTimeout, "be running and ready", e2epod.RunningReady,
+	); err != nil {
+		e2edebug.DumpAllNamespaceInfo(ctx, f.ClientSet, operatorNS)
+		e2ekubectl.LogFailedContainers(ctx, f.ClientSet, operatorNS, framework.Logf)
+		framework.Failf("%s plugin pod did not become ready: %v", pluginLabel, err)
+	}
+
+	for _, res := range resourceNames {
+		ginkgo.By(fmt.Sprintf("checking that resource %s is allocatable", res))
+
+		if err = e2eutils.WaitForNodesWithResource(ctx, f.ClientSet, res, resourceTimeout, e2eutils.WaitForPositiveResource); err != nil {
+			framework.Failf("nodes did not report allocatable resource %s: %v", res, err)
 		}
 	}
 
-	utils.Kubectl("", "delete", "-f", dpSampleYaml)
+	for _, wf := range workloadFunc {
+		wf(ctx, f)
+	}
+}
+
+func createQatConfigMap(ctx context.Context, f *framework.Framework, function string) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "qat-config",
+			Namespace: operatorNS,
+		},
+		Data: map[string]string{
+			"qat.conf": fmt.Sprintf("ServicesEnabled=%s\n", function),
+		},
+	}
+
+	if _, err := f.ClientSet.CoreV1().ConfigMaps(operatorNS).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		framework.Failf("unable to create QAT config ConfigMap: %v", err)
+	}
+}
+
+func deleteQatConfigMap(ctx context.Context, f *framework.Framework) {
+	if err := f.ClientSet.CoreV1().ConfigMaps(operatorNS).Delete(ctx, "qat-config", metav1.DeleteOptions{}); err != nil {
+		framework.Logf("unable to delete QAT config ConfigMap: %v", err)
+	}
+}
+
+func buildQATPluginCR() string {
+	qatCr := dpapi.QatDevicePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dpapi.GroupVersion.String(),
+			Kind:       "QatDevicePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "qatdeviceplugin-sample",
+		},
+		Spec: dpapi.QatDevicePluginSpec{
+			Image:              operutils.PluginImageName("intel-qat-plugin"),
+			InitImage:          operutils.PluginImageName("intel-qat-initcontainer"),
+			DpdkDriver:         "vfio-pci",
+			KernelVfDrivers:    []dpapi.KernelVfDriver{"4xxxvf", "420xxvf"},
+			MaxNumDevices:      16,
+			ProvisioningConfig: "qat-config",
+			LogLevel:           4,
+			NodeSelector:       map[string]string{"intel.feature.node.kubernetes.io/qat": "true"},
+		},
+	}
+
+	output, err := yaml.Marshal(&qatCr)
+	if err != nil {
+		framework.Failf("unable to marshal QATDevicePlugin CR to YAML: %v", err)
+	}
+
+	return string(output)
+}
+
+func buildSGXPluginCR() string {
+	sgxCr := dpapi.SgxDevicePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dpapi.GroupVersion.String(),
+			Kind:       "SgxDevicePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sgxdeviceplugin-sample",
+		},
+		Spec: dpapi.SgxDevicePluginSpec{
+			Image:          operutils.PluginImageName("intel-sgx-plugin"),
+			LogLevel:       4,
+			NodeSelector:   map[string]string{"intel.feature.node.kubernetes.io/sgx": "true"},
+			EnclaveLimit:   110,
+			ProvisionLimit: 110,
+		},
+	}
+
+	output, err := yaml.Marshal(&sgxCr)
+	if err != nil {
+		framework.Failf("unable to marshal SgxDevicePlugin CR to YAML: %v", err)
+	}
+
+	return string(output)
+}
+
+func buildDSAPluginCR(driver string) string {
+	dsaCr := dpapi.DsaDevicePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dpapi.GroupVersion.String(),
+			Kind:       "DsaDevicePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dsadeviceplugin-sample",
+		},
+		Spec: dpapi.DsaDevicePluginSpec{
+			Image:        operutils.PluginImageName("intel-dsa-plugin"),
+			InitImage:    operutils.PluginImageName("intel-idxd-config-initcontainer"),
+			Driver:       driver,
+			LogLevel:     4,
+			SharedDevNum: 10,
+			NodeSelector: map[string]string{"intel.feature.node.kubernetes.io/dsa": "true"},
+		},
+	}
+
+	output, err := yaml.Marshal(&dsaCr)
+	if err != nil {
+		framework.Failf("unable to marshal DsaDevicePlugin CR to YAML: %v", err)
+	}
+
+	return string(output)
+}
+
+func buildIAAPluginCR() string {
+	iaaCr := dpapi.IaaDevicePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dpapi.GroupVersion.String(),
+			Kind:       "IaaDevicePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "iaadeviceplugin-sample",
+		},
+		Spec: dpapi.IaaDevicePluginSpec{
+			Image:        operutils.PluginImageName("intel-iaa-plugin"),
+			InitImage:    operutils.PluginImageName("intel-idxd-config-initcontainer"),
+			LogLevel:     4,
+			SharedDevNum: 10,
+			NodeSelector: map[string]string{"intel.feature.node.kubernetes.io/iaa": "true"},
+		},
+	}
+
+	output, err := yaml.Marshal(&iaaCr)
+	if err != nil {
+		framework.Failf("unable to marshal IaaDevicePlugin CR to YAML: %v", err)
+	}
+
+	return string(output)
+}
+
+func buildGPUPluginCR() string {
+	gpuCr := dpapi.GpuDevicePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dpapi.GroupVersion.String(),
+			Kind:       "GpuDevicePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpudeviceplugin-sample",
+		},
+		Spec: dpapi.GpuDevicePluginSpec{
+			Image:            operutils.PluginImageName("intel-gpu-plugin"),
+			LogLevel:         4,
+			SharedDevNum:     10,
+			EnableMonitoring: true,
+			NodeSelector:     map[string]string{"intel.feature.node.kubernetes.io/gpu": "true"},
+		},
+	}
+
+	output, err := yaml.Marshal(&gpuCr)
+	if err != nil {
+		framework.Failf("unable to marshal GpuDevicePlugin CR to YAML: %v", err)
+	}
+
+	return string(output)
+}
+
+func qatDcWorkload(ctx context.Context, f *framework.Framework) {
+	compressTestYamlPath, errFailedToLocateRepoFile := e2eutils.LocateRepoFile(compressTestYaml)
+	if errFailedToLocateRepoFile != nil {
+		framework.Failf("unable to locate %q: %v", compressTestYaml, errFailedToLocateRepoFile)
+	}
+
+	ginkgo.By("create kustomization yaml for workload Pod")
+	tmpDir, err := operutils.CreateWorkloadKustomizationFromDir(filepath.Dir(compressTestYamlPath), operutils.PluginVersion())
+	if err != nil {
+		framework.Failf("unable to create kustomization: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ginkgo.By("submitting a compress pod requesting QAT resources")
+	e2ekubectl.RunKubectlOrDie(operatorNS, "apply", "-k", tmpDir)
+
+	defer func() {
+		ginkgo.By("deleting the compress test pod")
+		e2ekubectl.RunKubectlOrDie(operatorNS, "delete", "--ignore-not-found=true", "-k", tmpDir)
+	}()
+
+	ginkgo.By("waiting the compress pod to finish successfully")
+	err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, "qat-dpdk-test-compress-perf", operatorNS, 300*time.Second)
+	if err != nil {
+		if logs, logErr := e2epod.GetPodLogs(ctx, f.ClientSet, operatorNS, "qat-dpdk-test-compress-perf", "compress-perf"); logErr == nil {
+			framework.Logf("logs from compress-perf pod:\n%s", logs)
+		}
+		framework.Failf("compress pod did not finish successfully: %v", err)
+	}
+}
+
+func qatCyWorkload(ctx context.Context, f *framework.Framework) {
+	cryptoTestYamlPath, errFailedToLocateRepoFile := e2eutils.LocateRepoFile(cryptoTestYaml)
+	if errFailedToLocateRepoFile != nil {
+		framework.Failf("unable to locate %q: %v", cryptoTestYaml, errFailedToLocateRepoFile)
+	}
+
+	ginkgo.By("create kustomization yaml for workload Pod")
+	tmpDir, err := operutils.CreateWorkloadKustomizationFromFile(cryptoTestYamlPath, operutils.PluginVersion())
+	if err != nil {
+		framework.Failf("unable to create kustomization: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ginkgo.By("submitting a crypto pod requesting QAT resources")
+	e2ekubectl.RunKubectlOrDie(operatorNS, "apply", "-k", tmpDir)
+
+	defer func() {
+		ginkgo.By("deleting the crypto test pod")
+		e2ekubectl.RunKubectlOrDie(operatorNS, "delete", "--ignore-not-found=true", "-k", tmpDir)
+	}()
+
+	ginkgo.By("waiting the crypto pod to finish successfully")
+	err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, "qat-dpdk-test-crypto-perf", operatorNS, 300*time.Second)
+	if err != nil {
+		if logs, logErr := e2epod.GetPodLogs(ctx, f.ClientSet, operatorNS, "qat-dpdk-test-crypto-perf", "crypto-perf"); logErr == nil {
+			framework.Logf("logs from crypto-perf pod:\n%s", logs)
+		}
+		framework.Failf("crypto pod did not finish successfully: %v", err)
+	}
+}
+
+func sgxWorkload(ctx context.Context, f *framework.Framework) {
+	ginkgo.By("creating SGX Pod requesting SGX resources")
+	podSpec := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sgxplugin-tester"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:       "testcontainer",
+					Image:      operutils.PluginImageName("sgx-sdk-demo"),
+					WorkingDir: "/opt/intel/sgx-sample-app/",
+					Command:    []string{"/opt/intel/sgx-sample-app/sgx-sample-app"},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{"sgx.intel.com/epc": resource.MustParse("42")},
+						Limits:   v1.ResourceList{"sgx.intel.com/epc": resource.MustParse("42")},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+	pod, err := f.ClientSet.CoreV1().Pods(operatorNS).Create(ctx, podSpec, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "pod Create API error")
+
+	defer func() {
+		ginkgo.By("deleting the SGX test pod")
+		if err = f.ClientSet.CoreV1().Pods(operatorNS).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{}); err != nil {
+			framework.Logf("unable to delete SGX test pod: %v", err)
+		}
+	}()
+
+	ginkgo.By("waiting the pod to finish successfully")
+	err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, pod.ObjectMeta.Name, operatorNS, 60*time.Second)
+	if err != nil {
+		if logs, logErr := e2epod.GetPodLogs(ctx, f.ClientSet, operatorNS, pod.ObjectMeta.Name, "testcontainer"); logErr == nil {
+			framework.Logf("logs from testcontainer pod:\n%s", logs)
+		}
+		framework.Failf("testcontainer pod did not finish successfully: %v", err)
+	}
+}
+
+func dsaDpdkWorkload(ctx context.Context, f *framework.Framework) {
+	ginkgo.By("creating DSA Pod requesting DSA resources")
+
+	demoDpdkPath, err := e2eutils.LocateRepoFile(dpdkDemoYaml)
+	if err != nil {
+		framework.Failf("unable to locate %q: %v", dpdkDemoYaml, err)
+	}
+
+	// Create a kustomization yaml on the fly to set correct container image path and version for the deployment
+	tmpDir, err := operutils.CreateWorkloadKustomizationFromFile(demoDpdkPath, operutils.PluginVersion())
+	if err != nil {
+		framework.Failf("unable to create kustomization yaml: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	e2ekubectl.RunKubectlOrDie(operatorNS, "apply", "-k", tmpDir)
+
+	defer func() {
+		ginkgo.By("deleting the DSA DPDK test pod")
+		e2ekubectl.RunKubectlOrDie(operatorNS, "delete", "--ignore-not-found=true", "-k", tmpDir)
+	}()
+
+	ginkgo.By("waiting for the DSA DPDK demo to succeed")
+	err = e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, dpdkPodName, operatorNS, 200*time.Second)
+	if err != nil {
+		if logs, logErr := e2epod.GetPodLogs(ctx, f.ClientSet, operatorNS, dpdkPodName, dpdkPodName); logErr == nil {
+			framework.Logf("logs from DSA DPDK demo pod:\n%s", logs)
+		}
+		framework.Failf("DSA DPDK demo did not finish successfully: %v", err)
+	}
 }

--- a/test/e2e/operator/operator_suite_test.go
+++ b/test/e2e/operator/operator_suite_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Operator e2e test suite for Intel Device Plugins.
+
+package operator
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	operutils "github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/operator/utils"
+	"github.com/intel/intel-device-plugins-for-kubernetes/test/e2e/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/component-base/logs"
+	"k8s.io/component-base/version"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+const (
+	nfdNamespace     = "node-feature-discovery"
+	nfdNamespaceOCP  = "openshift-nfd"
+	nfdTimeout       = 5 * time.Minute
+	nodeReadyTimeout = 30 * time.Second
+)
+
+var (
+	isOCP bool
+)
+
+func init() {
+	ginkgo.SynchronizedBeforeSuite(setupCluster, func([]byte) {})
+}
+
+// setupCluster runs once on the first Ginkgo node.  It waits for cluster nodes to
+// be schedulable and ensures NFD is running (deploying it via kustomize if not
+// already present).
+func setupCluster(ctx context.Context) []byte {
+	c, err := framework.LoadClientset()
+	if err != nil {
+		framework.Failf("error loading client: %v", err)
+	}
+
+	framework.Logf("e2e test version: %s", version.Get().GitVersion)
+
+	if sv, svErr := c.DiscoveryClient.ServerVersion(); svErr == nil && sv != nil {
+		framework.Logf("kube-apiserver version: %s", sv.GitVersion)
+	}
+
+	framework.ExpectNoError(waitForNodes(ctx, c, nodeReadyTimeout))
+
+	checkRequiredEnvVariables(ctx, c)
+
+	isOCP = operutils.IsRunningOnOCP(ctx, c)
+
+	ensureProjectNamespace(ctx, c, !isOCP)
+	ensureNFD(ctx, c)
+	ensureNFDRules()
+
+	if !isOCP {
+		ensureCertManager(ctx, c)
+	}
+
+	framework.Logf("Setup done")
+
+	return []byte{}
+}
+
+func waitForNodes(ctx context.Context, c clientset.Interface, timeout time.Duration) error {
+	// actually wait for all the nodes to be ready and schedulable before proceeding
+	framework.Logf("waiting up to %s for all nodes to be ready and schedulable", timeout)
+
+	nodeList, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("cluster has %d node(s)", len(nodeList.Items))
+
+	if err = e2enode.WaitForReadyNodes(ctx, c, len(nodeList.Items), timeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// nfdRunningInNamespace returns true when the given namespace contains at
+// least one NFD pod.
+func nfdRunningInNamespace(ctx context.Context, c clientset.Interface, ns string) bool {
+	podList, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	return err == nil && len(podList.Items) > 0
+}
+
+// ensureNFD checks whether NFD is already running in either the OCP-standard
+// namespace (openshift-nfd) or the upstream namespace (node-feature-discovery).
+// If NFD is not found in either, it is deployed via the standard kustomize
+// manifests.
+func ensureNFD(ctx context.Context, c clientset.Interface) {
+	for _, ns := range []string{nfdNamespaceOCP, nfdNamespace} {
+		if nfdRunningInNamespace(ctx, c, ns) {
+			framework.Logf("NFD already running in %s; skipping deployment", ns)
+			return
+		}
+	}
+
+	framework.Logf("NFD not detected in %s or %s, deploying via kustomize...", nfdNamespaceOCP, nfdNamespace)
+
+	utils.Kubectl(nfdNamespace, "apply", "-k", "deployments/nfd/kustomization.yaml")
+
+	if waitErr := waitForNFD(ctx, c); waitErr != nil {
+		framework.Failf("NFD pods did not become ready: %v", waitErr)
+	}
+}
+
+// ensureNFDRules checks whether the intel-dp-devices NodeFeatureRule already
+// exists on the cluster.  If it is absent (NFD may have been installed without
+// the device-plugin rules, e.g. via the OCP NFD Operator), the rules overlay
+// is applied so that nodes get the labels the device-plugin tests rely on.
+func ensureNFDRules() {
+	// NodeFeatureRule is cluster-scoped; no namespace argument needed.
+	if _, err := e2ekubectl.RunKubectl("", "get", "nodefeaturerule", "intel-dp-devices"); err == nil {
+		framework.Logf("NodeFeatureRule intel-dp-devices already present; skipping rules deployment")
+		return
+	}
+
+	framework.Logf("NodeFeatureRule intel-dp-devices not found, applying NFD rules overlay...")
+	utils.Kubectl("", "apply", "-k", "deployments/nfd/overlays/node-feature-rules/kustomization.yaml")
+}
+
+func waitForNFD(ctx context.Context, c clientset.Interface) error {
+	framework.Logf("waiting up to %s for NFD pods to be ready", nfdTimeout)
+
+	_, err := e2epod.WaitForPodsWithLabelRunningReady(
+		ctx, c, nfdNamespace,
+		labels.Set{"app": "nfd-master"}.AsSelector(),
+		1, nfdTimeout,
+	)
+
+	return err
+}
+
+// ensureProjectNamespace checks that the namespace specified by the PROJECT_NAMESPACE exists.
+func ensureProjectNamespace(ctx context.Context, c clientset.Interface, createIfMissing bool) {
+	ns := operutils.ProjectNamespace()
+	if ns == "" {
+		framework.Failf("project namespace cannot be empty")
+	}
+
+	if _, err := c.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+		framework.Logf("namespace missing, should try to create it: %t", createIfMissing)
+
+		if createIfMissing {
+			_, err2 := c.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ns,
+				},
+			}, metav1.CreateOptions{})
+			if err2 != nil {
+				framework.Failf("failed to create project namespace %s: %v", ns, err2)
+			}
+
+			framework.Logf("project namespace %s created", ns)
+			return
+		}
+
+		framework.Failf("project namespace HAS to exist before running. failed to get project namespace %s: %v", ns, err)
+	}
+
+	framework.Logf("Project namespace %s exists", ns)
+}
+
+func ensureCertManager(ctx context.Context, c clientset.Interface) {
+	// Check if cert-manager is already running by looking for the cert-manager namespace.
+	if _, err := c.CoreV1().Namespaces().Get(ctx, "cert-manager", metav1.GetOptions{}); err == nil {
+		framework.Logf("cert-manager namespace already exists; assuming cert-manager is installed")
+		return
+	}
+
+	framework.Failf("cert-manager is required for tests running outside of OCP, but cert-manager namespace not found")
+}
+
+// checkRequiredEnvVariables ensures that all required environment variables are set and fails the test if any are missing.
+func checkRequiredEnvVariables(ctx context.Context, c clientset.Interface) {
+	alwaysRequired := []string{"PROJECT_NAMESPACE", "IMAGE_PATH", "PLUGIN_VERSION"}
+	for _, envVar := range alwaysRequired {
+		if _, found := os.LookupEnv(envVar); !found {
+			framework.Failf("environment variable %s must be set", envVar)
+		}
+	}
+}
+
+// TestDevicePluginsOperator is the entry point for the operator e2e test binary.
+func TestDevicePluginsOperator(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "E2E Device Plugins Operator Suite")
+}
+
+func TestMain(m *testing.M) {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	logs.InitLogs()
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	framework.RegisterCommonFlags(flag.CommandLine)
+	framework.RegisterClusterFlags(flag.CommandLine)
+	flag.Parse()
+
+	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	os.Exit(m.Run())
+}

--- a/test/e2e/operator/operator_suite_test.go
+++ b/test/e2e/operator/operator_suite_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"flag"
 	"os"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -226,6 +228,12 @@ func TestMain(m *testing.M) {
 	logs.InitLogs()
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
+	// controller-runtime's init() registers "kubeconfig" to flag.CommandLine before TestMain runs.
+	// framework.RegisterClusterFlags also registers "kubeconfig", which causes a panic.
+	// Remove the controller-runtime registration so the framework's version (which binds to
+	// TestContext.KubeConfig) takes over. "formal" is unexported, so unsafe is required.
+	fv := reflect.ValueOf(flag.CommandLine).Elem().FieldByName("formal")
+	reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().SetMapIndex(reflect.ValueOf("kubeconfig"), reflect.Value{})
 	framework.RegisterClusterFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/test/e2e/operator/utils/operator_utils.go
+++ b/test/e2e/operator/utils/operator_utils.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package operutils provides helper functions for operator-specific e2e tests.
+package operutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// pluginVersion is the default image tag used when building image references.
+// These variables allow defining custom container paths: <1:image registry>/<2:image path>/container:<3:plugin version>
+// e.g. my-registry.com/project-x/intel-deviceplugin-operator:1.2.3
+//         ^^^^1^^^^    ^^^^2^^^^                             ^^3^^
+// Project namespace is the cluster namespace where the operator is deployed
+// For OCP, project namespace and image path have to be same to allow pulling from the internal registry.
+
+var pluginVersion = "0.35.0"
+var projectNamespace = "inteldeviceplugins-system"
+var imagePath = "inteldeviceplugins-system"
+var imageRegistry = "image-registry.openshift-image-registry.svc:5000"
+
+func init() {
+	// Allow overriding the default plugin version with the PLUGIN_VERSION
+	if version := os.Getenv("PLUGIN_VERSION"); version != "" {
+		pluginVersion = version
+	}
+	if ns := os.Getenv("PROJECT_NAMESPACE"); ns != "" {
+		projectNamespace = ns
+	}
+	if registry := os.Getenv("IMAGE_REGISTRY"); registry != "" {
+		imageRegistry = registry
+	}
+	if imgPath := os.Getenv("IMAGE_PATH"); imgPath != "" {
+		imagePath = imgPath
+	}
+}
+
+func PluginVersion() string {
+	return pluginVersion
+}
+
+func ProjectNamespace() string {
+	return projectNamespace
+}
+
+func ImagePath() string {
+	return imagePath
+}
+
+func ImageRegistry() string {
+	return imageRegistry
+}
+
+// PluginImageName returns the fully-qualified container image reference for
+// the given image name.
+// When IMAGE_PATH is set, the reference points to the internal OCP
+// registry so that pods inside the cluster can pull without external TLS
+// concerns.  Otherwise, it points to docker.io/intel.
+func PluginImageName(name string) string {
+	return fmt.Sprintf("%s/%s/%s:%s", ImageRegistry(), ImagePath(), name, PluginVersion())
+}
+
+// CreateKustomizationOverlay writes a minimal kustomization.yaml into
+// tempDir that wraps the provided ocpOverlayDir.  When IMAGE_PATH is
+// set, image transformers redirect all upstream docker.io/intel/ images to the
+// internal OCP registry so that pods pull from within the cluster.
+//
+// The caller is responsible for removing tempDir after use.
+func CreateKustomizationOverlay(ocpOverlayDir, tempDir, version, namespace string) error {
+	absOverlay, err := filepath.Abs(ocpOverlayDir)
+	if err != nil {
+		return err
+	}
+
+	absTempDir, err := filepath.Abs(tempDir)
+	if err != nil {
+		return err
+	}
+
+	// Kustomize forbids absolute paths in resources; use a relative path from
+	// tempDir to the overlay directory instead.
+	relOverlay, err := filepath.Rel(absTempDir, absOverlay)
+	if err != nil {
+		return err
+	}
+
+	content := map[string]any{
+		"resources": []string{relOverlay},
+		"namespace": namespace,
+		"images":    buildImageOverrides(ImageRegistry()+"/"+ImagePath(), version),
+	}
+
+	bytes, err := yaml.Marshal(content)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(tempDir, "kustomization.yaml"), bytes, 0o600)
+}
+
+func buildImageOverrides(registry, version string) []map[string]string {
+	containers := []string{
+		"intel-deviceplugin-operator",
+		"crypto-perf",
+		"dsa-dpdk-dmadevtest",
+	}
+
+	overrides := make([]map[string]string, 0, len(containers)*2)
+	for _, container := range containers {
+		overrides = append(overrides, []map[string]string{
+			{
+				"name":    "intel/" + container,
+				"newName": registry + "/" + container,
+				"newTag":  version,
+			},
+			{
+				"name":    "docker.io/intel/" + container,
+				"newName": registry + "/" + container,
+				"newTag":  version,
+			},
+		}...)
+	}
+
+	return overrides
+}
+
+func IsRunningOnOCP(ctx context.Context, c clientset.Interface) bool {
+	_, err := c.CoreV1().Namespaces().Get(ctx, "openshift-apiserver", metav1.GetOptions{})
+	return err == nil
+}
+
+func CreateWorkloadKustomizationFromDir(originalDir, version string) (string, error) {
+	tempDir, err := os.MkdirTemp("", "workloaddir-kustomization")
+	if err != nil {
+		return "", err
+	}
+
+	// Copy originalDir into tempDir
+	err = filepath.Walk(originalDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		fbytes, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		destPath := filepath.Join(tempDir, filepath.Base(path))
+		writeErr := os.WriteFile(destPath, fbytes, 0600)
+		if writeErr != nil {
+			return writeErr
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	kustomizationObj := map[string]any{}
+
+	kustomizationFile := filepath.Join(tempDir, "kustomization.yaml")
+	kBytes, err := os.ReadFile(kustomizationFile)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+	if err = yaml.Unmarshal(kBytes, &kustomizationObj); err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	kustomizationObj["images"] = buildImageOverrides(ImageRegistry()+"/"+ImagePath(), version)
+
+	newKBytes, err := yaml.Marshal(kustomizationObj)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	if err = os.WriteFile(kustomizationFile, newKBytes, 0600); err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	return tempDir, nil
+}
+
+func CreateWorkloadKustomizationFromFile(originalFile, version string) (string, error) {
+	tempDir, err := os.MkdirTemp("", "workload-kustomization")
+	if err != nil {
+		return "", err
+	}
+
+	// Copy original file from originalFile into tempDir
+	originalBytes, err := os.ReadFile(originalFile)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	destFile := filepath.Join(tempDir, filepath.Base(originalFile))
+	if err = os.WriteFile(destFile, originalBytes, 0o600); err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	content := map[string]any{
+		"resources": []string{destFile},
+		"images":    buildImageOverrides(ImageRegistry()+"/"+ImagePath(), version),
+	}
+
+	bytes, err := yaml.Marshal(content)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	if err = os.WriteFile(filepath.Join(tempDir, "kustomization.yaml"), bytes, 0o600); err != nil {
+		os.RemoveAll(tempDir)
+		return "", err
+	}
+
+	return tempDir, nil
+}

--- a/test/e2e/scripts/common.sh
+++ b/test/e2e/scripts/common.sh
@@ -231,6 +231,10 @@ generate_tag() {
   local BUILD_VERSION
   BUILD_VERSION=$(grep -r --include="*.go" 'ImageMinVersion =' ${GITHUB_WORKSPACE} | head -1 | sed -e 's/.*"\(.*\)".*/\1/')
 
+  # Increase patch version to ensure the version is considered newer than any released version.
+  # This is needed as x.y.z-1234-1234 seems to be considered older than just x.y.z.
+  BUILD_VERSION=$(echo $BUILD_VERSION | awk -F. -v OFS=. '{$NF = $NF + 1} 1')
+
   # Add random components to avoid collision with other images.
   BUILD_VERSION=$BUILD_VERSION-$GITHUB_RUN_NUMBER-$RANDOM
 

--- a/test/e2e/scripts/run-tests.sh
+++ b/test/e2e/scripts/run-tests.sh
@@ -6,6 +6,13 @@ source "$script_path/common.sh"
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 export PATH=$PATH:~/bin/go/bin
 
+export PLUGINS_REPO_DIR=${GITHUB_WORKSPACE}
+
+export PROJECT_NAMESPACE=inteldeviceplugins-system
+export IMAGE_PATH=intel
+export PLUGIN_VERSION=${TAG}
+export IMAGE_REGISTRY=docker.io
+
 echo "Running tests: $TARGET_JOB"
 
 make "$TARGET_JOB" || {


### PR DESCRIPTION
Add scripts to mirror images in the cluster registry.