### PR TITLE
Fix table rendering in GPU plugin README by adding missing blank line

### DIFF
--- a/cmd/gpu_plugin/README.md
+++ b/cmd/gpu_plugin/README.md
@@ -41,6 +41,7 @@ video transcoding operations, and containers with the Intel OpenCL / oneAPI Leve
 backend libraries can offload compute operations to GPU.
 
 Intel GPU plugin may register four per-node resource types to the Kubernetes cluster:
+
 | Resource | Description |
 |:---- |:-------- |
 | gpu.intel.com/i915 | Legacy `i915` KMD (Kernel Mode Driver) provided GPU instance |


### PR DESCRIPTION
Added a missing blank line before the Markdown table so it renders correctly on GitHub Pages.

Fixes #2239 