### PR TITLE
Misc fixes for 0.36

### DIFF
--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -759,7 +759,8 @@ func (dp *devicePlugin) scan() (dpapi.DeviceTree, error) {
 	// all Intel GPUs are under single monitoring resource per KMD
 	if len(monitor) > 0 {
 		for resourceName, devices := range monitor {
-			deviceInfo := dpapi.NewDeviceInfo(pluginapi.Healthy, devices, nil, nil, nil, nil)
+			deviceInfo := dpapi.NewDeviceInfoWithTopologyHints(
+				pluginapi.Healthy, devices, nil, nil, nil, nil, nil)
 			devTree.AddDevice(resourceName, monitorID, deviceInfo)
 		}
 	}

--- a/test/e2e/scripts/common.sh
+++ b/test/e2e/scripts/common.sh
@@ -27,7 +27,7 @@ k3s_version_for_k8s_version() {
 
   local known_versions
 
-  known_versions="v1.36.0-rc2+k3s1;v1.35.0+k3s1;v1.34.1+k3s1;v1.33.5+k3s1;v1.32.9+k3s1;v1.31.9+k3s1;v1.30.13+k3s1"
+  known_versions="v1.36.1+k3s1;v1.35.0+k3s1;v1.34.1+k3s1;v1.33.5+k3s1;v1.32.9+k3s1;v1.31.9+k3s1;v1.30.13+k3s1"
 
   local latest
   latest=$(echo $known_versions | tr ';' '\n' | grep "$requested" | head -1)


### PR DESCRIPTION
* Fix repeated warnings from gpu plugin (/dev/meiX not accessible)
* Move to 1.36.1 k3s version