### PR TITLE
build: drop -N -l flags

### DIFF
--- a/build/docker/intel-deviceplugin-operator.Dockerfile
+++ b/build/docker/intel-deviceplugin-operator.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_deviceplugin_operator

--- a/build/docker/intel-dlb-plugin.Dockerfile
+++ b/build/docker/intel-dlb-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_dlb_device_plugin

--- a/build/docker/intel-dsa-plugin.Dockerfile
+++ b/build/docker/intel-dsa-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_dsa_device_plugin

--- a/build/docker/intel-fpga-admissionwebhook.Dockerfile
+++ b/build/docker/intel-fpga-admissionwebhook.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_fpga_admissionwebhook

--- a/build/docker/intel-fpga-initcontainer.Dockerfile
+++ b/build/docker/intel-fpga-initcontainer.Dockerfile
@@ -40,7 +40,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG CRI_HOOK=intel-fpga-crihook

--- a/build/docker/intel-fpga-plugin.Dockerfile
+++ b/build/docker/intel-fpga-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_fpga_device_plugin

--- a/build/docker/intel-gpu-fakedev.Dockerfile
+++ b/build/docker/intel-gpu-fakedev.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_gpu_fakedev

--- a/build/docker/intel-gpu-initcontainer.Dockerfile
+++ b/build/docker/intel-gpu-initcontainer.Dockerfile
@@ -40,7 +40,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/gpu-sw/intel-gpu-nfdhook

--- a/build/docker/intel-gpu-levelzero.Dockerfile
+++ b/build/docker/intel-gpu-levelzero.Dockerfile
@@ -21,7 +21,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ENV CGO_CFLAGS="-pipe -fno-plt"
 ENV CGO_LDFLAGS="-fstack-protector-strong -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,noexecstack,-z,defs,-s,-w"
 ENV CGOFLAGS="-trimpath -mod=readonly -buildmode=pie"
-ENV GCFLAGS="all=-spectre=all -N -l"
+ENV GCFLAGS="all=-spectre=all"
 ENV ASMFLAGS="-spectre=all"
 ENV LDFLAGS="all=-linkmode=external -s -w"
 ARG GOLICENSES_VERSION

--- a/build/docker/intel-gpu-levelzero.ubi.Dockerfile
+++ b/build/docker/intel-gpu-levelzero.ubi.Dockerfile
@@ -22,7 +22,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ENV CGO_CFLAGS="-pipe -fno-plt"
 ENV CGO_LDFLAGS="-fstack-protector-strong -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,noexecstack,-z,defs,-s"
 ENV CGOFLAGS="-trimpath -mod=readonly -buildmode=pie"
-ENV GCFLAGS="all=-spectre=all -N -l"
+ENV GCFLAGS="all=-spectre=all"
 ENV ASMFLAGS="-spectre=all"
 ENV LDFLAGS="all=-linkmode=external -s -w"
 ARG GOLICENSES_VERSION

--- a/build/docker/intel-gpu-plugin.Dockerfile
+++ b/build/docker/intel-gpu-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_gpu_device_plugin

--- a/build/docker/intel-iaa-plugin.Dockerfile
+++ b/build/docker/intel-iaa-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_iaa_device_plugin

--- a/build/docker/intel-npu-plugin.Dockerfile
+++ b/build/docker/intel-npu-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_npu_device_plugin

--- a/build/docker/intel-qat-plugin.Dockerfile
+++ b/build/docker/intel-qat-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_qat_device_plugin

--- a/build/docker/intel-sgx-admissionwebhook.Dockerfile
+++ b/build/docker/intel-sgx-admissionwebhook.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_sgx_admissionwebhook

--- a/build/docker/intel-sgx-initcontainer.Dockerfile
+++ b/build/docker/intel-sgx-initcontainer.Dockerfile
@@ -40,7 +40,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/sgx-sw/intel-sgx-epchook

--- a/build/docker/intel-sgx-plugin.Dockerfile
+++ b/build/docker/intel-sgx-plugin.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_sgx_device_plugin

--- a/build/docker/intel-xpumanager-sidecar.Dockerfile
+++ b/build/docker/intel-xpumanager-sidecar.Dockerfile
@@ -41,7 +41,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION
 ARG EP=/usr/local/bin/intel_xpumanager_sidecar

--- a/build/docker/lib/default_args.docker
+++ b/build/docker/lib/default_args.docker
@@ -2,6 +2,6 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ARG GO111MODULE=on
 ARG LDFLAGS="all=-w -s"
 ARG GOFLAGS="-trimpath"
-ARG GCFLAGS="all=-spectre=all -N -l"
+ARG GCFLAGS="all=-spectre=all"
 ARG ASMFLAGS="-spectre=all"
 ARG GOLICENSES_VERSION

--- a/build/docker/templates/intel-gpu-levelzero.Dockerfile.in
+++ b/build/docker/templates/intel-gpu-levelzero.Dockerfile.in
@@ -10,7 +10,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ENV CGO_CFLAGS="-pipe -fno-plt"
 ENV CGO_LDFLAGS="-fstack-protector-strong -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,noexecstack,-z,defs,-s,-w"
 ENV CGOFLAGS="-trimpath -mod=readonly -buildmode=pie"
-ENV GCFLAGS="all=-spectre=all -N -l"
+ENV GCFLAGS="all=-spectre=all"
 ENV ASMFLAGS="-spectre=all"
 ENV LDFLAGS="all=-linkmode=external -s -w"
 

--- a/build/docker/templates/intel-gpu-levelzero.ubi.Dockerfile.in
+++ b/build/docker/templates/intel-gpu-levelzero.ubi.Dockerfile.in
@@ -12,7 +12,7 @@ ARG DIR=/intel-device-plugins-for-kubernetes
 ENV CGO_CFLAGS="-pipe -fno-plt"
 ENV CGO_LDFLAGS="-fstack-protector-strong -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,noexecstack,-z,defs,-s"
 ENV CGOFLAGS="-trimpath -mod=readonly -buildmode=pie"
-ENV GCFLAGS="all=-spectre=all -N -l"
+ENV GCFLAGS="all=-spectre=all"
 ENV ASMFLAGS="-spectre=all"
 ENV LDFLAGS="all=-linkmode=external -s -w"
 


### PR DESCRIPTION
They are accidentally added and shouldn't be used in release binaries.